### PR TITLE
Refactoring Object Output and PEP-8 Cleanup

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+ignore = E501
+max-line-length = 100
+exclude = tests/*

--- a/.gitignore
+++ b/.gitignore
@@ -124,6 +124,9 @@ ENV/
 env.bak/
 venv.bak/
 
+# PyStorm project settings
+.idea/
+
 # Spyder project settings
 .spyderproject
 .spyproject

--- a/config.json.dist
+++ b/config.json.dist
@@ -6,7 +6,7 @@
         "database": "",
         "port": 3306,
         "raise_on_warnings": true,
-        "compress": true,
+        "compress": false,
         "charset": "",
         "collation": ""
     }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 import os
 import sys
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,9 +16,9 @@ Migrating to v2
 ===============
 
 With the new major version bump for the ``wwdtm`` library, there have been a
-large number of API changes from ``libwwdtm`` version 1.x to the current
-version. This section of the documentation will provide a summary of changes
-and changes to function/method locations.
+large number of API changes from ``wwdtm`` version 1.x to the current version.
+This section of the documentation will provide a summary of changes and
+changes to function/method locations.
 
 Table of Contents
 =================

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -71,3 +71,18 @@ required database connection information or an existing database connection:
 The latter option may be useful if you are using connection pooling within
 your application and you're just passing in a connection created from that
 connection pool.
+
+Method Output Type Matches Type Hinting
+=======================================
+
+With version 1 of ``wwdtm``, if the requested data could not be retrieved from
+the database, most functions that would normally return a list or a dictionary
+would return ``None`` or ``False`` instead.
+
+This behavior is changed in version 2 in which methods that have type hinting
+stating that a method returns a ``Dict`` will return an empty dictionary.
+Methods that have type hinting stating that the method returns a list will
+return an empty list.
+
+Methods that are designed to return ``int`` or ``string`` will continue to
+return ``None`` if the requested data could not be retrieved.

--- a/docs/wwdtm/index.rst
+++ b/docs/wwdtm/index.rst
@@ -18,3 +18,4 @@ The following is a list of modules provided in the library:
     panelist
     scorekeeper
     show
+    validation

--- a/docs/wwdtm/validation.rst
+++ b/docs/wwdtm/validation.rst
@@ -1,0 +1,12 @@
+validation
+----------
+
+This module provides functions used to validate various data types used
+within the library.
+
+Functions
+=========
+
+.. automodule:: wwdtm.validation
+    :members:
+    :inherited-members:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 filterwarnings =
     ignore::DeprecationWarning:mysql.*:
-norecursedirs = .git venv
+norecursedirs = .git venv dist .eggs wwdtm.egg-info

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,3 @@
-wheel
-setuptools
-build
 mysql-connector-python==8.0.26
 numpy==1.21.2
 pytest==6.2.5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+flake8>=4.0.1
 mysql-connector-python==8.0.26
 numpy==1.21.2
 pytest==6.2.5

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Package setup file"""
 
 from setuptools import setup

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -27,29 +27,29 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [976])
-def test_guest_appearances_retrieve_appearances_by_id(id: int):
+@pytest.mark.parametrize("guest_id", [976])
+def test_guest_appearances_retrieve_appearances_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_id`
 
-    :param id: Guest ID to test retrieving guest appearances
-    :type id: int
+    :param guest_id: Guest ID to test retrieving guest appearances
+    :type guest_id: int
     """
     appearances = GuestAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(id)
+    appearance = appearances.retrieve_appearances_by_id(guest_id)
 
-    assert "count" in appearance, f"'count' was not returned for ID {id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+    assert "count" in appearance, f"'count' was not returned for ID {guest_id}"
+    assert "shows" in appearance, f"'shows' was not returned for ID {guest_id}"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks"])
-def test_guest_appearances_retrieve_appearances_by_slug(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanks"])
+def test_guest_appearances_retrieve_appearances_by_slug(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_slug`
 
-    :param slug: Guest slug string to test retrieving guest appearances
-    :type slug: str
+    :param guest_slug: Guest slug string to test retrieving guest appearances
+    :type guest_slug: str
     """
     appearances = GuestAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(slug)
+    appearance = appearances.retrieve_appearances_by_slug(guest_slug)
 
-    assert "count" in appearance, f"'count' was not returned for slug {slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {slug}"
+    assert "count" in appearance, f"'count' was not returned for slug {guest_slug}"
+    assert "shows" in appearance, f"'shows' was not returned for slug {guest_slug}"

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.guest.GuestAppearances`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.guest import GuestAppearances
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [976])
 def test_guest_appearances_retrieve_appearances_by_id(id: int):
     """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_id`
@@ -37,6 +39,7 @@ def test_guest_appearances_retrieve_appearances_by_id(id: int):
 
     assert "count" in appearance, f"'count' was not returned for ID {id}"
     assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanks"])
 def test_guest_appearances_retrieve_appearances_by_slug(slug: str):

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.guest.Guest`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.guest import Guest
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_guest_retrieve_all():
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all`
     """
@@ -33,6 +35,7 @@ def test_guest_retrieve_all():
 
     assert guests, "No guests could be retrieved"
     assert "id" in guests[0], "'id' was not returned for the first list item"
+
 
 def test_guest_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_details`
@@ -45,6 +48,7 @@ def test_guest_retrieve_all_details():
     assert "appearances" in guests[0], ("'appearances' was not returned for "
                                         "the first list item")
 
+
 def test_guest_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_ids`
     """
@@ -53,6 +57,7 @@ def test_guest_retrieve_all_ids():
 
     assert ids, "No guest IDs could be retrieved"
 
+
 def test_guest_retrieve_all_slugs():
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_slugs`
     """
@@ -60,6 +65,7 @@ def test_guest_retrieve_all_slugs():
     slugs = guest.retrieve_all_slugs()
 
     assert slugs, "No guest slug strings could be retrieved"
+
 
 @pytest.mark.parametrize("id", [976])
 def test_guest_retrieve_by_id(id: int):
@@ -74,6 +80,7 @@ def test_guest_retrieve_by_id(id: int):
     assert info, f"Guest ID {id} not found"
     assert "name" in info, f"'name' was not returned for ID {id}"
 
+
 @pytest.mark.parametrize("slug", ["tom-hanks"])
 def test_guest_retrieve_by_slug(slug: str):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_slug`
@@ -86,6 +93,7 @@ def test_guest_retrieve_by_slug(slug: str):
 
     assert info, f"Guest slug {slug} not found"
     assert "name" in info, f"'name' was not returned for slug {slug}"
+
 
 @pytest.mark.parametrize("id", [976])
 def test_guest_retrieve_details_by_id(id: int):
@@ -100,6 +108,7 @@ def test_guest_retrieve_details_by_id(id: int):
     assert info, f"Guest ID {id} not found"
     assert "name" in info, f"'name' attribute was returned for ID {id}"
     assert "appearances" in info, f"'appearances' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanks"])
 def test_guest_guest_retrieve_details_by_slug(slug: str):

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -67,59 +67,60 @@ def test_guest_retrieve_all_slugs():
     assert slugs, "No guest slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("id", [976])
-def test_guest_retrieve_by_id(id: int):
+@pytest.mark.parametrize("guest_id", [976])
+def test_guest_retrieve_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_id`
 
-    :param id: Guest ID to test retrieving guest information
-    :type id: int
+    :param guest_id: Guest ID to test retrieving guest information
+    :type guest_id: int
     """
     guest = Guest(connect_dict=get_connect_dict())
-    info = guest.retrieve_by_id(id)
+    info = guest.retrieve_by_id(guest_id)
 
-    assert info, f"Guest ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
+    assert info, f"Guest ID {guest_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {guest_id}"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks"])
-def test_guest_retrieve_by_slug(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanks"])
+def test_guest_retrieve_by_slug(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_slug`
 
-    :param slug: Guest slug string to test retrieving guest information
-    :type slug: str
+    :param guest_slug: Guest slug string to test retrieving guest
+        information
+    :type guest_slug: str
     """
     guest = Guest(connect_dict=get_connect_dict())
-    info = guest.retrieve_by_slug(slug)
+    info = guest.retrieve_by_slug(guest_slug)
 
-    assert info, f"Guest slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
+    assert info, f"Guest slug {guest_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {guest_slug}"
 
 
-@pytest.mark.parametrize("id", [976])
-def test_guest_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("guest_id", [976])
+def test_guest_retrieve_details_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_id`
 
-    :param id: Guest ID to test retrieving guest details
-    :type id: int
+    :param guest_id: Guest ID to test retrieving guest details
+    :type guest_id: int
     """
     guest = Guest(connect_dict=get_connect_dict())
-    info = guest.retrieve_details_by_id(id)
+    info = guest.retrieve_details_by_id(guest_id)
 
-    assert info, f"Guest ID {id} not found"
-    assert "name" in info, f"'name' attribute was returned for ID {id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {id}"
+    assert info, f"Guest ID {guest_id} not found"
+    assert "name" in info, f"'name' attribute was returned for ID {guest_id}"
+    assert "appearances" in info, f"'appearances' was not returned for ID {guest_id}"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks"])
-def test_guest_guest_retrieve_details_by_slug(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanks"])
+def test_guest_guest_retrieve_details_by_slug(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_slug`
 
-    :param slug: Guest slug string to test retrieving guest details
-    :type slug: str
+    :param guest_slug: Guest slug string to test retrieving guest details
+    :type guest_slug: str
     """
     guest = Guest(connect_dict=get_connect_dict())
-    info = guest.retrieve_details_by_slug(slug)
+    info = guest.retrieve_details_by_slug(guest_slug)
 
-    assert info, f"Guest slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
-    assert "appearances" in info, f"'appearances' was not returned for slug {slug}"
+    assert info, f"Guest slug {guest_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {guest_slug}"
+    assert "appearances" in info, f"'appearances' was not returned for slug {guest_slug}"

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -67,7 +67,7 @@ def test_guest_utility_convert_slug_to_id(guest_slug: str):
     id_ = utility.convert_slug_to_id(guest_slug)
 
     assert id_, f"Guest ID for slug {guest_slug} was not found"
-    assert isinstance(id, int), f"Invalid value returned for slug {guest_slug}"
+    assert isinstance(id_, int), f"Invalid value returned for slug {guest_slug}"
 
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanx", "steven-colbert"])

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -27,109 +27,111 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [54])
-def test_guest_utility_convert_id_to_slug(id: int):
+@pytest.mark.parametrize("guest_id", [54])
+def test_guest_utility_convert_id_to_slug(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
 
-    :param id: Guest ID to test converting into guest slug string
-    :type id: int
+    :param guest_id: Guest ID to test converting into guest slug string
+    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(guest_id)
 
-    assert slug, f"Guest slug for ID {id} was not found"
-    assert isinstance(slug, str), f"Invalid value returned for ID {id}"
+    assert slug, f"Guest slug for ID {guest_id} was not found"
+    assert isinstance(slug, str), f"Invalid value returned for ID {guest_id}"
 
 
-@pytest.mark.parametrize("id", [-54])
-def test_guest_utility_convert_invalid_id_to_slug(id: int):
+@pytest.mark.parametrize("guest_id", [-54])
+def test_guest_utility_convert_invalid_id_to_slug(guest_id: int):
     """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
 
-    :param id: Guest ID to test failing to convert into guest slug
+    :param guest_id: Guest ID to test failing to convert into guest slug
         string
-    :type id: int
+    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(guest_id)
 
-    assert not slug, f"Guest slug for ID {id} was found"
+    assert not slug, f"Guest slug for ID {guest_id} was found"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks", "stephen-colbert"])
-def test_guest_utility_convert_slug_to_id(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanks", "stephen-colbert"])
+def test_guest_utility_convert_slug_to_id(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`
 
-    :param slug: Guest slug string to test converting into guest ID
-    :type slug: str
+    :param guest_slug: Guest slug string to test converting into guest
+        ID
+    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(guest_slug)
 
-    assert id, f"Guest ID for slug {slug} was not found"
-    assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+    assert id_, f"Guest ID for slug {guest_slug} was not found"
+    assert isinstance(id, int), f"Invalid value returned for slug {guest_slug}"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanx", "steven-colbert"])
-def test_guest_utility_convert_invalid_slug_to_id(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanx", "steven-colbert"])
+def test_guest_utility_convert_invalid_slug_to_id(guest_slug: str):
     """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`
 
-    :param slug: Guest slug string to test failing to convert into guest
-        ID
-    :type slug: str
+    :param guest_slug: Guest slug string to test failing to convert into
+        guest ID
+    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(guest_slug)
 
-    assert not id, f"Guest ID for slug {slug} was found"
+    assert not id_, f"Guest ID for slug {guest_slug} was found"
 
 
-@pytest.mark.parametrize("id", [54])
-def test_guest_utility_id_exists(id: int):
+@pytest.mark.parametrize("guest_id", [54])
+def test_guest_utility_id_exists(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
 
-    :param id: Guest ID to test if a guest exists
-    :type id: int
+    :param guest_id: Guest ID to test if a guest exists
+    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(guest_id)
 
-    assert result, f"Guest ID {id} does not exist"
+    assert result, f"Guest ID {guest_id} does not exist"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_guest_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("guest_id", [-1])
+def test_guest_utility_id_not_exists(guest_id: int):
     """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
 
-    :param id: Guest ID to test if a guest does not exist
-    :type id: int
+    :param guest_id: Guest ID to test if a guest does not exist
+    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(guest_id)
 
-    assert not result, f"Guest ID {id} exists"
+    assert not result, f"Guest ID {guest_id} exists"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks", "stephen-colbert"])
-def test_guest_utility_slug_exists(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanks", "stephen-colbert"])
+def test_guest_utility_slug_exists(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
 
-    :param slug: Guest slug string to test if a guest exists
-    :type slug: str
+    :param guest_slug: Guest slug string to test if a guest exists
+    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(guest_slug)
 
-    assert result, f"Guest slug {slug} does not exist"
+    assert result, f"Guest slug {guest_slug} does not exist"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanx", "steven-colbert"])
-def test_guest_utility_slug_not_exists(slug: str):
+@pytest.mark.parametrize("guest_slug", ["tom-hanx", "steven-colbert"])
+def test_guest_utility_slug_not_exists(guest_slug: str):
     """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
 
-    :param slug: Guest slug string to test if a guest does not exist
-    :type slug: str
+    :param guest_slug: Guest slug string to test if a guest does not
+        exist
+    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(guest_slug)
 
-    assert not result, f"Guest slug {slug} exists"
+    assert not result, f"Guest slug {guest_slug} exists"

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wdtm.guest.GuestUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.guest import GuestUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [54])
 def test_guest_utility_convert_id_to_slug(id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
@@ -37,6 +39,7 @@ def test_guest_utility_convert_id_to_slug(id: int):
 
     assert slug, f"Guest slug for ID {id} was not found"
     assert isinstance(slug, str), f"Invalid value returned for ID {id}"
+
 
 @pytest.mark.parametrize("id", [-54])
 def test_guest_utility_convert_invalid_id_to_slug(id: int):
@@ -51,6 +54,7 @@ def test_guest_utility_convert_invalid_id_to_slug(id: int):
 
     assert not slug, f"Guest slug for ID {id} was found"
 
+
 @pytest.mark.parametrize("slug", ["tom-hanks", "stephen-colbert"])
 def test_guest_utility_convert_slug_to_id(slug: str):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`
@@ -63,6 +67,7 @@ def test_guest_utility_convert_slug_to_id(slug: str):
 
     assert id, f"Guest ID for slug {slug} was not found"
     assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanx", "steven-colbert"])
 def test_guest_utility_convert_invalid_slug_to_id(slug: str):
@@ -77,6 +82,7 @@ def test_guest_utility_convert_invalid_slug_to_id(slug: str):
 
     assert not id, f"Guest ID for slug {slug} was found"
 
+
 @pytest.mark.parametrize("id", [54])
 def test_guest_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
@@ -88,6 +94,7 @@ def test_guest_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Guest ID {id} does not exist"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_guest_utility_id_not_exists(id: int):
@@ -101,6 +108,7 @@ def test_guest_utility_id_not_exists(id: int):
 
     assert not result, f"Guest ID {id} exists"
 
+
 @pytest.mark.parametrize("slug", ["tom-hanks", "stephen-colbert"])
 def test_guest_utility_slug_exists(slug: str):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
@@ -112,6 +120,7 @@ def test_guest_utility_slug_exists(slug: str):
     result = utility.slug_exists(slug)
 
     assert result, f"Guest slug {slug} does not exist"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanx", "steven-colbert"])
 def test_guest_utility_slug_not_exists(slug: str):

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -27,29 +27,30 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [2])
-def test_host_appearances_retrieve_appearances_by_id(id: int):
+@pytest.mark.parametrize("host_id", [2])
+def test_host_appearances_retrieve_appearances_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_id`
 
-    :param id: Host ID to test retrieving host appearances
-    :type id: int
+    :param host_id: Host ID to test retrieving host appearances
+    :type host_id: int
     """
     appearances = HostAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(id)
+    appearance = appearances.retrieve_appearances_by_id(host_id)
 
-    assert "count" in appearance, f"'count' was not returned for ID {id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+    assert "count" in appearance, f"'count' was not returned for ID {host_id}"
+    assert "shows" in appearance, f"'shows' was not returned for ID {host_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_host_appearances_retrieve_appearances_by_slug(slug: str):
+@pytest.mark.parametrize("host_slug", ["luke-burbank"])
+def test_host_appearances_retrieve_appearances_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_slug`
 
-    :param slug: Host slug string to test retrieving host appearances
-    :type slug: str
+    :param host_slug: Host slug string to test retrieving host
+        appearances
+    :type host_slug: str
     """
     appearances = HostAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(slug)
+    appearance = appearances.retrieve_appearances_by_slug(host_slug)
 
-    assert "count" in appearance, f"'count' was not returned for slug {slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {slug}"
+    assert "count" in appearance, f"'count' was not returned for slug {host_slug}"
+    assert "shows" in appearance, f"'shows' was not returned for slug {host_slug}"

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.host.HostAppearances`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.host import HostAppearances
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [2])
 def test_host_appearances_retrieve_appearances_by_id(id: int):
     """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_id`
@@ -37,6 +39,7 @@ def test_host_appearances_retrieve_appearances_by_id(id: int):
 
     assert "count" in appearance, f"'count' was not returned for ID {id}"
     assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_host_appearances_retrieve_appearances_by_slug(slug: str):

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.host.Host`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.host import Host
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_host_retrieve_all():
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_all`
     """
@@ -33,6 +35,7 @@ def test_host_retrieve_all():
 
     assert hosts, "No hosts could be retrieved"
     assert "id" in hosts[0], "'id' was not returned for the first list item"
+
 
 def test_host_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_details`
@@ -45,6 +48,7 @@ def test_host_retrieve_all_details():
     assert "appearances" in hosts[0], ("'appearances' was not returned for the"
                                        "first list item")
 
+
 def test_host_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_ids`
     """
@@ -53,6 +57,7 @@ def test_host_retrieve_all_ids():
 
     assert ids, "No host IDs could be retrieved"
 
+
 def test_host_retrieve_all_slugs():
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_slugs`
     """
@@ -60,6 +65,7 @@ def test_host_retrieve_all_slugs():
     slugs = host.retrieve_all_slugs()
 
     assert slugs, "No host slug strings could be retrieved"
+
 
 @pytest.mark.parametrize("id", [2])
 def test_host_retrieve_by_id(id: int):
@@ -73,6 +79,7 @@ def test_host_retrieve_by_id(id: int):
 
     assert info, f"Host ID {id} not found"
     assert "name" in info, f"'name' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("id", [2])
 def test_host_retrieve_details_by_id(id: int):
@@ -88,6 +95,7 @@ def test_host_retrieve_details_by_id(id: int):
     assert "name" in info, f"'name' was not returned for ID {id}"
     assert "appearances" in info, f"'appearances' was not returned for ID {id}"
 
+
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_host_retrieve_by_slug(slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_slug`
@@ -100,6 +108,7 @@ def test_host_retrieve_by_slug(slug: str):
 
     assert info, f"Host slug {slug} not found"
     assert "name" in info, f"'name' was not returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_host_retrieve_details_by_slug(slug: str):

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -67,59 +67,60 @@ def test_host_retrieve_all_slugs():
     assert slugs, "No host slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("id", [2])
-def test_host_retrieve_by_id(id: int):
+@pytest.mark.parametrize("host_id", [2])
+def test_host_retrieve_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_id`
 
-    :param id: Host ID to test retrieving host information
-    :type id: int
+    :param host_id: Host ID to test retrieving host information
+    :type host_id: int
     """
     host = Host(connect_dict=get_connect_dict())
-    info = host.retrieve_by_id(id)
+    info = host.retrieve_by_id(host_id)
 
-    assert info, f"Host ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
+    assert info, f"Host ID {host_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {host_id}"
 
 
-@pytest.mark.parametrize("id", [2])
-def test_host_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("host_id", [2])
+def test_host_retrieve_details_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`
 
-    :param id: Host ID to test retrieving host details
-    :type id: int
+    :param host_id: Host ID to test retrieving host details
+    :type host_id: int
     """
     host = Host(connect_dict=get_connect_dict())
-    info = host.retrieve_details_by_id(id)
+    info = host.retrieve_details_by_id(host_id)
 
-    assert info, f"Host ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {id}"
+    assert info, f"Host ID {host_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {host_id}"
+    assert "appearances" in info, f"'appearances' was not returned for ID {host_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_host_retrieve_by_slug(slug: str):
+@pytest.mark.parametrize("host_slug", ["luke-burbank"])
+def test_host_retrieve_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_slug`
 
-    :param slug: Host slug string to test retrieving host information
-    :type slug: str
+    :param host_slug: Host slug string to test retrieving host
+        information
+    :type host_slug: str
     """
     host = Host(connect_dict=get_connect_dict())
-    info = host.retrieve_by_slug(slug)
+    info = host.retrieve_by_slug(host_slug)
 
-    assert info, f"Host slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
+    assert info, f"Host slug {host_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {host_slug}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_host_retrieve_details_by_slug(slug: str):
+@pytest.mark.parametrize("host_slug", ["luke-burbank"])
+def test_host_retrieve_details_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_slug`
 
-    :param slug: Host slug string to test retrieving host details
-    :type slug: str
+    :param host_slug: Host slug string to test retrieving host details
+    :type host_slug: str
     """
     host = Host(connect_dict=get_connect_dict())
-    info = host.retrieve_details_by_slug(slug)
+    info = host.retrieve_details_by_slug(host_slug)
 
-    assert info, f"Host slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
-    assert "appearances" in info, f"'appearances' was not returned for slug {slug}"
+    assert info, f"Host slug {host_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {host_slug}"
+    assert "appearances" in info, f"'appearances' was not returned for slug {host_slug}"

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -27,108 +27,109 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [2])
-def test_host_utility_convert_id_to_slug(id: int):
+@pytest.mark.parametrize("host_id", [2])
+def test_host_utility_convert_id_to_slug(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
 
-    :param id: Host ID to test converting into host slug string
-    :type id: int
+    :param host_id: Host ID to test converting into host slug string
+    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(host_id)
 
-    assert slug, f"Host slug for ID {id} was not found"
-    assert isinstance(slug, str), f"Invalid value returned for ID {id}"
+    assert slug, f"Host slug for ID {host_id} was not found"
+    assert isinstance(slug, str), f"Invalid value returned for ID {host_id}"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_host_utility_convert_invalid_id_to_slug(id: int):
+@pytest.mark.parametrize("host_id", [-1])
+def test_host_utility_convert_invalid_id_to_slug(host_id: int):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
 
-    :param id: Host ID to test failing to convert into host slug string
-    :type id: int
+    :param host_id: Host ID to test failing to convert into host slug
+        string
+    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(host_id)
 
-    assert not slug, f"Host slug for ID {id} was found"
+    assert not slug, f"Host slug for ID {host_id} was found"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks"])
-def test_host_utility_convert_slug_to_id(slug: str):
+@pytest.mark.parametrize("host_slug", ["tom-hanks"])
+def test_host_utility_convert_slug_to_id(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
 
-    :param slug: Host slug string to test converting into host ID
-    :type slug: str
+    :param host_slug: Host slug string to test converting into host ID
+    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(host_slug)
 
-    assert id, f"Host ID for slug {slug} was not found"
-    assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+    assert id_, f"Host ID for slug {host_slug} was not found"
+    assert isinstance(id_, int), f"Invalid value returned for slug {host_slug}"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanx"])
-def test_host_utility_convert_invalid_slug_to_id(slug: str):
+@pytest.mark.parametrize("host_slug", ["tom-hanx"])
+def test_host_utility_convert_invalid_slug_to_id(host_slug: str):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
 
-    :param slug: Host slug string to test failing to convert into host
-        ID
-    :type slug: str
+    :param host_slug: Host slug string to test failing to convert into
+        host ID
+    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    result = utility.convert_slug_to_id(slug)
+    result = utility.convert_slug_to_id(host_slug)
 
-    assert not result, f"Host ID for slug {slug} found"
+    assert not result, f"Host ID for slug {host_slug} found"
 
 
-@pytest.mark.parametrize("id", [2])
-def test_host_utility_id_exists(id: int):
+@pytest.mark.parametrize("host_id", [2])
+def test_host_utility_id_exists(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.id_exists`
 
-    :param id: Host ID to test if a host exists
-    :type id: int
+    :param host_id: Host ID to test if a host exists
+    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(host_id)
 
-    assert result, f"Host ID {id} does not exist"
+    assert result, f"Host ID {host_id} does not exist"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_host_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("host_id", [-1])
+def test_host_utility_id_not_exists(host_id: int):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.id_exists()`
 
-    :param id: Host ID to test if a host does not exist
-    :type id: int
+    :param host_id: Host ID to test if a host does not exist
+    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(host_id)
 
-    assert not result, f"Host ID {id} exists"
+    assert not result, f"Host ID {host_id} exists"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanks"])
-def test_host_utility_slug_exists(slug: str):
+@pytest.mark.parametrize("host_slug", ["tom-hanks"])
+def test_host_utility_slug_exists(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
 
-    :param slug: Host slug string to test if a host exists
-    :type slug: str
+    :param host_slug: Host slug string to test if a host exists
+    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(host_slug)
 
-    assert result, f"Host slug {slug} does not exist"
+    assert result, f"Host slug {host_slug} does not exist"
 
 
-@pytest.mark.parametrize("slug", ["tom-hanx"])
-def test_host_utility_slug_not_exists(slug: str):
+@pytest.mark.parametrize("host_slug", ["tom-hanx"])
+def test_host_utility_slug_not_exists(host_slug: str):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
 
-    :param slug: Host slug string to test if a host does not exist
-    :type slug: str
+    :param host_slug: Host slug string to test if a host does not exist
+    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(host_slug)
 
-    assert not result, f"Host slug {slug} exists"
+    assert not result, f"Host slug {host_slug} exists"

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.host.HostUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.host import HostUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [2])
 def test_host_utility_convert_id_to_slug(id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
@@ -38,6 +40,7 @@ def test_host_utility_convert_id_to_slug(id: int):
     assert slug, f"Host slug for ID {id} was not found"
     assert isinstance(slug, str), f"Invalid value returned for ID {id}"
 
+
 @pytest.mark.parametrize("id", [-1])
 def test_host_utility_convert_invalid_id_to_slug(id: int):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
@@ -49,6 +52,7 @@ def test_host_utility_convert_invalid_id_to_slug(id: int):
     slug = utility.convert_id_to_slug(id)
 
     assert not slug, f"Host slug for ID {id} was found"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanks"])
 def test_host_utility_convert_slug_to_id(slug: str):
@@ -63,6 +67,7 @@ def test_host_utility_convert_slug_to_id(slug: str):
     assert id, f"Host ID for slug {slug} was not found"
     assert isinstance(id, int), f"Invalid value returned for slug {slug}"
 
+
 @pytest.mark.parametrize("slug", ["tom-hanx"])
 def test_host_utility_convert_invalid_slug_to_id(slug: str):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
@@ -76,6 +81,7 @@ def test_host_utility_convert_invalid_slug_to_id(slug: str):
 
     assert not result, f"Host ID for slug {slug} found"
 
+
 @pytest.mark.parametrize("id", [2])
 def test_host_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.id_exists`
@@ -87,6 +93,7 @@ def test_host_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Host ID {id} does not exist"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_host_utility_id_not_exists(id: int):
@@ -100,6 +107,7 @@ def test_host_utility_id_not_exists(id: int):
 
     assert not result, f"Host ID {id} exists"
 
+
 @pytest.mark.parametrize("slug", ["tom-hanks"])
 def test_host_utility_slug_exists(slug: str):
     """Testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
@@ -111,6 +119,7 @@ def test_host_utility_slug_exists(slug: str):
     result = utility.slug_exists(slug)
 
     assert result, f"Host slug {slug} does not exist"
+
 
 @pytest.mark.parametrize("slug", ["tom-hanx"])
 def test_host_utility_slug_not_exists(slug: str):

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -67,61 +67,62 @@ def test_location_retrieve_all_slugs():
     assert slugs, "No location slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("id", [95])
-def test_location_retrieve_by_id(id: int):
+@pytest.mark.parametrize("location_id", [95])
+def test_location_retrieve_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_id`
 
-    :param id: Location ID to test retrieving location information
-    :type id: int
+    :param location_id: Location ID to test retrieving location
+        information
+    :type location_id: int
     """
     location = Location(connect_dict=get_connect_dict())
-    info = location.retrieve_by_id(id)
+    info = location.retrieve_by_id(location_id)
 
-    assert info, f"Location ID {id} not found"
-    assert "venue" in info, f"'venue' was not returned for ID {id}"
+    assert info, f"Location ID {location_id} not found"
+    assert "venue" in info, f"'venue' was not returned for ID {location_id}"
 
 
-@pytest.mark.parametrize("id", [95])
-def test_location_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("location_id", [95])
+def test_location_retrieve_details_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`
 
-    :param id: Location ID to test retrieving location details
-    :type id: int
+    :param location_id: Location ID to test retrieving location details
+    :type location_id: int
     """
     location = Location(connect_dict=get_connect_dict())
-    info = location.retrieve_details_by_id(id)
+    info = location.retrieve_details_by_id(location_id)
 
-    assert info, f"Location ID {id} not found"
-    assert "venue" in info, f"'venue' was not returned for ID {id}"
-    assert "recordings" in info, f"'recordings' was not returned for ID {id}"
+    assert info, f"Location ID {location_id} not found"
+    assert "venue" in info, f"'venue' was not returned for ID {location_id}"
+    assert "recordings" in info, f"'recordings' was not returned for ID {location_id}"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
-def test_location_retrieve_by_slug(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
+def test_location_retrieve_by_slug(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_slug`
 
-    :param slug: Location slug string to test retrieving location
-        information
-    :type slug: str
+    :param location_slug: Location slug string to test retrieving
+        location information
+    :type location_slug: str
     """
     location = Location(connect_dict=get_connect_dict())
-    info = location.retrieve_by_slug(slug)
+    info = location.retrieve_by_slug(location_slug)
 
-    assert info, f"Location slug {slug} not found"
-    assert "venue" in info, f"'venue' was not returned for slug {slug}"
+    assert info, f"Location slug {location_slug} not found"
+    assert "venue" in info, f"'venue' was not returned for slug {location_slug}"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
-def test_location_retrieve_details_by_slug(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
+def test_location_retrieve_details_by_slug(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_details_by_slug`
 
-    :param slug: Location slug string to test retrieving location
-        details
-    :type slug: str
+    :param location_slug: Location slug string to test retrieving
+        location details
+    :type location_slug: str
     """
     location = Location(connect_dict=get_connect_dict())
-    info = location.retrieve_details_by_slug(slug)
+    info = location.retrieve_details_by_slug(location_slug)
 
-    assert info, f"Location slug {slug} not found"
-    assert "venue" in info, f"'venue' was not returned for slug {slug}"
-    assert "recordings" in info, f"'recordings' was not returned for slug {slug}"
+    assert info, f"Location slug {location_slug} not found"
+    assert "venue" in info, f"'venue' was not returned for slug {location_slug}"
+    assert "recordings" in info, f"'recordings' was not returned for slug {location_slug}"

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.location.Location`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.location import Location
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_location_retrieve_all():
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_all`
     """
@@ -33,6 +35,7 @@ def test_location_retrieve_all():
 
     assert locations, "No locations could be retrieved"
     assert "id" in locations[0], "'id' was not returned for the first list item"
+
 
 def test_location_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_details`
@@ -45,6 +48,7 @@ def test_location_retrieve_all_details():
     assert "recordings" in locations[0], ("'recordings' was not returned for "
                                           "the first list item")
 
+
 def test_location_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_ids`
     """
@@ -53,6 +57,7 @@ def test_location_retrieve_all_ids():
 
     assert ids, "No location IDs could be retrieved"
 
+
 def test_location_retrieve_all_slugs():
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_slugs`
     """
@@ -60,6 +65,7 @@ def test_location_retrieve_all_slugs():
     slugs = location.retrieve_all_slugs()
 
     assert slugs, "No location slug strings could be retrieved"
+
 
 @pytest.mark.parametrize("id", [95])
 def test_location_retrieve_by_id(id: int):
@@ -74,9 +80,10 @@ def test_location_retrieve_by_id(id: int):
     assert info, f"Location ID {id} not found"
     assert "venue" in info, f"'venue' was not returned for ID {id}"
 
+
 @pytest.mark.parametrize("id", [95])
 def test_location_retrieve_details_by_id(id: int):
-    """Testing for :py:meth:`wwdtm.location.ocation.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`
 
     :param id: Location ID to test retrieving location details
     :type id: int
@@ -87,6 +94,7 @@ def test_location_retrieve_details_by_id(id: int):
     assert info, f"Location ID {id} not found"
     assert "venue" in info, f"'venue' was not returned for ID {id}"
     assert "recordings" in info, f"'recordings' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
 def test_location_retrieve_by_slug(slug: str):
@@ -101,6 +109,7 @@ def test_location_retrieve_by_slug(slug: str):
 
     assert info, f"Location slug {slug} not found"
     assert "venue" in info, f"'venue' was not returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
 def test_location_retrieve_details_by_slug(slug: str):

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.location.LocationRecordings`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.location import LocationRecordings
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [95])
 def test_location_recordings_retrieve_recordings_by_id(id: int):
     """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_id`
@@ -37,6 +39,7 @@ def test_location_recordings_retrieve_recordings_by_id(id: int):
 
     assert "count" in recording, f"'count' was not returned for ID {id}"
     assert "shows" in recording, f"'shows' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
 def test_location_recordings_retrieve_recordings_by_slug(slug: str):

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -27,30 +27,31 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [95])
-def test_location_recordings_retrieve_recordings_by_id(id: int):
+@pytest.mark.parametrize("location_id", [95])
+def test_location_recordings_retrieve_recordings_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_id`
 
-    :param id: Location ID to test retrieving location recordings
-    :type id: int
+    :param location_id: Location ID to test retrieving location
+        recordings
+    :type location_id: int
     """
     recordings = LocationRecordings(connect_dict=get_connect_dict())
-    recording = recordings.retrieve_recordings_by_id(id)
+    recording = recordings.retrieve_recordings_by_id(location_id)
 
-    assert "count" in recording, f"'count' was not returned for ID {id}"
-    assert "shows" in recording, f"'shows' was not returned for ID {id}"
+    assert "count" in recording, f"'count' was not returned for ID {location_id}"
+    assert "shows" in recording, f"'shows' was not returned for ID {location_id}"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
-def test_location_recordings_retrieve_recordings_by_slug(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
+def test_location_recordings_retrieve_recordings_by_slug(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_slug`
 
-    :param slug: Location slug string to test retrieving location
-        recordings
-    :type slug: str
+    :param location_slug: Location slug string to test retrieving
+        location recordings
+    :type location_slug: str
     """
     recordings = LocationRecordings(connect_dict=get_connect_dict())
-    recording = recordings.retrieve_recordings_by_slug(slug)
+    recording = recordings.retrieve_recordings_by_slug(location_slug)
 
-    assert "count" in recording, f"'count' was not returned for slug {slug}"
-    assert "shows" in recording, f"'shows' was not returned for slug {slug}"
+    assert "count" in recording, f"'count' was not returned for slug {location_slug}"
+    assert "shows" in recording, f"'shows' was not returned for slug {location_slug}"

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -155,7 +155,7 @@ def test_location_utility_slugify_location_city_state(city: str, state: str):
         slug = utility.slugify_location(city=city, state=state)
 
 @pytest.mark.parametrize("id, venue, city, state",
-                         [("2", "Chase Auditorium", "Chicago", "IL")])
+                         [(2, "Chase Auditorium", "Chicago", "IL")])
 def test_location_utility_slugify_location_full(id: int,
                                                 venue: str,
                                                 city: str,
@@ -178,20 +178,18 @@ def test_location_utility_slugify_location_full(id: int,
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"
 
-@pytest.mark.parametrize("venue", ["Chase Auditorium"])
-def test_location_utility_slugify_location_venue(venue: str):
+@pytest.mark.parametrize("id, venue", [(2, "Chase Auditorium")])
+def test_location_utility_slugify_location_venue(id: int, venue: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
     with venue name
 
+    :param id: Location ID to include in the slug string
+    :type id: int
     :param venue: Venue name to include in the slug string
     :type venue: str
-    :param city: City to include in the slug string
-    :type city: str
-    :param state: State to include in the slug string
-    :type state: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.slugify_location(venue=venue)
+    slug = utility.slugify_location(id=id, venue=venue)
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.location.LocationUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.location import LocationUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [95])
 def test_location_utility_convert_id_to_slug(id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`
@@ -36,6 +38,7 @@ def test_location_utility_convert_id_to_slug(id: int):
     slug = utility.convert_id_to_slug(id)
 
     assert slug, f"Location slug for ID {id} was not found"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_location_utility_convert_invalid_id_to_slug(id: int):
@@ -50,6 +53,7 @@ def test_location_utility_convert_invalid_id_to_slug(id: int):
 
     assert not slug, f"Location slug for ID {id} was found"
 
+
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
 def test_location_utility_convert_slug_to_id(slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`
@@ -62,6 +66,7 @@ def test_location_utility_convert_slug_to_id(slug: str):
     id = utility.convert_slug_to_id(slug)
 
     assert id, f"Location ID for slug {slug} was not found"
+
 
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-li"])
 def test_location_utility_convert_invalid_slug_to_id(slug: str):
@@ -76,6 +81,7 @@ def test_location_utility_convert_invalid_slug_to_id(slug: str):
 
     assert not id, f"Location ID for slug {slug} was found"
 
+
 @pytest.mark.parametrize("id", [95])
 def test_location_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
@@ -87,6 +93,7 @@ def test_location_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Location ID {id} does not exist"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_location_utility_id_not_exists(id: int):
@@ -100,6 +107,7 @@ def test_location_utility_id_not_exists(id: int):
 
     assert not result, f"Location ID {id} exists"
 
+
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
 def test_location_utility_slug_exists(slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`
@@ -111,6 +119,7 @@ def test_location_utility_slug_exists(slug: str):
     result = utility.slug_exists(slug)
 
     assert result, f"Location slug {slug} does not exist"
+
 
 @pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-li"])
 def test_location_utility_slug_not_exists(slug: str):
@@ -126,6 +135,7 @@ def test_location_utility_slug_not_exists(slug: str):
 
     assert not result, f"Location slug {slug} exists"
 
+
 @pytest.mark.parametrize("city",
                          ["Chicago"])
 def test_location_utility_slugify_location_city(city: str):
@@ -138,6 +148,10 @@ def test_location_utility_slugify_location_city(city: str):
     with pytest.raises(ValueError):
         utility = LocationUtility(connect_dict=get_connect_dict())
         slug = utility.slugify_location(city=city)
+
+        assert slug, "Unable to convert into a slug string"
+        assert isinstance(slug, str), "Value returned is not a string"
+
 
 @pytest.mark.parametrize("city, state",
                          [("Chicago", "IL")])
@@ -153,6 +167,10 @@ def test_location_utility_slugify_location_city_state(city: str, state: str):
     with pytest.raises(ValueError):
         utility = LocationUtility(connect_dict=get_connect_dict())
         slug = utility.slugify_location(city=city, state=state)
+
+        assert slug, "Unable to convert into a slug string"
+        assert isinstance(slug, str), "Value returned is not a string"
+
 
 @pytest.mark.parametrize("id, venue, city, state",
                          [(2, "Chase Auditorium", "Chicago", "IL")])
@@ -177,6 +195,7 @@ def test_location_utility_slugify_location_full(id: int,
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"
+
 
 @pytest.mark.parametrize("id, venue", [(2, "Chase Auditorium")])
 def test_location_utility_slugify_location_venue(id: int, venue: str):
@@ -214,6 +233,7 @@ def test_location_utility_slugify_location_venue_city_state(venue: str,
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"
+
 
 @pytest.mark.parametrize("id", [2])
 def test_location_utility_slugify_location_id(id: int):

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -27,113 +27,115 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [95])
-def test_location_utility_convert_id_to_slug(id: int):
+@pytest.mark.parametrize("location_id", [95])
+def test_location_utility_convert_id_to_slug(location_id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`
 
-    :param id: Location ID to test converting into location slug string
-    :type id: int
+    :param location_id: Location ID to test converting into location
+        slug string
+    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(location_id)
 
-    assert slug, f"Location slug for ID {id} was not found"
+    assert slug, f"Location slug for ID {location_id} was not found"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_location_utility_convert_invalid_id_to_slug(id: int):
+@pytest.mark.parametrize("location_id", [-1])
+def test_location_utility_convert_invalid_id_to_slug(location_id: int):
     """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`
 
-    :param id: Location ID to test failing to convert into location
-        slug string
-    :type id: int
+    :param location_id: Location ID to test failing to convert into
+        location slug string
+    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(location_id)
 
-    assert not slug, f"Location slug for ID {id} was found"
+    assert not slug, f"Location slug for ID {location_id} was found"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
-def test_location_utility_convert_slug_to_id(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
+def test_location_utility_convert_slug_to_id(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`
 
-    :param slug: Location slug string to test converting into location
-        ID
-    :type slug: str
+    :param location_slug: Location slug string to test converting into
+        location ID
+    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(location_slug)
 
-    assert id, f"Location ID for slug {slug} was not found"
+    assert id_, f"Location ID for slug {location_slug} was not found"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-li"])
-def test_location_utility_convert_invalid_slug_to_id(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-li"])
+def test_location_utility_convert_invalid_slug_to_id(location_slug: str):
     """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`
 
-    :param slug: Location slug string to test failing to convert into
-        location ID
-    :type slug: str
+    :param location_slug: Location slug string to test failing to
+        convert into location ID
+    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(location_slug)
 
-    assert not id, f"Location ID for slug {slug} was found"
+    assert not id_, f"Location ID for slug {location_slug} was found"
 
 
-@pytest.mark.parametrize("id", [95])
-def test_location_utility_id_exists(id: int):
+@pytest.mark.parametrize("location_id", [95])
+def test_location_utility_id_exists(location_id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
 
-    :param id: Location ID to test if a location exists
-    :type id: int
+    :param location_id: Location ID to test if a location exists
+    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(location_id)
 
-    assert result, f"Location ID {id} does not exist"
+    assert result, f"Location ID {location_id} does not exist"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_location_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("location_id", [-1])
+def test_location_utility_id_not_exists(location_id: int):
     """Negative testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
 
-    :param id: Location ID to test if a location does not exist
-    :type id: int
+    :param location_id: Location ID to test if a location does not exist
+    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(location_id)
 
-    assert not result, f"Location ID {id} exists"
+    assert not result, f"Location ID {location_id} exists"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-il"])
-def test_location_utility_slug_exists(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
+def test_location_utility_slug_exists(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`
 
-    :param slug: Location slug string to test if a location exists
-    :type slug: str
+    :param location_slug: Location slug string to test if a location
+        exists
+    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(location_slug)
 
-    assert result, f"Location slug {slug} does not exist"
+    assert result, f"Location slug {location_slug} does not exist"
 
 
-@pytest.mark.parametrize("slug", ["the-chicago-theatre-chicago-li"])
-def test_location_utility_slug_not_exists(slug: str):
+@pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-li"])
+def test_location_utility_slug_not_exists(location_slug: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`
     with venue name
 
-    :param slug: Location slug string to test if a location
+    :param location_slug: Location slug string to test if a location
         does not exists
-    :type slug: str
+    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(location_slug)
 
-    assert not result, f"Location slug {slug} exists"
+    assert not result, f"Location slug {location_slug} exists"
 
 
 @pytest.mark.parametrize("city",
@@ -172,17 +174,17 @@ def test_location_utility_slugify_location_city_state(city: str, state: str):
         assert isinstance(slug, str), "Value returned is not a string"
 
 
-@pytest.mark.parametrize("id, venue, city, state",
+@pytest.mark.parametrize("location_id, venue, city, state",
                          [(2, "Chase Auditorium", "Chicago", "IL")])
-def test_location_utility_slugify_location_full(id: int,
+def test_location_utility_slugify_location_full(location_id: int,
                                                 venue: str,
                                                 city: str,
                                                 state: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
     with location ID, venue, city and state names
 
-    :param id: Location ID to include in the slug string
-    :type id: int
+    :param location_id: Location ID to include in the slug string
+    :type location_id: int
     :param venue: Venue name to include in the slug string
     :type venue: str
     :param city: City to include in the slug string
@@ -191,24 +193,26 @@ def test_location_utility_slugify_location_full(id: int,
     :type state: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.slugify_location(id=id, venue=venue, city=city, state=state)
+    slug = utility.slugify_location(location_id=location_id, venue=venue,
+                                    city=city, state=state)
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"
 
 
-@pytest.mark.parametrize("id, venue", [(2, "Chase Auditorium")])
-def test_location_utility_slugify_location_venue(id: int, venue: str):
+@pytest.mark.parametrize("location_id, venue", [(2, "Chase Auditorium")])
+def test_location_utility_slugify_location_venue(location_id: int,
+                                                 venue: str):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
     with venue name
 
-    :param id: Location ID to include in the slug string
-    :type id: int
+    :param location_id: Location ID to include in the slug string
+    :type location_id: int
     :param venue: Venue name to include in the slug string
     :type venue: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.slugify_location(id=id, venue=venue)
+    slug = utility.slugify_location(location_id=location_id, venue=venue)
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"
@@ -235,16 +239,16 @@ def test_location_utility_slugify_location_venue_city_state(venue: str,
     assert isinstance(slug, str), "Value returned is not a string"
 
 
-@pytest.mark.parametrize("id", [2])
-def test_location_utility_slugify_location_id(id: int):
+@pytest.mark.parametrize("location_id", [2])
+def test_location_utility_slugify_location_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
     with venue, city and state names
 
-    :param id: Location ID to include in the slug string
-    :type id: int
+    :param location_id: Location ID to include in the slug string
+    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
-    slug = utility.slugify_location(id=id)
+    slug = utility.slugify_location(location_id=location_id)
 
     assert slug, "Unable to convert into a slug string"
     assert isinstance(slug, str), "Value returned is not a string"

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -27,57 +27,59 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_appearances_retrieve_appearances_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
 
-    :param id: Panelist ID to test retrieving panelist appearances
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        appearances
+    :type panelist_id: int
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(id)
+    appearance = appearances.retrieve_appearances_by_id(panelist_id)
 
-    assert "count" in appearance, f"'count' was not returned for ID {id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+    assert "count" in appearance, f"'count' was not returned for ID {panelist_id}"
+    assert "shows" in appearance, f"'shows' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_appearances_retrieve_appearances_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        appearances
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist appearances
+    :type panelist_slug: str
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(slug)
+    appearance = appearances.retrieve_appearances_by_slug(panelist_slug)
 
-    assert "count" in appearance, f"'count' was not returned for slug {slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {slug}"
+    assert "count" in appearance, f"'count' was not returned for slug {panelist_slug}"
+    assert "shows" in appearance, f"'shows' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_appearances_retrieve_yearly_appearances_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_id`
 
-    :param id: Panelist ID to test retrieving a panelist's appearances
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving a panelist's
+        appearances
+    :type panelist_id: int
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    breakdown = appearances.retrieve_yearly_appearances_by_id(id)
+    breakdown = appearances.retrieve_yearly_appearances_by_id(panelist_id)
 
-    assert breakdown, f"No values returned for panelist appearances"
+    assert breakdown, f"No appearance information returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_appearances_retrieve_yearly_appearances_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_appearances_retrieve_yearly_appearances_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        appearances
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist appearances
+    :type panelist_slug: str
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    breakdown = appearances.retrieve_yearly_appearances_by_slug(slug)
+    breakdown = appearances.retrieve_yearly_appearances_by_slug(panelist_slug)
 
-    assert breakdown, f"No values returned for panelist appearances"
+    assert breakdown, f"No appearance information returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.panelist.PanelistAppearances`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.panelist import PanelistAppearances
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_appearances_retrieve_appearances_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
@@ -37,6 +39,7 @@ def test_panelist_appearances_retrieve_appearances_by_id(id: int):
 
     assert "count" in appearance, f"'count' was not returned for ID {id}"
     assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_appearances_retrieve_appearances_by_slug(slug: str):
@@ -52,6 +55,7 @@ def test_panelist_appearances_retrieve_appearances_by_slug(slug: str):
     assert "count" in appearance, f"'count' was not returned for slug {slug}"
     assert "shows" in appearance, f"'shows' was not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_appearances_retrieve_yearly_appearances_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_id`
@@ -62,7 +66,8 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(id: int):
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_id(id)
 
-    assert breakdown, (f"No values returned for panelist appearances")
+    assert breakdown, f"No values returned for panelist appearances"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_appearances_retrieve_yearly_appearances_by_slug(slug: str):
@@ -75,4 +80,4 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_slug(slug: str):
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_slug(slug)
 
-    assert breakdown, (f"No values returned for panelist appearances")
+    assert breakdown, f"No values returned for panelist appearances"

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -67,61 +67,62 @@ def test_panelist_retrieve_all_slugs():
     assert slugs, "No panelist slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_retrieve_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_retrieve_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_by_id(id)
+    info = panelist.retrieve_by_id(panelist_id)
 
-    assert info, f"Panelist ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
+    assert info, f"Panelist ID {panelist_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_retrieve_details_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
 
-    :param id: Panelist ID to test retrieving panelist details
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist details
+    :type panelist_id: int
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_id(id)
+    info = panelist.retrieve_details_by_id(panelist_id)
 
-    assert info, f"Panelist ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {id}"
+    assert info, f"Panelist ID {panelist_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {panelist_id}"
+    assert "appearances" in info, f"'appearances' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank", "drew-carey"])
-def test_panelist_retrieve_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank", "drew-carey"])
+def test_panelist_retrieve_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_by_slug(slug)
+    info = panelist.retrieve_by_slug(panelist_slug)
 
-    assert info, f"Panelist slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
+    assert info, f"Panelist slug {panelist_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_retrieve_details_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_retrieve_details_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        details
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist details
+    :type panelist_slug: str
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_slug(slug)
+    info = panelist.retrieve_details_by_slug(panelist_slug)
 
-    assert info, f"Panelist slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
-    assert "appearances" in info, f"'appearances' was not returned for slug {slug}"
+    assert info, f"Panelist slug {panelist_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
+    assert "appearances" in info, f"'appearances' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.panelist.Panelist`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.panelist import Panelist
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_panelist_retrieve_all():
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all`
     """
@@ -33,6 +35,7 @@ def test_panelist_retrieve_all():
 
     assert panelists, "No panelists could be retrieved"
     assert "id" in panelists[0], "'id' was not returned for the first list item"
+
 
 def test_panelist_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`
@@ -43,7 +46,8 @@ def test_panelist_retrieve_all_details():
     assert panelists, "No panelists could be retrieved"
     assert "id" in panelists[0], "'id' was not returned for first list item"
     assert "appearances" in panelists[0], ("'appearances' was not returned for "
-                                       "the first list item")
+                                           "the first list item")
+
 
 def test_panelist_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_ids`
@@ -53,6 +57,7 @@ def test_panelist_retrieve_all_ids():
 
     assert ids, "No panelist IDs could be retrieved"
 
+
 def test_panelist_retrieve_all_slugs():
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_slugs`
     """
@@ -60,6 +65,7 @@ def test_panelist_retrieve_all_slugs():
     slugs = panelist.retrieve_all_slugs()
 
     assert slugs, "No panelist slug strings could be retrieved"
+
 
 @pytest.mark.parametrize("id", [14])
 def test_panelist_retrieve_by_id(id: int):
@@ -73,6 +79,7 @@ def test_panelist_retrieve_by_id(id: int):
 
     assert info, f"Panelist ID {id} not found"
     assert "name" in info, f"'name' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("id", [14])
 def test_panelist_retrieve_details_by_id(id: int):
@@ -88,6 +95,7 @@ def test_panelist_retrieve_details_by_id(id: int):
     assert "name" in info, f"'name' was not returned for ID {id}"
     assert "appearances" in info, f"'appearances' was not returned for ID {id}"
 
+
 @pytest.mark.parametrize("slug", ["luke-burbank", "drew-carey"])
 def test_panelist_retrieve_by_slug(slug: str):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`
@@ -101,6 +109,7 @@ def test_panelist_retrieve_by_slug(slug: str):
 
     assert info, f"Panelist slug {slug} not found"
     assert "name" in info, f"'name' was not returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_retrieve_details_by_slug(slug: str):

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -27,142 +27,146 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_scores_retrieve_scores_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_by_id(id)
+    scoring = scores.retrieve_scores_by_id(panelist_id)
 
-    assert scoring, f"Scoring data not returned for ID {id}"
+    assert scoring, f"Scoring data not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_scores_retrieve_scores_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_by_slug(slug)
+    scoring = scores.retrieve_scores_by_slug(panelist_slug)
 
-    assert scoring, f"Scoring data not returned for slug {slug}"
+    assert scoring, f"Scoring data not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_scores_retrieve_scores_grouped_list_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_grouped_list_by_id(id)
+    scoring = scores.retrieve_scores_grouped_list_by_id(panelist_id)
 
-    assert "score" in scoring, f"'score' was not returned for ID {id}"
-    assert "count" in scoring, f"'count' was not returned for ID {id}"
+    assert "score" in scoring, f"'score' was not returned for ID {panelist_id}"
+    assert "count" in scoring, f"'count' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_scores_retrieve_scores_grouped_list_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_grouped_list_by_slug(slug)
+    scoring = scores.retrieve_scores_grouped_list_by_slug(panelist_slug)
 
-    assert "score" in scoring, f"'score' was not returned for slug {slug}"
-    assert "count" in scoring, f"'count' was not returned for slug {slug}"
+    assert "score" in scoring, f"'score' was not returned for slug {panelist_slug}"
+    assert "count" in scoring, f"'count' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_grouped_ordered_pair_by_id(id)
+    scoring = scores.retrieve_scores_grouped_ordered_pair_by_id(panelist_id)
 
-    assert scoring, f"Scoring data not returned for ID {id}"
+    assert scoring, f"Scoring data not returned for ID {panelist_id}"
     assert isinstance(scoring[0], tuple), "First list item is not a tuple"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_grouped_ordered_pair_by_slug(slug)
+    scoring = scores.retrieve_scores_grouped_ordered_pair_by_slug(panelist_slug)
 
-    assert scoring, f"Scoring data not returned for slug {slug}"
+    assert scoring, f"Scoring data not returned for slug {panelist_slug}"
     assert isinstance(scoring[0], tuple), "First list item is not a tuple"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_scores_retrieve_scores_list_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist information
+    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_list_by_id(id)
+    scoring = scores.retrieve_scores_list_by_id(panelist_id)
 
-    assert "shows" in scoring, f"'shows' was not returned for ID {id}"
-    assert "scores" in scoring, f"'scores' was not returned for ID {id}"
+    assert "shows" in scoring, f"'shows' was not returned for ID {panelist_id}"
+    assert "scores" in scoring, f"'scores' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_scores_retrieve_scores_list_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_list_by_slug(slug)
+    scoring = scores.retrieve_scores_list_by_slug(panelist_slug)
 
-    assert "shows" in scoring, f"'shows' was not returned for slug {slug}"
-    assert "scores" in scoring, f"'scores' was not returned for slug {slug}"
+    assert "shows" in scoring, f"'shows' was not returned for slug {panelist_slug}"
+    assert "scores" in scoring, f"'scores' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_scores_retrieve_scores_ordered_pair_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_ordered_pair_by_id(id)
+    scoring = scores.retrieve_scores_ordered_pair_by_id(panelist_id)
 
-    assert scoring, f"Scoring data not returned for ID {id}"
+    assert scoring, f"Scoring data not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
+    :param panelist_slug: Panelist slug string to test retrieving panelist
         information
-    :type slug: str
+    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
-    scoring = scores.retrieve_scores_ordered_pair_by_slug(slug)
+    scoring = scores.retrieve_scores_ordered_pair_by_slug(panelist_slug)
 
-    assert scoring, f"Scoring data not returned for slug {slug}"
+    assert scoring, f"Scoring data not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.panelist.PanelistScores`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.panelist import PanelistScores
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_scores_retrieve_scores_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_id`
@@ -36,6 +38,7 @@ def test_panelist_scores_retrieve_scores_by_id(id: int):
     scoring = scores.retrieve_scores_by_id(id)
 
     assert scoring, f"Scoring data not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_by_slug(slug: str):
@@ -50,6 +53,7 @@ def test_panelist_scores_retrieve_scores_by_slug(slug: str):
 
     assert scoring, f"Scoring data not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_scores_retrieve_scores_grouped_list_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_id`
@@ -62,6 +66,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_id(id: int):
 
     assert "score" in scoring, f"'score' was not returned for ID {id}"
     assert "count" in scoring, f"'count' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_grouped_list_by_slug(slug: str):
@@ -77,6 +82,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_slug(slug: str):
     assert "score" in scoring, f"'score' was not returned for slug {slug}"
     assert "count" in scoring, f"'count' was not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_id`
@@ -89,6 +95,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(id: int):
 
     assert scoring, f"Scoring data not returned for ID {id}"
     assert isinstance(scoring[0], tuple), "First list item is not a tuple"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(slug: str):
@@ -104,6 +111,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(slug: str)
     assert scoring, f"Scoring data not returned for slug {slug}"
     assert isinstance(scoring[0], tuple), "First list item is not a tuple"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_scores_retrieve_scores_list_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_id`
@@ -116,6 +124,7 @@ def test_panelist_scores_retrieve_scores_list_by_id(id: int):
 
     assert "shows" in scoring, f"'shows' was not returned for ID {id}"
     assert "scores" in scoring, f"'scores' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_list_by_slug(slug: str):
@@ -131,6 +140,7 @@ def test_panelist_scores_retrieve_scores_list_by_slug(slug: str):
     assert "shows" in scoring, f"'shows' was not returned for slug {slug}"
     assert "scores" in scoring, f"'scores' was not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_id`
@@ -142,6 +152,7 @@ def test_panelist_scores_retrieve_scores_ordered_pair_by_id(id: int):
     scoring = scores.retrieve_scores_ordered_pair_by_id(id)
 
     assert scoring, f"Scoring data not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(slug: str):

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -27,86 +27,89 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_statistics_retrieve_bluffs_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_statistics_retrieve_bluffs_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    bluffs = statistics.retrieve_bluffs_by_id(id)
+    bluffs = statistics.retrieve_bluffs_by_id(panelist_id)
 
-    assert "chosen" in bluffs, f"'chosen' was not returned for ID {id}"
-    assert "correct" in bluffs, f"'correct' was not returned for ID {id}"
+    assert "chosen" in bluffs, f"'chosen' was not returned for ID {panelist_id}"
+    assert "correct" in bluffs, f"'correct' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_bluffs_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_statistics_retrieve_bluffs_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    bluffs = statistics.retrieve_bluffs_by_slug(slug)
+    bluffs = statistics.retrieve_bluffs_by_slug(panelist_slug)
 
-    assert "chosen" in bluffs, f"'chosen' was not returned for slug {slug}"
-    assert "correct" in bluffs, f"'correct' was not returned for slug {slug}"
+    assert "chosen" in bluffs, f"'chosen' was not returned for slug {panelist_slug}"
+    assert "correct" in bluffs, f"'correct' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_statistics_retrieve_rank_info_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_statistics_retrieve_rank_info_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    ranks = statistics.retrieve_rank_info_by_id(id)
+    ranks = statistics.retrieve_rank_info_by_id(panelist_id)
 
-    assert "first" in ranks, f"'first' was not returned for ID {id}"
+    assert "first" in ranks, f"'first' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_rank_info_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    ranks = statistics.retrieve_rank_info_by_slug(slug)
+    ranks = statistics.retrieve_rank_info_by_slug(panelist_slug)
 
-    assert "first" in ranks, f"'first' was not returned for slug {slug}"
+    assert "first" in ranks, f"'first' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_statistics_retrieve_statistics_by_id(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_statistics_retrieve_statistics_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
 
-    :param id: Panelist ID to test retrieving panelist information
-    :type id: int
+    :param panelist_id: Panelist ID to test retrieving panelist
+        information
+    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_id(id)
+    stats = statistics.retrieve_statistics_by_id(panelist_id)
 
-    assert "scoring" in stats, f"'scoring' was not returned for ID {id}"
-    assert "ranking" in stats, f"'ranking' was not returned for ID {id}"
+    assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
+    assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_statistics_by_slug(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+def test_panelist_statistics_retrieve_statistics_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
 
-    :param slug: Panelist slug string to test retrieving panelist
-        information
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_slug(slug)
+    stats = statistics.retrieve_statistics_by_slug(panelist_slug)
 
-    assert "scoring" in stats, f"'scoring' was not returned for slug {slug}"
-    assert "ranking" in stats, f"'ranking' was not returned for slug {slug}"
+    assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
+    assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.panelist.PanelistStatistics`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.panelist import PanelistStatistics
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_statistics_retrieve_bluffs_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_id`
@@ -37,6 +39,7 @@ def test_panelist_statistics_retrieve_bluffs_by_id(id: int):
 
     assert "chosen" in bluffs, f"'chosen' was not returned for ID {id}"
     assert "correct" in bluffs, f"'correct' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_statistics_retrieve_bluffs_by_slug(slug: str):
@@ -52,6 +55,7 @@ def test_panelist_statistics_retrieve_bluffs_by_slug(slug: str):
     assert "chosen" in bluffs, f"'chosen' was not returned for slug {slug}"
     assert "correct" in bluffs, f"'correct' was not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_statistics_retrieve_rank_info_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_id`
@@ -63,6 +67,7 @@ def test_panelist_statistics_retrieve_rank_info_by_id(id: int):
     ranks = statistics.retrieve_rank_info_by_id(id)
 
     assert "first" in ranks, f"'first' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_statistics_retrieve_rank_info_by_slug(slug: str):
@@ -77,6 +82,7 @@ def test_panelist_statistics_retrieve_rank_info_by_slug(slug: str):
 
     assert "first" in ranks, f"'first' was not returned for slug {slug}"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_statistics_retrieve_statistics_by_id(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
@@ -89,6 +95,7 @@ def test_panelist_statistics_retrieve_statistics_by_id(id: int):
 
     assert "scoring" in stats, f"'scoring' was not returned for ID {id}"
     assert "ranking" in stats, f"'ranking' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["luke-burbank"])
 def test_panelist_statistics_retrieve_statistics_by_slug(slug: str):

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.panelist.PanelistUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.panelist import PanelistUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -25,6 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_utility_convert_id_to_slug(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
@@ -38,6 +40,7 @@ def test_panelist_utility_convert_id_to_slug(id: int):
     assert slug, f"Panelist slug for ID {id} was not found"
     assert isinstance(slug, str), f"Invalid value returned for ID {id}"
 
+
 @pytest.mark.parametrize("id", [-1])
 def test_panelist_utility_convert_invalid_id_to_slug(id: int):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
@@ -50,6 +53,7 @@ def test_panelist_utility_convert_invalid_id_to_slug(id: int):
     slug = utility.convert_id_to_slug(id)
 
     assert not slug, f"Panelist slug for ID {id} was found"
+
 
 @pytest.mark.parametrize("slug", ["faith-salie"])
 def test_panelist_utility_convert_slug_to_id(slug: str):
@@ -65,6 +69,7 @@ def test_panelist_utility_convert_slug_to_id(slug: str):
     assert id, f"Panelist ID for slug {slug} was not found"
     assert isinstance(id, int), f"Invalid value returned for slug {slug}"
 
+
 @pytest.mark.parametrize("slug", ["faith-sale"])
 def test_panelist_utility_convert_invalid_slug_to_id(slug: str):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`
@@ -78,6 +83,7 @@ def test_panelist_utility_convert_invalid_slug_to_id(slug: str):
 
     assert not id, f"Panelist ID for slug {slug} was found"
 
+
 @pytest.mark.parametrize("id", [14])
 def test_panelist_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
@@ -89,6 +95,7 @@ def test_panelist_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Panelist ID {id} does not exist"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_panelist_utility_id_not_exists(id: int):
@@ -102,6 +109,7 @@ def test_panelist_utility_id_not_exists(id: int):
 
     assert not result, f"Panelist ID {id} exists"
 
+
 @pytest.mark.parametrize("slug", ["faith-salie"])
 def test_panelist_utility_slug_exists(slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`
@@ -113,6 +121,7 @@ def test_panelist_utility_slug_exists(slug: str):
     result = utility.slug_exists(slug)
 
     assert result, f"Panelist slug {slug} does not exist"
+
 
 @pytest.mark.parametrize("slug", ["faith-sale"])
 def test_panelist_utility_slug_not_exists(slug: str):

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -27,111 +27,113 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_utility_convert_id_to_slug(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_utility_convert_id_to_slug(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
 
-    :param id: Panelist ID to test converting into panelist slug string
-    :type id: int
+    :param panelist_id: Panelist ID to test converting into panelist
+        slug string
+    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(panelist_id)
 
-    assert slug, f"Panelist slug for ID {id} was not found"
-    assert isinstance(slug, str), f"Invalid value returned for ID {id}"
+    assert slug, f"Panelist slug for ID {panelist_id} was not found"
+    assert isinstance(slug, str), f"Invalid value returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_panelist_utility_convert_invalid_id_to_slug(id: int):
+@pytest.mark.parametrize("panelist_id", [-1])
+def test_panelist_utility_convert_invalid_id_to_slug(panelist_id: int):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
 
-    :param id: Panelist ID to test failing to convert into panelist
-        slug string
-    :type id: int
+    :param panelist_id: Panelist ID to test failing to convert into
+        panelist slug string
+    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(panelist_id)
 
-    assert not slug, f"Panelist slug for ID {id} was found"
+    assert not slug, f"Panelist slug for ID {panelist_id} was found"
 
 
-@pytest.mark.parametrize("slug", ["faith-salie"])
-def test_panelist_utility_convert_slug_to_id(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["faith-salie"])
+def test_panelist_utility_convert_slug_to_id(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`
 
-    :param slug: Panelist slug string to test converting into panelist
-        ID
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test converting into
+        panelist ID
+    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(panelist_slug)
 
-    assert id, f"Panelist ID for slug {slug} was not found"
-    assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+    assert id_, f"Panelist ID for slug {panelist_slug} was not found"
+    assert isinstance(id_, int), f"Invalid value returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("slug", ["faith-sale"])
-def test_panelist_utility_convert_invalid_slug_to_id(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["faith-sale"])
+def test_panelist_utility_convert_invalid_slug_to_id(panelist_slug: str):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`
 
-    :param slug: Panelist slug string to test failing to convert into
-        panelist ID
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test failing to
+        convert into panelist ID
+    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(panelist_slug)
 
-    assert not id, f"Panelist ID for slug {slug} was found"
+    assert not id_, f"Panelist ID for slug {panelist_slug} was found"
 
 
-@pytest.mark.parametrize("id", [14])
-def test_panelist_utility_id_exists(id: int):
+@pytest.mark.parametrize("panelist_id", [14])
+def test_panelist_utility_id_exists(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
 
-    :param id: Panelist ID to test if a panelist exists
-    :type id: int
+    :param panelist_id: Panelist ID to test if a panelist exists
+    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(panelist_id)
 
-    assert result, f"Panelist ID {id} does not exist"
+    assert result, f"Panelist ID {panelist_id} does not exist"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_panelist_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("panelist_id", [-1])
+def test_panelist_utility_id_not_exists(panelist_id: int):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
 
-    :param id: Panelist ID to test if a panelist does not exist
-    :type id: int
+    :param panelist_id: Panelist ID to test if a panelist does not exist
+    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(panelist_id)
 
-    assert not result, f"Panelist ID {id} exists"
+    assert not result, f"Panelist ID {panelist_id} exists"
 
 
-@pytest.mark.parametrize("slug", ["faith-salie"])
-def test_panelist_utility_slug_exists(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["faith-salie"])
+def test_panelist_utility_slug_exists(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`
 
-    :param slug: Panelist slug string to test if a panelist exists
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test if a panelist
+        exists
+    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(panelist_slug)
 
-    assert result, f"Panelist slug {slug} does not exist"
+    assert result, f"Panelist slug {panelist_slug} does not exist"
 
 
-@pytest.mark.parametrize("slug", ["faith-sale"])
-def test_panelist_utility_slug_not_exists(slug: str):
+@pytest.mark.parametrize("panelist_slug", ["faith-sale"])
+def test_panelist_utility_slug_not_exists(panelist_slug: str):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`
 
-    :param slug: Panelist slug string to test if a panelist does not
-        exist
-    :type slug: str
+    :param panelist_slug: Panelist slug string to test if a panelist
+        does not exist
+    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(panelist_slug)
 
-    assert not result, f"Panelist slug {slug} exists"
+    assert not result, f"Panelist slug {panelist_slug} exists"

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperAppearances`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.scorekeeper import ScorekeeperAppearances
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -20,6 +21,7 @@ def get_connect_dict() -> Dict[str, Any]:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
+
 
 @pytest.mark.parametrize("id", [13])
 def test_scorekeeper_appearance_retrieve_appearances_by_id(id: int):
@@ -34,6 +36,7 @@ def test_scorekeeper_appearance_retrieve_appearances_by_id(id: int):
 
     assert "count" in appearance, f"'count' was not returned for ID {id}"
     assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("slug", ["chioke-i-anson"])
 def test_scorekeeper_appearance_retrieve_appearances_by_slug(slug: str):

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -23,31 +23,31 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [13])
-def test_scorekeeper_appearance_retrieve_appearances_by_id(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [13])
+def test_scorekeeper_appearance_retrieve_appearances_by_id(scorekeeper_id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_id`
 
-    :param id: Scorekeeper ID to test retrieving scorekeeper
+    :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         appearances
-    :type id: int
+    :type scorekeeper_id: int
     """
     appearances = ScorekeeperAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(id)
+    appearance = appearances.retrieve_appearances_by_id(scorekeeper_id)
 
-    assert "count" in appearance, f"'count' was not returned for ID {id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {id}"
+    assert "count" in appearance, f"'count' was not returned for ID {scorekeeper_id}"
+    assert "shows" in appearance, f"'shows' was not returned for ID {scorekeeper_id}"
 
 
-@pytest.mark.parametrize("slug", ["chioke-i-anson"])
-def test_scorekeeper_appearance_retrieve_appearances_by_slug(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
+def test_scorekeeper_appearance_retrieve_appearances_by_slug(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_slug`
 
-    :param slug: Scorekeeper slug string to test retrieving scorekeeper
-        appearances
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test retrieving
+        scorekeeper appearances
+    :type scorekeeper_slug: str
     """
     appearances = ScorekeeperAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(slug)
+    appearance = appearances.retrieve_appearances_by_slug(scorekeeper_slug)
 
-    assert "count" in appearance, f"'count' was not returned for slug {slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {slug}"
+    assert "count" in appearance, f"'count' was not returned for slug {scorekeeper_slug}"
+    assert "shows" in appearance, f"'shows' was not returned for slug {scorekeeper_slug}"

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -63,61 +63,63 @@ def test_scorekeeper_retrieve_all_slugs():
     assert slugs, "No scorekeeper slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("id", [13])
-def test_scorekeeper_retrieve_by_id(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [13])
+def test_scorekeeper_retrieve_by_id(scorekeeper_id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_id`
 
-    :param id: Scorekeeper ID to test retrieving scorekeeper information
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
+        information
+    :type scorekeeper_id: int
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
-    info = scorekeeper.retrieve_by_id(id)
+    info = scorekeeper.retrieve_by_id(scorekeeper_id)
 
-    assert info, f"Scorekeeper ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
+    assert info, f"Scorekeeper ID {scorekeeper_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {scorekeeper_id}"
 
 
-@pytest.mark.parametrize("id", [13])
-def test_scorekeeper_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [13])
+def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_id`
 
-    :param id: Scorekeeper ID to test retrieving scorekeeper details
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
+        details
+    :type scorekeeper_id: int
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
-    info = scorekeeper.retrieve_details_by_id(id)
+    info = scorekeeper.retrieve_details_by_id(scorekeeper_id)
 
-    assert info, f"Scorekeeper ID {id} not found"
-    assert "name" in info, f"'name' was not returned for ID {id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {id}"
+    assert info, f"Scorekeeper ID {scorekeeper_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {scorekeeper_id}"
+    assert "appearances" in info, f"'appearances' was not returned for ID {scorekeeper_id}"
 
 
-@pytest.mark.parametrize("slug", ["chioke-i-anson"])
-def test_scorekeeper_retrieve_by_slug(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
+def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_slug`
 
-    :param slug: Scorekeeper slug string to test retrieving scorekeeper
-        information
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test retrieving
+        scorekeeper information
+    :type scorekeeper_slug: str
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
-    info = scorekeeper.retrieve_by_slug(slug)
+    info = scorekeeper.retrieve_by_slug(scorekeeper_slug)
 
-    assert info, f"Scorekeeper slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
+    assert info, f"Scorekeeper slug {scorekeeper_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {scorekeeper_slug}"
 
 
-@pytest.mark.parametrize("slug", ["chioke-i-anson"])
-def test_scorekeeper_retrieve_details_by_slug(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
+def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_slug`
 
-    :param slug: Scorekeeper slug string to test retrieving scorekeeper
-        details
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test retrieving
+        scorekeeper details
+    :type scorekeeper_slug: str
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
-    info = scorekeeper.retrieve_details_by_slug(slug)
+    info = scorekeeper.retrieve_details_by_slug(scorekeeper_slug)
 
-    assert info, f"Scorekeeper slug {slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {slug}"
-    assert "appearances" in info, f"'appearances' was not returned for slug {slug}"
+    assert info, f"Scorekeeper slug {scorekeeper_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {scorekeeper_slug}"
+    assert "appearances" in info, f"'appearances' was not returned for slug {scorekeeper_slug}"

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.scorekeeper.Scorekeeper`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.scorekeeper import Scorekeeper
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -21,6 +22,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_scorekeeper_retrieve_all():
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all`
     """
@@ -29,6 +31,7 @@ def test_scorekeeper_retrieve_all():
 
     assert scorekeepers, "No scorekeepers could be retrieved"
     assert "id" in scorekeepers[0], "'id' was not returned for the first list item"
+
 
 def test_scorekeeper_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_details`
@@ -41,6 +44,7 @@ def test_scorekeeper_retrieve_all_details():
     assert "appearances" in scorekeepers[0], ("'appearances' was not returned "
                                               "for the first list item")
 
+
 def test_scorekeeper_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_ids`
     """
@@ -49,6 +53,7 @@ def test_scorekeeper_retrieve_all_ids():
 
     assert ids, "No scorekeeper IDs could be retrieved"
 
+
 def test_scorekeeper_retrieve_all_slugs():
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_slugs`
     """
@@ -56,6 +61,7 @@ def test_scorekeeper_retrieve_all_slugs():
     slugs = scorekeeper.retrieve_all_slugs()
 
     assert slugs, "No scorekeeper slug strings could be retrieved"
+
 
 @pytest.mark.parametrize("id", [13])
 def test_scorekeeper_retrieve_by_id(id: int):
@@ -69,6 +75,7 @@ def test_scorekeeper_retrieve_by_id(id: int):
 
     assert info, f"Scorekeeper ID {id} not found"
     assert "name" in info, f"'name' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("id", [13])
 def test_scorekeeper_retrieve_details_by_id(id: int):
@@ -84,6 +91,7 @@ def test_scorekeeper_retrieve_details_by_id(id: int):
     assert "name" in info, f"'name' was not returned for ID {id}"
     assert "appearances" in info, f"'appearances' was not returned for ID {id}"
 
+
 @pytest.mark.parametrize("slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_by_slug(slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_slug`
@@ -97,6 +105,7 @@ def test_scorekeeper_retrieve_by_slug(slug: str):
 
     assert info, f"Scorekeeper slug {slug} not found"
     assert "name" in info, f"'name' was not returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_details_by_slug(slug: str):

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.scorekeeper import ScorekeeperUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -20,6 +21,7 @@ def get_connect_dict() -> Dict[str, Any]:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
+
 
 @pytest.mark.parametrize("id", [2])
 def test_scorekeeper_utility_convert_id_to_slug(id: int):
@@ -35,6 +37,7 @@ def test_scorekeeper_utility_convert_id_to_slug(id: int):
     assert slug, f"Scorekeeper slug for ID {id} was not found"
     assert isinstance(slug, str), f"Invalid value returned for ID {id}"
 
+
 @pytest.mark.parametrize("id", [-1])
 def test_scorekeeper_utility_convert_invalid_id_to_slug(id: int):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`
@@ -48,6 +51,7 @@ def test_scorekeeper_utility_convert_invalid_id_to_slug(id: int):
 
     assert not slug, f"Scorekeeper slug for ID {id} was found"
 
+
 @pytest.mark.parametrize("slug", ["korva-coleman"])
 def test_scorekeeper_utility_convert_slug_to_id(slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`
@@ -59,8 +63,9 @@ def test_scorekeeper_utility_convert_slug_to_id(slug: str):
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     id = utility.convert_slug_to_id(slug)
 
-    assert slug, f"Scorekeeper ID for slug {slug} was found"
-    assert isinstance(slug, str), f"Invalid value returned for slug {slug}"
+    assert id, f"Scorekeeper ID for slug {slug} was found"
+    assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+
 
 @pytest.mark.parametrize("slug", ["corva-coleman"])
 def test_scorekeeper_utility_convert_invalid_slug_to_id(slug: str):
@@ -75,6 +80,7 @@ def test_scorekeeper_utility_convert_invalid_slug_to_id(slug: str):
 
     assert not slug, f"Scorekeeper ID for slug {slug} was not found"
 
+
 @pytest.mark.parametrize("id", [2])
 def test_scorekeeper_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`
@@ -86,6 +92,7 @@ def test_scorekeeper_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Scorekeeper ID {id} does not exist"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_scorekeeper_utility_id_not_exists(id: int):
@@ -99,6 +106,7 @@ def test_scorekeeper_utility_id_not_exists(id: int):
 
     assert not result, f"Scorekeeper ID {id} exists"
 
+
 @pytest.mark.parametrize("slug", ["korva-coleman"])
 def test_scorekeeper_utility_slug_exists(slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
@@ -110,6 +118,7 @@ def test_scorekeeper_utility_slug_exists(slug: str):
     result = utility.slug_exists(slug)
 
     assert result, f"Scorekeeper slug {slug} does not exist"
+
 
 @pytest.mark.parametrize("slug", ["corva-coleman"])
 def test_scorekeeper_utility_slug_not_exists(slug: str):

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -23,112 +23,116 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [2])
-def test_scorekeeper_utility_convert_id_to_slug(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [2])
+def test_scorekeeper_utility_convert_id_to_slug(scorekeeper_id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`
 
-    :param id: Scorekeeper ID to test converting into scorekeeper slug
-        string
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test converting into
+        scorekeeper slug string
+    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(scorekeeper_id)
 
-    assert slug, f"Scorekeeper slug for ID {id} was not found"
-    assert isinstance(slug, str), f"Invalid value returned for ID {id}"
+    assert slug, f"Scorekeeper slug for ID {scorekeeper_id} was not found"
+    assert isinstance(slug, str), f"Invalid value returned for ID {scorekeeper_id}"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_scorekeeper_utility_convert_invalid_id_to_slug(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [-1])
+def test_scorekeeper_utility_convert_invalid_id_to_slug(scorekeeper_id: int):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`
 
-    :param id: Scorekeeper ID to test failing to convert into
-        scorekeeper slug string
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test failing to convert
+        into scorekeeper slug string
+    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_id_to_slug(id)
+    slug = utility.convert_id_to_slug(scorekeeper_id)
 
-    assert not slug, f"Scorekeeper slug for ID {id} was found"
+    assert not slug, f"Scorekeeper slug for ID {scorekeeper_id} was found"
 
 
-@pytest.mark.parametrize("slug", ["korva-coleman"])
-def test_scorekeeper_utility_convert_slug_to_id(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["korva-coleman"])
+def test_scorekeeper_utility_convert_slug_to_id(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`
 
-    :param slug: Scorekeeper slug string to test converting into
-        scorekeeper ID
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test converting
+        into scorekeeper ID
+    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    id = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(scorekeeper_slug)
 
-    assert id, f"Scorekeeper ID for slug {slug} was found"
-    assert isinstance(id, int), f"Invalid value returned for slug {slug}"
+    assert id_, f"Scorekeeper ID for slug {scorekeeper_slug} was found"
+    assert isinstance(id_, int), f"Invalid value returned for slug {scorekeeper_slug}"
 
 
-@pytest.mark.parametrize("slug", ["corva-coleman"])
-def test_scorekeeper_utility_convert_invalid_slug_to_id(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["corva-coleman"])
+def test_scorekeeper_utility_convert_invalid_slug_to_id(scorekeeper_slug: str):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`
 
-    :param slug: Scorekeeper slug string to test failing to convert
-        into scorekeeper ID
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test failing to
+        convert into scorekeeper ID
+    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    slug = utility.convert_slug_to_id(slug)
+    id_ = utility.convert_slug_to_id(scorekeeper_slug)
 
-    assert not slug, f"Scorekeeper ID for slug {slug} was not found"
+    assert not id_, f"Scorekeeper ID for slug {scorekeeper_slug} was not found"
 
 
-@pytest.mark.parametrize("id", [2])
-def test_scorekeeper_utility_id_exists(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [2])
+def test_scorekeeper_utility_id_exists(scorekeeper_id: int):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`
 
-    :param id: Scorekeeper ID to test if a scorekeeper exists
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper
+        exists
+    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(scorekeeper_id)
 
-    assert result, f"Scorekeeper ID {id} does not exist"
+    assert result, f"Scorekeeper ID {scorekeeper_id} does not exist"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_scorekeeper_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("scorekeeper_id", [-1])
+def test_scorekeeper_utility_id_not_exists(scorekeeper_id: int):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`
 
-    :param id: Scorekeeper ID to test if a scorekeeper does not exist
-    :type id: int
+    :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper does
+        not exist
+    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(scorekeeper_id)
 
-    assert not result, f"Scorekeeper ID {id} exists"
+    assert not result, f"Scorekeeper ID {scorekeeper_id} exists"
 
 
-@pytest.mark.parametrize("slug", ["korva-coleman"])
-def test_scorekeeper_utility_slug_exists(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["korva-coleman"])
+def test_scorekeeper_utility_slug_exists(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
 
-    :param slug: Scorekeeper slug string to test if a scorekeeper exists
-    :type slug: str
+    :param scorekeeper_slug: Scorekeeper slug string to test if a
+        scorekeeper exists
+    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(scorekeeper_slug)
 
-    assert result, f"Scorekeeper slug {slug} does not exist"
+    assert result, f"Scorekeeper slug {scorekeeper_slug} does not exist"
 
 
-@pytest.mark.parametrize("slug", ["corva-coleman"])
-def test_scorekeeper_utility_slug_not_exists(slug: str):
+@pytest.mark.parametrize("scorekeeper_slug", ["corva-coleman"])
+def test_scorekeeper_utility_slug_not_exists(scorekeeper_slug: str):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
 
-    :param slug: Scorekeeper slug string to test if a scorekeeper does
+    :param scorekeeper_slug: Scorekeeper slug string to test if a
+        scorekeeper does
         not exist
-    :type slug: str
+    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
-    result = utility.slug_exists(slug)
+    result = utility.slug_exists(scorekeeper_slug)
 
-    assert not result, f"Scorekeeper slug {slug} exists"
+    assert not result, f"Scorekeeper slug {scorekeeper_slug} exists"

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -23,71 +23,71 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_info_retrieve_bluff_info_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_bluff_info_by_id`
 
-    :param id: Show ID to test retrieving show Bluff the Listener
+    :param show_id: Show ID to test retrieving show Bluff the Listener
         information
-    :type id: int
+    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    bluff = info.retrieve_bluff_info_by_id(id)
+    bluff = info.retrieve_bluff_info_by_id(show_id)
 
-    assert bluff, (f"Bluff the Listener information for show ID {id} could "
+    assert bluff, (f"Bluff the Listener information for show ID {show_id} could "
                    f"not be retrieved")
     assert "chosen_panelist" in bluff, (f"'chosen_panelist' was not returned with "
-                                        f"panelist information for show ID {id}")
+                                        f"panelist information for show ID {show_id}")
     assert "correct_panelist" in bluff, (f"'correct_panelist' was not returned with "
-                                         f"panelist information for show ID {id}")
+                                         f"panelist information for show ID {show_id}")
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_info_retrieve_core_info_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_info_retrieve_core_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
 
-    :param id: Show ID to test retrieving show core information
-    :type id: int
+    :param show_id: Show ID to test retrieving show core information
+    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    core = info.retrieve_core_info_by_id(id)
+    core = info.retrieve_core_info_by_id(show_id)
 
-    assert core, f"Core information for show ID {id} could not be retrieved"
+    assert core, f"Core information for show ID {show_id} could not be retrieved"
     assert "id" in core, (f"'id' was not returned with core information for "
-                          f"show ID {id}")
+                          f"show ID {show_id}")
     assert "description" in core, (f"'description' was not returned with show "
-                                   f"information for show ID {id}")
+                                   f"information for show ID {show_id}")
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_info_retrieve_guest_info_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_info_retrieve_guest_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_guest_info_by_id`
 
-    :param id: Show ID to test retrieving show guest information
-    :type id: int
+    :param show_id: Show ID to test retrieving show guest information
+    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    guests = info.retrieve_guest_info_by_id(id)
+    guests = info.retrieve_guest_info_by_id(show_id)
 
-    assert guests, f"Guest information for show ID {id} could not be retrieved"
+    assert guests, f"Guest information for show ID {show_id} could not be retrieved"
     assert "id" in guests[0], (f"'id' was not returned for the first list item "
-                               f"for show ID {id}")
+                               f"for show ID {show_id}")
     assert "score" in guests[0], (f"'score' was not returned for the first list "
-                                  f"item for show ID {id}")
+                                  f"item for show ID {show_id}")
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_info_retrieve_panelist_info_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_info_retrieve_panelist_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
 
-    :param id: Show ID to test retrieving show panelist information
-    :type id: int
+    :param show_id: Show ID to test retrieving show panelist information
+    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    panelists = info.retrieve_panelist_info_by_id(id)
+    panelists = info.retrieve_panelist_info_by_id(show_id)
 
-    assert panelists, f"Guest information for show ID {id} could not be retrieved"
+    assert panelists, f"Guest information for show ID {show_id} could not be retrieved"
     assert "id" in panelists[0], (f"'id' was not returned for the first list "
-                                  f"item for show ID {id}")
+                                  f"item for show ID {show_id}")
     assert "score" in panelists[0], (f"'score' was not returned for the first "
-                                     f"list item for show ID {id}")
+                                     f"list item for show ID {show_id}")

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object :py:class:`wwdtm.show.ShowInfo`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.show import ShowInfo
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -20,6 +21,7 @@ def get_connect_dict() -> Dict[str, Any]:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
+
 
 @pytest.mark.parametrize("id", [1162])
 def test_show_info_retrieve_bluff_info_by_id(id: int):
@@ -39,6 +41,7 @@ def test_show_info_retrieve_bluff_info_by_id(id: int):
     assert "correct_panelist" in bluff, (f"'correct_panelist' was not returned with "
                                          f"panelist information for show ID {id}")
 
+
 @pytest.mark.parametrize("id", [1162])
 def test_show_info_retrieve_core_info_by_id(id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
@@ -55,6 +58,7 @@ def test_show_info_retrieve_core_info_by_id(id: int):
     assert "description" in core, (f"'description' was not returned with show "
                                    f"information for show ID {id}")
 
+
 @pytest.mark.parametrize("id", [1162])
 def test_show_info_retrieve_guest_info_by_id(id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_guest_info_by_id`
@@ -70,6 +74,7 @@ def test_show_info_retrieve_guest_info_by_id(id: int):
                                f"for show ID {id}")
     assert "score" in guests[0], (f"'score' was not returned for the first list "
                                   f"item for show ID {id}")
+
 
 @pytest.mark.parametrize("id", [1162])
 def test_show_info_retrieve_panelist_info_by_id(id: int):

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object :py:class:`wwdtm.show.Show`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.show import Show
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -21,6 +22,7 @@ def get_connect_dict() -> Dict[str, Any]:
         if "database" in config_dict:
             return config_dict["database"]
 
+
 def test_show_retrieve_all():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all`
     """
@@ -29,6 +31,7 @@ def test_show_retrieve_all():
 
     assert shows, "No shows could be retrieved"
     assert "id" in shows[0], "No Show ID returned for the first list item"
+
 
 def test_show_retrieve_all_details():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`
@@ -40,6 +43,7 @@ def test_show_retrieve_all_details():
     assert "date" in shows[0], "'date' was not returned for the first list item"
     assert "host" in shows[0], "'host' was not returned for first list item"
 
+
 def test_show_retrieve_all_ids():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_ids`
     """
@@ -48,6 +52,7 @@ def test_show_retrieve_all_ids():
 
     assert ids, "No show IDs could be retrieved"
 
+
 def test_show_retrieve_all_dates():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates`
     """
@@ -55,6 +60,7 @@ def test_show_retrieve_all_dates():
     dates = show.retrieve_all_dates()
 
     assert dates, "No show dates could be retrieved"
+
 
 def test_show_retrieve_all_dates_tuple():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates_tuple`
@@ -65,6 +71,7 @@ def test_show_retrieve_all_dates_tuple():
     assert dates, "No show dates could be retrieved"
     assert isinstance(dates[0], tuple), "First list item is not a tuple"
 
+
 def test_show_retrieve_all_show_years_months():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_show_years_months`
     """
@@ -74,6 +81,7 @@ def test_show_retrieve_all_show_years_months():
     assert dates, "No dates could be retrieved"
     assert isinstance(dates[0], str), "First list item is not a string"
 
+
 def test_show_retrieve_all_show_years_months_tuple():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_shows_years_months_tuple`
     """
@@ -82,6 +90,7 @@ def test_show_retrieve_all_show_years_months_tuple():
 
     assert dates, "No dates could be retrieved"
     assert isinstance(dates[0], tuple), "First list item is not a tuple"
+
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
 def test_show_retrieve_by_date(year: int, month: int, day: int):
@@ -103,6 +112,7 @@ def test_show_retrieve_by_date(year: int, month: int, day: int):
     assert "date" in info, (f"'date' was not returned for show "
                             f"{year:04d}-{month:02d}-{day:02d}")
 
+
 @pytest.mark.parametrize("date", ["2018-10-27"])
 def test_show_retrieve_by_date_string(date: str):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date_string`
@@ -117,6 +127,7 @@ def test_show_retrieve_by_date_string(date: str):
     assert info, f"Show for date {date} not found"
     assert "date" in info, f"'date' was not returned for show {date}"
 
+
 @pytest.mark.parametrize("id", [1162])
 def test_show_retrieve_by_id(id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_id`
@@ -129,6 +140,7 @@ def test_show_retrieve_by_id(id: int):
 
     assert info, f"Show ID {id} not found"
     assert "date" in info, f"'date' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_by_year(year: int):
@@ -143,6 +155,7 @@ def test_show_retrieve_by_year(year: int):
     assert shows, f"No shows could be retrieved for year {year:04d}"
     assert "id" in shows[0], (f"'id' was not returned for the first list item "
                               f"for year {year:04d}")
+
 
 @pytest.mark.parametrize("year, month", [(1998, 1), (2018, 10)])
 def test_show_retrieve_by_year_month(year: int, month: int):
@@ -161,6 +174,7 @@ def test_show_retrieve_by_year_month(year: int, month: int):
                    f"{year:04d}-{month:02d}")
     assert "id" in shows[0], (f"'id' was not returned for the first list "
                               f"item for year/month {year:02d}-{month:04d}")
+
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
 def test_show_retrieve_details_by_date(year: int, month: int, day: int):
@@ -182,6 +196,7 @@ def test_show_retrieve_details_by_date(year: int, month: int, day: int):
     assert "host" in info, (f"'host' was not returned for show "
                             f"{year:04d}-{month:02d}-{day:02d}")
 
+
 @pytest.mark.parametrize("date", ["2018-10-27"])
 def test_show_retrieve_details_by_date_string(date: str):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`
@@ -197,6 +212,7 @@ def test_show_retrieve_details_by_date_string(date: str):
     assert "date" in info, f"'date' was not returned for show {date}"
     assert "host" in info, f"'host' was not returned for show {date}"
 
+
 @pytest.mark.parametrize("id", [1162, 1246])
 def test_show_retrieve_details_by_id(id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
@@ -210,6 +226,7 @@ def test_show_retrieve_details_by_id(id: int):
     assert info, f"Show ID {id} not found"
     assert "date" in info, f"'date' was not returned for ID {id}"
     assert "host" in info, f"'host' was not returned for ID {id}"
+
 
 @pytest.mark.parametrize("year", [2021])
 def test_show_retrieve_details_by_year(year: int):
@@ -226,6 +243,7 @@ def test_show_retrieve_details_by_year(year: int):
                                f"item for year {year:04d}")
     assert "host" in info[0], (f"'host' was not returned for first list "
                                f"item for year {year:04d}")
+
 
 @pytest.mark.parametrize("year, month", [(2020, 4)])
 def test_show_retrieve_details_by_year_month(year: int, month: int):
@@ -246,6 +264,7 @@ def test_show_retrieve_details_by_year_month(year: int, month: int):
     assert "host" in info[0], (f"'host' was not returned for first list item "
                                f"for year/month {year:04d}-{month:02d}")
 
+
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_months_by_year(year: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_months_by_year`
@@ -258,6 +277,7 @@ def test_show_retrieve_months_by_year(year: int):
 
     assert months, f"No months could be retrieved for year {year:04d}"
 
+
 def test_show_retrieve_recent():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent`
     """
@@ -266,6 +286,7 @@ def test_show_retrieve_recent():
 
     assert shows, "No shows could be retrieved"
     assert "id" in shows[0], "No Show ID returned for the first list item"
+
 
 def test_show_retrieve_recent_details():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`
@@ -276,6 +297,7 @@ def test_show_retrieve_recent_details():
     assert shows, "No shows could be retrieved"
     assert "date" in shows[0], "'date' was not returned for the first list item"
     assert "host" in shows[0], "'host' was not returned for first list item"
+
 
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_scores_by_year(year: int):
@@ -290,6 +312,7 @@ def test_show_retrieve_scores_by_year(year: int):
 
     assert scores, f"No scores could be retrieved by year {year:04d}"
     assert isinstance(scores[0], tuple), "First list item is not a tuple"
+
 
 def test_show_retrieve_years():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_years`

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -128,18 +128,18 @@ def test_show_retrieve_by_date_string(date: str):
     assert "date" in info, f"'date' was not returned for show {date}"
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_retrieve_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_retrieve_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_id`
 
-    :param id: Show ID to test retrieving show information
-    :type id: int
+    :param show_id: Show ID to test retrieving show information
+    :type show_id: int
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_by_id(id)
+    info = show.retrieve_by_id(show_id)
 
-    assert info, f"Show ID {id} not found"
-    assert "date" in info, f"'date' was not returned for ID {id}"
+    assert info, f"Show ID {show_id} not found"
+    assert "date" in info, f"'date' was not returned for ID {show_id}"
 
 
 @pytest.mark.parametrize("year", [2018])
@@ -213,19 +213,19 @@ def test_show_retrieve_details_by_date_string(date: str):
     assert "host" in info, f"'host' was not returned for show {date}"
 
 
-@pytest.mark.parametrize("id", [1162, 1246])
-def test_show_retrieve_details_by_id(id: int):
+@pytest.mark.parametrize("show_id", [1162, 1246])
+def test_show_retrieve_details_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
 
-    :param id: Show ID to test retrieving show details
-    :type id: int
+    :param show_id: Show ID to test retrieving show details
+    :type show_id: int
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_id(id)
+    info = show.retrieve_details_by_id(show_id)
 
-    assert info, f"Show ID {id} not found"
-    assert "date" in info, f"'date' was not returned for ID {id}"
-    assert "host" in info, f"'host' was not returned for ID {id}"
+    assert info, f"Show ID {show_id} not found"
+    assert "date" in info, f"'date' was not returned for ID {show_id}"
+    assert "host" in info, f"'host' was not returned for ID {show_id}"
 
 
 @pytest.mark.parametrize("year", [2021])

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -37,11 +37,11 @@ def test_show_utility_convert_date_to_id(year: int,
     :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    id = utility.convert_date_to_id(year, month, day)
+    id_ = utility.convert_date_to_id(year, month, day)
 
-    assert id, f"Show ID for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert isinstance(id, int), (f"Invalid value returned for date "
-                                 f"{year:04d}-{month:02d}-{day:02d}")
+    assert id_, f"Show ID for date {year:04d}-{month:02d}-{day:02d} not found"
+    assert isinstance(id_, int), (f"Invalid value returned for date "
+                                  f"{year:04d}-{month:02d}-{day:02d}")
 
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 26)])
@@ -60,36 +60,36 @@ def test_show_utility_convert_invalid_date_to_id(year: int,
     :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    id = utility.convert_date_to_id(year, month, day)
+    id_ = utility.convert_date_to_id(year, month, day)
 
-    assert not id, f"Show ID for date {year:04d}-{month:02d}-{day:02d} was found"
+    assert not id_, f"Show ID for date {year:04d}-{month:02d}-{day:02d} was found"
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_utility_convert_id_to_date(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_utility_convert_id_to_date(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
 
-    :param id: Show ID to test converting into show date
-    :type id: int
+    :param show_id: Show ID to test converting into show date
+    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    date = utility.convert_id_to_date(id)
+    date = utility.convert_id_to_date(show_id)
 
-    assert date, f"Show date for ID {id} was not found"
-    assert isinstance(date, str), f"Invalid value returned for ID {date}"
+    assert date, f"Show date for ID {show_id} was not found"
+    assert isinstance(date, str), f"Invalid value returned for ID {show_id}"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_show_utility_convert_invalid_id_to_date(id: int):
+@pytest.mark.parametrize("show_id", [-1])
+def test_show_utility_convert_invalid_id_to_date(show_id: int):
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
 
-    :param id: Show ID to test failing to convert into show date
-    :type id: int
+    :param show_id: Show ID to test failing to convert into show date
+    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    date = utility.convert_id_to_date(id)
+    date = utility.convert_id_to_date(show_id)
 
-    assert not date, f"Show date for ID {id} was found"
+    assert not date, f"Show date for ID {show_id} was found"
 
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
@@ -131,27 +131,27 @@ def test_show_utility_date_not_exists(year: int,
     assert not result, f"Show date {year:04d}-{month:02d}-{day:02d} was found"
 
 
-@pytest.mark.parametrize("id", [1162])
-def test_show_utility_id_exists(id: int):
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_utility_id_exists(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
 
-    :param id: Show ID to test if a show exists
-    :type id: int
+    :param show_id: Show ID to test if a show exists
+    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(show_id)
 
-    assert result, f"Show ID {id} was not found"
+    assert result, f"Show ID {show_id} was not found"
 
 
-@pytest.mark.parametrize("id", [-1])
-def test_show_utility_id_not_exists(id: int):
+@pytest.mark.parametrize("show_id", [-1])
+def test_show_utility_id_not_exists(show_id: int):
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
 
-    :param id: Show ID to test if a show does not exist
-    :type id: int
+    :param show_id: Show ID to test if a show does not exist
+    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
-    result = utility.id_exists(id)
+    result = utility.id_exists(show_id)
 
-    assert not result, f"Show ID {id} was found"
+    assert not result, f"Show ID {show_id} was found"

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Testing for object :py:class:`wwdtm.show.ShowUtility`
 """
 import json
@@ -10,6 +10,7 @@ from typing import Any, Dict
 
 import pytest
 from wwdtm.show import ShowUtility
+
 
 @pytest.mark.skip
 def get_connect_dict() -> Dict[str, Any]:
@@ -20,6 +21,7 @@ def get_connect_dict() -> Dict[str, Any]:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
+
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
 def test_show_utility_convert_date_to_id(year: int,
@@ -41,6 +43,7 @@ def test_show_utility_convert_date_to_id(year: int,
     assert isinstance(id, int), (f"Invalid value returned for date "
                                  f"{year:04d}-{month:02d}-{day:02d}")
 
+
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 26)])
 def test_show_utility_convert_invalid_date_to_id(year: int,
                                                  month: int,
@@ -61,6 +64,7 @@ def test_show_utility_convert_invalid_date_to_id(year: int,
 
     assert not id, f"Show ID for date {year:04d}-{month:02d}-{day:02d} was found"
 
+
 @pytest.mark.parametrize("id", [1162])
 def test_show_utility_convert_id_to_date(id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
@@ -74,6 +78,7 @@ def test_show_utility_convert_id_to_date(id: int):
     assert date, f"Show date for ID {id} was not found"
     assert isinstance(date, str), f"Invalid value returned for ID {date}"
 
+
 @pytest.mark.parametrize("id", [-1])
 def test_show_utility_convert_invalid_id_to_date(id: int):
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
@@ -85,6 +90,7 @@ def test_show_utility_convert_invalid_id_to_date(id: int):
     date = utility.convert_id_to_date(id)
 
     assert not date, f"Show date for ID {id} was found"
+
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
 def test_show_utility_date_exists(year: int,
@@ -103,6 +109,7 @@ def test_show_utility_date_exists(year: int,
     result = utility.date_exists(year, month, day)
 
     assert result, f"Show date {year:04d}-{month:02d}-{day:02d} was not found"
+
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 24)])
 def test_show_utility_date_not_exists(year: int,
@@ -123,6 +130,7 @@ def test_show_utility_date_not_exists(year: int,
 
     assert not result, f"Show date {year:04d}-{month:02d}-{day:02d} was found"
 
+
 @pytest.mark.parametrize("id", [1162])
 def test_show_utility_id_exists(id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
@@ -134,6 +142,7 @@ def test_show_utility_id_exists(id: int):
     result = utility.id_exists(id)
 
     assert result, f"Show ID {id} was not found"
+
 
 @pytest.mark.parametrize("id", [-1])
 def test_show_utility_id_not_exists(id: int):

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -5,6 +5,8 @@
 # wwdtm is released under the terms of the Apache License 2.0
 """Explicitly listing all modules in this package"""
 
+from wwdtm import validation
+
 from wwdtm.guest import (Guest,
                          GuestAppearances,
                          GuestUtility)

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Explicitly listing all modules in this package"""
 
 from wwdtm.guest import (Guest,

--- a/wwdtm/guest/__init__.py
+++ b/wwdtm/guest/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Guest module
 """
 from wwdtm.guest.appearances import GuestAppearances

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Guest Appearance Retrieval Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.guest.utility import GuestUtility
+
 
 class GuestAppearances:
     """This class contains functions that retrieve guest appearance
@@ -65,7 +66,7 @@ class GuestAppearances:
                  "SELECT COUNT(gm.showid) FROM ww_showguestmap gm "
                  "JOIN ww_shows s ON s.showid = gm.showid "
                  "WHERE gm.guestid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id ,))
+        cursor.execute(query, (id, id, ))
         result = cursor.fetchone()
 
         if result:
@@ -122,8 +123,8 @@ class GuestAppearances:
         """Returns a list of dictionary objects containing appearance
         information for the requested guest slug string.
 
-        :param str: Guest slug string
-        :type str: slug
+        :param slug: Guest slug string
+        :type slug: str
         :return: Dictionary containing appearance counts and list of
             appearances for a guest. If guest appearances could not be
             retrieved, empty dictionary is returned.

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -41,19 +41,19 @@ class GuestAppearances:
         self.utility = GuestUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_appearances_by_id(self, guest_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested guest ID.
 
-        :param id: Guest ID
-        :type id: int
+        :param guest_id: Guest ID
+        :type guest_id: int
         :return: Dictionary containing appearance counts and list of
             appearances for a guest. If guest appearances could not be
             retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(guest_id)
         except ValueError:
             return {}
 
@@ -66,7 +66,7 @@ class GuestAppearances:
                  "SELECT COUNT(gm.showid) FROM ww_showguestmap gm "
                  "JOIN ww_shows s ON s.showid = gm.showid "
                  "WHERE gm.guestid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id, ))
+        cursor.execute(query, (id_, id_, ))
         result = cursor.fetchone()
 
         if result:
@@ -89,7 +89,7 @@ class GuestAppearances:
                  "JOIN ww_shows s ON s.showid = gm.showid "
                  "WHERE gm.guestid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -119,19 +119,19 @@ class GuestAppearances:
         return appearance_info
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_appearances_by_slug(self, guest_slug: str) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested guest slug string.
 
-        :param slug: Guest slug string
-        :type slug: str
+        :param guest_slug: Guest slug string
+        :type guest_slug: str
         :return: Dictionary containing appearance counts and list of
             appearances for a guest. If guest appearances could not be
             retrieved, empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(guest_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_appearances_by_id(id)
+        return self.retrieve_appearances_by_id(id_)

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -53,7 +53,7 @@ class GuestAppearances:
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
@@ -129,6 +129,6 @@ class GuestAppearances:
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_appearances_by_id(id)

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -47,7 +47,8 @@ class GuestAppearances:
         :param id: Guest ID
         :type id: int
         :return: Dictionary containing appearance counts and list of
-            appearances for a guest
+            appearances for a guest. If guest appearances could not be
+            retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
@@ -124,7 +125,8 @@ class GuestAppearances:
         :param str: Guest slug string
         :type str: slug
         :return: Dictionary containing appearance counts and list of
-            appearances for a guest
+            appearances for a guest. If guest appearances could not be
+            retrieved, empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.guest.utility import GuestUtility
+from wwdtm.validation import valid_int_id
 
 
 class GuestAppearances:
@@ -52,9 +53,7 @@ class GuestAppearances:
             retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(guest_id)
-        except ValueError:
+        if not valid_int_id(guest_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -66,7 +65,7 @@ class GuestAppearances:
                  "SELECT COUNT(gm.showid) FROM ww_showguestmap gm "
                  "JOIN ww_shows s ON s.showid = gm.showid "
                  "WHERE gm.guestid = %s ) AS all_shows;")
-        cursor.execute(query, (id_, id_, ))
+        cursor.execute(query, (guest_id, guest_id, ))
         result = cursor.fetchone()
 
         if result:
@@ -89,7 +88,7 @@ class GuestAppearances:
                  "JOIN ww_shows s ON s.showid = gm.showid "
                  "WHERE gm.guestid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (guest_id, ))
         results = cursor.fetchall()
         cursor.close()
 

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -100,7 +100,7 @@ class GuestAppearances:
                     "date": appearance["date"].isoformat(),
                     "best_of": bool(appearance["best_of"]),
                     "repeat_show": bool(appearance["repeatshowid"]),
-                    "score": appearance["score"],
+                    "score": appearance["score"] if appearance["score"] else None,
                     "score_exception": bool(appearance["score_exception"]),
                 }
                 appearances.append(info)

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Guest Data Retrieval Functions
 """
 from functools import lru_cache
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.guest.appearances import GuestAppearances
 from wwdtm.guest.utility import GuestUtility
+
 
 class Guest:
     """This class contains functions used to retrieve guest data from a
@@ -51,7 +52,7 @@ class Guest:
             is returned.
         :rtype: List[Dict[str, Any]]
         """
-        self.database_connection.is_connected
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT guestid AS id, guest, guestslug AS slug "
                  "FROM ww_guests "

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.guest.appearances import GuestAppearances
 from wwdtm.guest.utility import GuestUtility
+from wwdtm.validation import valid_int_id
 
 
 class Guest:
@@ -174,9 +175,7 @@ class Guest:
             returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(guest_id)
-        except ValueError:
+        if not valid_int_id(guest_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -184,7 +183,7 @@ class Guest:
                  "FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (guest_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -236,16 +235,14 @@ class Guest:
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(guest_id)
-        except ValueError:
+        if not valid_int_id(guest_id):
             return {}
 
-        info = self.retrieve_by_id(id_)
+        info = self.retrieve_by_id(guest_id)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(guest_id)
 
         return info
 

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -47,7 +47,7 @@ class Guest:
         name and slug string for all guests.
 
         :return: List of all guests and their corresponding
-            information. If no guests could be retrieved, an empty list
+            information. If guests could not be retrieved, an empty list
             is returned.
         :rtype: List[Dict[str, Any]]
         """
@@ -81,7 +81,7 @@ class Guest:
         name, slug string and appearance information for all guests.
 
         :return: List of all guests and their corresponding
-            information and appearances. If no guests could be
+            information and appearances. If guests could not be
             retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
@@ -115,7 +115,7 @@ class Guest:
         """Returns a list of all guest IDs from the database, sorted by
         guest name.
 
-        :return: List of all guest IDs. If no guest IDs could be
+        :return: List of all guest IDs. If guest IDs could not be
             retrieved, an emtpy list is returned.
         :rtype: List[int]
         """
@@ -140,8 +140,8 @@ class Guest:
         """Returns a list of all guest slug strings from the database,
         sorted by guest name.
 
-        :return: List of all guest slug strings. If no guest slugs could
-            be retrieved, an emtpy list is returned.
+        :return: List of all guest slug strings. If guest slug strings
+            could not be retrieved, an emtpy list is returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -168,8 +168,9 @@ class Guest:
 
         :param id: Guest ID
         :type id: int
-        :return: Dictionary containing guest information. If no guest
-            information is found, an empty dictionary is returned.
+        :return: Dictionary containing guest information. If guest
+            information could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
@@ -204,8 +205,9 @@ class Guest:
 
         :param slug: Guest slug string
         :type slug: str
-        :return: Dictionary containing guest information. If no guest
-            information is found, an empty dictionary is returned.
+        :return: Dictionary containing guest information. If guest
+            information could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
@@ -229,8 +231,8 @@ class Guest:
         :param id: Guest ID
         :type id: int
         :return: Dictionary containing guest information and their
-            appearances. If no guest information is found, an empty
-            dictionary is returned.
+            appearances. If guest information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
@@ -255,8 +257,8 @@ class Guest:
         :param slug: Guest slug string
         :type slug: str
         :return: Dictionary containing guest information and their
-            appearances. If no guest information is found, an empty
-            dictionary is returned.
+            appearances. If guest information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -163,19 +163,19 @@ class Guest:
         return ids
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, guest_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing guest ID, name and
         slug string for the requested guest ID.
 
-        :param id: Guest ID
-        :type id: int
+        :param guest_id: Guest ID
+        :type guest_id: int
         :return: Dictionary containing guest information. If guest
             information could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(guest_id)
         except ValueError:
             return {}
 
@@ -184,7 +184,7 @@ class Guest:
                  "FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -200,77 +200,77 @@ class Guest:
         return info
 
     @lru_cache(typed=True)
-    def retrieve_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_by_slug(self, guest_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing guest ID, name and
         slug string for the requested guest slug string.
 
-        :param slug: Guest slug string
-        :type slug: str
+        :param guest_slug: Guest slug string
+        :type guest_slug: str
         :return: Dictionary containing guest information. If guest
             information could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = guest_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, guest_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing guest ID, name, slug
         string and appearance information for the requested Guest ID.
 
-        :param id: Guest ID
-        :type id: int
+        :param guest_id: Guest ID
+        :type guest_id: int
         :return: Dictionary containing guest information and their
             appearances. If guest information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(guest_id)
         except ValueError:
             return {}
 
-        info = self.retrieve_by_id(id)
+        info = self.retrieve_by_id(id_)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
 
         return info
 
     @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_details_by_slug(self, guest_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing guest ID, name, slug
         string and appearance information for the requested Guest slug
         string.
 
-        :param slug: Guest slug string
-        :type slug: str
+        :param guest_slug: Guest slug string
+        :type guest_slug: str
         :return: Dictionary containing guest information and their
             appearances. If guest information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = guest_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -47,7 +47,8 @@ class Guest:
         name and slug string for all guests.
 
         :return: List of all guests and their corresponding
-            information
+            information. If no guests could be retrieved, an empty list
+            is returned.
         :rtype: List[Dict[str, Any]]
         """
         self.database_connection.is_connected
@@ -61,7 +62,7 @@ class Guest:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         guests = []
         for row in results:
@@ -80,7 +81,8 @@ class Guest:
         name, slug string and appearance information for all guests.
 
         :return: List of all guests and their corresponding
-            information and appearances
+            information and appearances. If no guests could be
+            retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -93,7 +95,7 @@ class Guest:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         guests = []
         for row in results:
@@ -113,7 +115,8 @@ class Guest:
         """Returns a list of all guest IDs from the database, sorted by
         guest name.
 
-        :return: List of all guest IDs
+        :return: List of all guest IDs. If no guest IDs could be
+            retrieved, an emtpy list is returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -125,7 +128,7 @@ class Guest:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -137,7 +140,8 @@ class Guest:
         """Returns a list of all guest slug strings from the database,
         sorted by guest name.
 
-        :return: List of all guest slug strings
+        :return: List of all guest slug strings. If no guest slugs could
+            be retrieved, an emtpy list is returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -149,7 +153,7 @@ class Guest:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -164,13 +168,14 @@ class Guest:
 
         :param id: Guest ID
         :type id: int
-        :return: Dictionary containing guest information
+        :return: Dictionary containing guest information. If no guest
+            information is found, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT guestid AS id, guest, guestslug AS slug "
@@ -182,7 +187,7 @@ class Guest:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         info = {
             "id": result["id"],
@@ -199,19 +204,20 @@ class Guest:
 
         :param slug: Guest slug string
         :type slug: str
-        :return: Dictionary containing guest information
+        :return: Dictionary containing guest information. If no guest
+            information is found, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -223,17 +229,18 @@ class Guest:
         :param id: Guest ID
         :type id: int
         :return: Dictionary containing guest information and their
-            appearances
+            appearances. If no guest information is found, an empty
+            dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.retrieve_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
 
@@ -248,18 +255,19 @@ class Guest:
         :param slug: Guest slug string
         :type slug: str
         :return: Dictionary containing guest information and their
-            appearances
+            appearances. If no guest information is found, an empty
+            dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+from wwdtm.validation import valid_int_id
 
 
 class GuestUtility:
@@ -47,16 +48,14 @@ class GuestUtility:
         :return: Guest slug string, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(guest_id)
-        except ValueError:
+        if not valid_int_id(guest_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT guestslug FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (guest_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -104,16 +103,14 @@ class GuestUtility:
         :return: True or False, based on whether the guest ID exists
         :rtype: bool
         """
-        try:
-            id_ = int(guest_id)
-        except ValueError:
+        if not valid_int_id(guest_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT guestid FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (guest_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -39,16 +39,16 @@ class GuestUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> Optional[str]:
+    def convert_id_to_slug(self, guest_id: int) -> Optional[str]:
         """Converts a guest's ID to the matching guest slug string.
 
-        :param id: Guest ID
-        :type id: int
+        :param guest_id: Guest ID
+        :type guest_id: int
         :return: Guest slug string, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(guest_id)
         except ValueError:
             return None
 
@@ -56,7 +56,7 @@ class GuestUtility:
         query = ("SELECT guestslug FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -66,17 +66,17 @@ class GuestUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+    def convert_slug_to_id(self, guest_slug: str) -> Optional[int]:
         """Converts a guest's slug string to the matching guest ID, if
         a match is found. If no match is found, None is returned.
 
-        :param slug: Guest slug string
-        :type slug: str
+        :param guest_slug: Guest slug string
+        :type guest_slug: str
         :return: Guest ID, if a match is found
         :rtype: int
         """
         try:
-            slug = slug.strip()
+            slug = guest_slug.strip()
             if not slug:
                 return None
         except ValueError:
@@ -96,16 +96,16 @@ class GuestUtility:
         return None
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, guest_id: int) -> bool:
         """Checks to see if a guest ID exists.
 
-        :param id: Guest ID
-        :type id: int
+        :param guest_id: Guest ID
+        :type guest_id: int
         :return: True or False, based on whether the guest ID exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(guest_id)
         except ValueError:
             return False
 
@@ -113,24 +113,24 @@ class GuestUtility:
         query = ("SELECT guestid FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         return bool(result)
 
     @lru_cache(typed=True)
-    def slug_exists(self, slug: str) -> bool:
+    def slug_exists(self, guest_slug: str) -> bool:
         """Checks to see if a guest slug string exists.
 
-        :param slug: Guest slug string
-        :type slug: str
+        :param guest_slug: Guest slug string
+        :type guest_slug: str
         :return: True or False, based on whether the guest slug string
             exists
         :rtype: bool
         """
         try:
-            slug = slug.strip()
+            slug = guest_slug.strip()
             if not slug:
                 return False
         except ValueError:

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -2,13 +2,14 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Guest Data Utility Functions
 """
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+
 
 class GuestUtility:
     """This class contains supporting functions used to check whether
@@ -38,7 +39,7 @@ class GuestUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> str:
+    def convert_id_to_slug(self, id: int) -> Optional[str]:
         """Converts a guest's ID to the matching guest slug string.
 
         :param id: Guest ID
@@ -53,8 +54,8 @@ class GuestUtility:
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT guestslug FROM ww_guests "
-                    "WHERE guestid = %s "
-                    "LIMIT 1;")
+                 "WHERE guestid = %s "
+                 "LIMIT 1;")
         cursor.execute(query, (id, ))
         result = cursor.fetchone()
         cursor.close()
@@ -65,12 +66,12 @@ class GuestUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> int:
+    def convert_slug_to_id(self, slug: str) -> Optional[int]:
         """Converts a guest's slug string to the matching guest ID, if
         a match is found. If no match is found, None is returned.
 
-        :param id: Guest slug string
-        :type id: str
+        :param slug: Guest slug string
+        :type slug: str
         :return: Guest ID, if a match is found
         :rtype: int
         """

--- a/wwdtm/host/__init__.py
+++ b/wwdtm/host/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Host module
 """
 from wwdtm.host.appearances import HostAppearances

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Host Appearance Retrieval Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.host.utility import HostUtility
+
 
 class HostAppearances:
     """This class contains functions that retrieve host appearance
@@ -58,14 +59,14 @@ class HostAppearances:
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
-                    "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
-                    "JOIN ww_shows s ON s.showid = hm.showid "
-                    "WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND "
-                    "hm.hostid = %s ) AS regular_shows, ( "
-                    "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
-                    "JOIN ww_shows s ON s.showid = hm.showid "
-                    "WHERE hm.hostid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id ,))
+                 "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
+                 "JOIN ww_shows s ON s.showid = hm.showid "
+                 "WHERE s.bestof = 0 AND s.repeatshowid IS NULL AND "
+                 "hm.hostid = %s ) AS regular_shows, ( "
+                 "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
+                 "JOIN ww_shows s ON s.showid = hm.showid "
+                 "WHERE hm.hostid = %s ) AS all_shows;")
+        cursor.execute(query, (id, id, ))
         result = cursor.fetchone()
 
         if result:

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.host.utility import HostUtility
+from wwdtm.validation import valid_int_id
 
 
 class HostAppearances:
@@ -52,9 +53,7 @@ class HostAppearances:
             retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(host_id)
-        except ValueError:
+        if not valid_int_id(host_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -66,7 +65,7 @@ class HostAppearances:
                  "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
                  "JOIN ww_shows s ON s.showid = hm.showid "
                  "WHERE hm.hostid = %s ) AS all_shows;")
-        cursor.execute(query, (id_, id_, ))
+        cursor.execute(query, (host_id, host_id, ))
         result = cursor.fetchone()
 
         if result:
@@ -88,7 +87,7 @@ class HostAppearances:
                  "JOIN ww_shows s ON s.showid = hm.showid "
                  "WHERE hm.hostid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (host_id, ))
         results = cursor.fetchall()
         cursor.close()
 

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -47,13 +47,14 @@ class HostAppearances:
         :param id: Host ID
         :type id: int
         :return:  Dictionary containing appearance counts and list of
-            appearances for a host
+            appearances for a host. If host appearances could not be
+            retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
@@ -122,11 +123,12 @@ class HostAppearances:
         :param slug: Host slug string
         :type slug: str
         :return:  Dictionary containing appearance counts and list of
-            appearances for a host
+            appearances for a host. If host appearances could not be
+            retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_appearances_by_id(id)

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -41,19 +41,19 @@ class HostAppearances:
         self.utility = HostUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_appearances_by_id(self, host_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested host ID.
 
-        :param id: Host ID
-        :type id: int
+        :param host_id: Host ID
+        :type host_id: int
         :return:  Dictionary containing appearance counts and list of
             appearances for a host. If host appearances could not be
             retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(host_id)
         except ValueError:
             return {}
 
@@ -66,7 +66,7 @@ class HostAppearances:
                  "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
                  "JOIN ww_shows s ON s.showid = hm.showid "
                  "WHERE hm.hostid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id, ))
+        cursor.execute(query, (id_, id_, ))
         result = cursor.fetchone()
 
         if result:
@@ -88,7 +88,7 @@ class HostAppearances:
                  "JOIN ww_shows s ON s.showid = hm.showid "
                  "WHERE hm.hostid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -117,19 +117,19 @@ class HostAppearances:
         return appearance_info
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_appearances_by_slug(self, host_slug: str) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested host ID.
 
-        :param slug: Host slug string
-        :type slug: str
+        :param host_slug: Host slug string
+        :type host_slug: str
         :return:  Dictionary containing appearance counts and list of
             appearances for a host. If host appearances could not be
             retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(host_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_appearances_by_id(id)
+        return self.retrieve_appearances_by_id(id_)

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Host Data Retrieval Functions
 """
 from functools import lru_cache
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.host.appearances import HostAppearances
 from wwdtm.host.utility import HostUtility
+
 
 class Host:
     """This class contains functions used to retrieve host data from a

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.host.appearances import HostAppearances
 from wwdtm.host.utility import HostUtility
+from wwdtm.validation import valid_int_id
 
 
 class Host:
@@ -176,9 +177,7 @@ class Host:
             returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(host_id)
-        except ValueError:
+        if not valid_int_id(host_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -187,7 +186,7 @@ class Host:
                  "FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (host_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -240,16 +239,14 @@ class Host:
             empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(host_id)
-        except ValueError:
+        if not valid_int_id(host_id):
             return {}
 
-        info = self.retrieve_by_id(id_)
+        info = self.retrieve_by_id(host_id)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(host_id)
 
         return info
 

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -165,19 +165,19 @@ class Host:
         return ids
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, host_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing host ID, name and
         slug string for the requested host ID.
 
-        :param id: Host ID
-        :type id: int
+        :param host_id: Host ID
+        :type host_id: int
         :return: Dictionary containing host information. If host
             information could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(host_id)
         except ValueError:
             return {}
 
@@ -187,7 +187,7 @@ class Host:
                  "FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -204,77 +204,77 @@ class Host:
         return info
 
     @lru_cache(typed=True)
-    def retrieve_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_by_slug(self, host_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing host ID, name and
         slug string for the requested host slug string.
 
-        :param slug: Host slug string
-        :type slug: str
+        :param host_slug: Host slug string
+        :type host_slug: str
         :return: Dictionary containing host information. If host
             information could be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = host_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, host_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing host ID, name, slug
         string and appearance information for the requested host ID.
 
-        :param id: Host ID
-        :type id: int
+        :param host_id: Host ID
+        :type host_id: int
         :return: Dictionary containing host information and their
             appearances. If host information could be retrieved, an
             empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(host_id)
         except ValueError:
             return {}
 
-        info = self.retrieve_by_id(id)
+        info = self.retrieve_by_id(id_)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
 
         return info
 
     @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_details_by_slug(self, host_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing host ID, name, slug
         string and appearance information for the requested host slug
         string.
 
-        :param slug: Host slug string
-        :type slug: str
+        :param host_slug: Host slug string
+        :type host_slug: str
         :return: Dictionary containing host information and their
             appearances. If host information could be retrieved, an
             empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = host_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -46,7 +46,8 @@ class Host:
         """Returns a list of dictionary objects containing host ID,
         name and slug string for all hosts.
 
-        :return: List of all hosts and their corresponding information
+        :return: List of all hosts and their corresponding information.
+            If hosts could not be retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -60,7 +61,7 @@ class Host:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         hosts = []
         for row in results:
@@ -80,7 +81,8 @@ class Host:
         name, slug string and appearance information for all hosts.
 
         :return: List of all hosts and their corresponding information
-            and appearances
+            and appearances. If hosts could not be retrieved, an empty
+            list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -94,7 +96,7 @@ class Host:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         hosts = []
         for row in results:
@@ -115,7 +117,8 @@ class Host:
         """Returns a list of all host IDs from the database, sorted by
         host name.
 
-        :return: List of all host IDs
+        :return: List of all host IDs. If host IDs could not be
+            retrieved, an empty list is returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -127,7 +130,7 @@ class Host:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -139,7 +142,8 @@ class Host:
         """Returns a list of all host slug strings from the database,
         sorted by host name.
 
-        :return: List of all host slug strings
+        :return: List of all host slug strings. If host slug strings
+            could not be retrieved, an empty list is returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -151,7 +155,7 @@ class Host:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -166,13 +170,15 @@ class Host:
 
         :param id: Host ID
         :type id: int
-        :return: Dictionary containing host information
+        :return: Dictionary containing host information. If host
+            information could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT hostid AS id, host, hostslug AS slug, "
@@ -185,7 +191,7 @@ class Host:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         info = {
             "id": result["id"],
@@ -203,19 +209,21 @@ class Host:
 
         :param slug: Host slug string
         :type slug: str
-        :return: Dictionary containing host information
+        :return: Dictionary containing host information. If host
+            information could be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -227,17 +235,18 @@ class Host:
         :param id: Host ID
         :type id: int
         :return: Dictionary containing host information and their
-            appearances
+            appearances. If host information could be retrieved, an
+            empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.retrieve_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
 
@@ -252,18 +261,19 @@ class Host:
         :param slug: Host slug string
         :type slug: str
         :return: Dictionary containing host information and their
-            appearances
+            appearances. If host information could be retrieved, an
+            empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -2,13 +2,14 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Host Data Utility Functions
 """
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+
 
 class HostUtility:
     """This class contains supporting functions used to check whether
@@ -38,7 +39,7 @@ class HostUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> str:
+    def convert_id_to_slug(self, id: int) -> Optional[str]:
         """Converts a host's ID to the matching host slug string value.
 
         :param id: Host ID
@@ -65,7 +66,7 @@ class HostUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> int:
+    def convert_slug_to_id(self, slug: str) -> Optional[int]:
         """Converts a host's slug string to the matching host ID value.
 
         :param slug: Host slug string
@@ -133,7 +134,6 @@ class HostUtility:
                 return False
         except ValueError:
             return False
-
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostslug FROM ww_hosts "

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+from wwdtm.validation import valid_int_id
 
 
 class HostUtility:
@@ -47,16 +48,14 @@ class HostUtility:
         :return: Host slug string, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(host_id)
-        except ValueError:
+        if not valid_int_id(host_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostslug FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (host_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -103,16 +102,14 @@ class HostUtility:
         :return: True or False, based on whether the host ID exists
         :rtype: bool
         """
-        try:
-            id_ = int(host_id)
-        except ValueError:
+        if not valid_int_id(host_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostid FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (host_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -39,16 +39,16 @@ class HostUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> Optional[str]:
+    def convert_id_to_slug(self, host_id: int) -> Optional[str]:
         """Converts a host's ID to the matching host slug string value.
 
-        :param id: Host ID
-        :type id: int
+        :param host_id: Host ID
+        :type host_id: int
         :return: Host slug string, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(host_id)
         except ValueError:
             return None
 
@@ -56,7 +56,7 @@ class HostUtility:
         query = ("SELECT hostslug FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -66,16 +66,16 @@ class HostUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+    def convert_slug_to_id(self, host_slug: str) -> Optional[int]:
         """Converts a host's slug string to the matching host ID value.
 
-        :param slug: Host slug string
-        :type slug: str
+        :param host_slug: Host slug string
+        :type host_slug: str
         :return: Host ID, if a match is found
         :rtype: int
         """
         try:
-            slug = slug.strip()
+            slug = host_slug.strip()
             if not slug:
                 return None
         except ValueError:
@@ -95,16 +95,16 @@ class HostUtility:
         return None
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, host_id: int) -> bool:
         """Checks to see if a host ID exists.
 
-        :param id: Host ID
-        :type id: int
+        :param host_id: Host ID
+        :type host_id: int
         :return: True or False, based on whether the host ID exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(host_id)
         except ValueError:
             return False
 
@@ -112,24 +112,24 @@ class HostUtility:
         query = ("SELECT hostid FROM ww_hosts "
                  "WHERE hostid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         return bool(result)
 
     @lru_cache(typed=True)
-    def slug_exists(self, slug: str) -> bool:
+    def slug_exists(self, host_slug: str) -> bool:
         """Checks to see if a host slug string exists.
 
-        :param slug: Host slug string
-        :type slug: str
+        :param host_slug: Host slug string
+        :type host_slug: str
         :return: True or False, based on whether the host slug string
             exists
         :rtype: bool
         """
         try:
-            slug = slug.strip()
+            slug = host_slug.strip()
             if not slug:
                 return False
         except ValueError:

--- a/wwdtm/location/__init__.py
+++ b/wwdtm/location/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Location module
 """
 from wwdtm.location.location import Location

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from mysql.connector import connect
 from wwdtm.location.recordings import LocationRecordings
 from wwdtm.location.utility import LocationUtility
+from wwdtm.validation import valid_int_id
 
 
 class Location:
@@ -212,9 +213,7 @@ class Location:
             dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(location_id)
-        except ValueError:
+        if not valid_int_id(location_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -223,7 +222,7 @@ class Location:
                  "FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (location_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -282,16 +281,14 @@ class Location:
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(location_id)
-        except ValueError:
+        if not valid_int_id(location_id):
             return {}
 
-        info = self.retrieve_by_id(id_)
+        info = self.retrieve_by_id(location_id)
         if not info:
             return {}
 
-        info["recordings"] = self.recordings.retrieve_recordings_by_id(id_)
+        info["recordings"] = self.recordings.retrieve_recordings_by_id(location_id)
 
         return info
 

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Location Data Retrieval Functions
 """
 from functools import lru_cache
@@ -11,6 +11,7 @@ from typing import Any, Dict, List, Optional
 from mysql.connector import connect
 from wwdtm.location.recordings import LocationRecordings
 from wwdtm.location.utility import LocationUtility
+
 
 class Location:
     """This class contains functions used to retrieve location data
@@ -45,7 +46,7 @@ class Location:
         """Returns a list of dictionary objects containing location ID,
         city, state, venue and slug string for all locations.
 
-        :param sort_by_venue: Sets wheter to sort by venue first, or
+        :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
         :return: List of all locations and their corresponding
@@ -89,12 +90,12 @@ class Location:
         return locations
 
     def retrieve_all_details(self, sort_by_venue: bool = False
-                            ) -> List[Dict[str, Any]]:
+                             ) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing location ID,
         city, state, venue, slug string and recording information for
         all locations.
 
-        :param sort_by_venue: Sets wheter to sort by venue first, or
+        :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
         :return: List of all locations and their corresponding
@@ -141,7 +142,7 @@ class Location:
     def retrieve_all_ids(self, sort_by_venue: bool = False) -> List[int]:
         """Returns a list of all locations IDs from the database.
 
-        :param sort_by_venue: Sets wheter to sort by venue first, or
+        :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
         :return: List of all location IDs. If location IDs could not be
@@ -172,7 +173,7 @@ class Location:
         """Returns a list of all location slug strings from the
         database.
 
-        :param sort_by_venue: Sets wheter to sort by venue first, or
+        :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
         :return: List of all location slug strings. If location slug

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -73,7 +73,7 @@ class Location:
 
         locations = []
         for row in results:
-            slug = self.utility.slugify_location(id=row["id"],
+            slug = self.utility.slugify_location(location_id=row["id"],
                                                  venue=row["venue"],
                                                  city=row["city"],
                                                  state=row["state"])
@@ -121,7 +121,7 @@ class Location:
 
         locations = []
         for row in results:
-            slug = self.utility.slugify_location(id=row["id"],
+            slug = self.utility.slugify_location(location_id=row["id"],
                                                  venue=row["venue"],
                                                  city=row["city"],
                                                  state=row["state"])
@@ -201,19 +201,19 @@ class Location:
         return ids
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, location_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing location ID, venue,
         city, state and slug string for the requested location ID.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :return: Dictionary containing location information. If
             location information could not be retrieved, an empty
             dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(location_id)
         except ValueError:
             return {}
 
@@ -223,14 +223,14 @@ class Location:
                  "FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         if not result:
             return {}
 
-        slug = self.utility.slugify_location(id=result["id"],
+        slug = self.utility.slugify_location(location_id=result["id"],
                                              venue=result["venue"],
                                              city=result["city"],
                                              state=result["state"])
@@ -245,78 +245,78 @@ class Location:
         return location
 
     @lru_cache(typed=True)
-    def retrieve_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_by_slug(self, location_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing location ID, venue,
         city, state and slug string for the requested location ID.
 
-        :param slug: Location slug string
-        :type slug: str
+        :param location_slug: Location slug string
+        :type location_slug: str
         :return: Dictionary containing location information. If
             location information could not be retrieved, an empty
             dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = location_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, location_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing location ID, venue,
         city, state, slug string and a list of recordings for the
         requested location ID.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :return: Dictionary containing location information and their
             recordings. If location information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(location_id)
         except ValueError:
             return {}
 
-        info = self.retrieve_by_id(id)
+        info = self.retrieve_by_id(id_)
         if not info:
             return {}
 
-        info["recordings"] = self.recordings.retrieve_recordings_by_id(id)
+        info["recordings"] = self.recordings.retrieve_recordings_by_id(id_)
 
         return info
 
     @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_details_by_slug(self, location_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing location ID, venue,
         city, state, slug string and a list of recordings for the
         requested location slug string.
 
-        :param slug: Location slug string
-        :type slug: str
+        :param location_slug: Location slug string
+        :type location_slug: str
         :return: Dictionary containing location information and their
             recordings. If location information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = location_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -48,7 +48,9 @@ class Location:
         :param sort_by_venue: Sets wheter to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
-        :return: List of all locations and their corresponding information
+        :return: List of all locations and their corresponding
+            information. If locations could not be retrieved, an empty
+            list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -66,7 +68,7 @@ class Location:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         locations = []
         for row in results:
@@ -96,7 +98,8 @@ class Location:
             by state and city first
         :type sort_by_venue: bool
         :return: List of all locations and their corresponding
-            information and recordings
+            information and recordings. If locations could not be
+            retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -113,7 +116,7 @@ class Location:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         locations = []
         for row in results:
@@ -141,7 +144,8 @@ class Location:
         :param sort_by_venue: Sets wheter to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
-        :return: List of all location IDs
+        :return: List of all location IDs. If location IDs could not be
+            retrieved, an empty list is returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -156,7 +160,7 @@ class Location:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -171,7 +175,8 @@ class Location:
         :param sort_by_venue: Sets wheter to sort by venue first, or
             by state and city first
         :type sort_by_venue: bool
-        :return: List of all location slug strings
+        :return: List of all location slug strings. If location slug
+            strings could not be retrieved, an empty list is returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -186,7 +191,7 @@ class Location:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -201,13 +206,15 @@ class Location:
 
         :param id: Location ID
         :type id: int
-        :return: Dictionary containing location information
+        :return: Dictionary containing location information. If
+            location information could not be retrieved, an empty
+            dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT locationid AS id, city, state, venue, "
@@ -220,7 +227,7 @@ class Location:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         slug = self.utility.slugify_location(id=result["id"],
                                              venue=result["venue"],
@@ -243,19 +250,21 @@ class Location:
 
         :param slug: Location slug string
         :type slug: str
-        :return: Dictionary containing location information
+        :return: Dictionary containing location information. If
+            location information could not be retrieved, an empty
+            dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -268,17 +277,18 @@ class Location:
         :param id: Location ID
         :type id: int
         :return: Dictionary containing location information and their
-            recordings
+            recordings. If location information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.retrieve_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["recordings"] = self.recordings.retrieve_recordings_by_id(id)
 
@@ -293,18 +303,19 @@ class Location:
         :param slug: Location slug string
         :type slug: str
         :return: Dictionary containing location information and their
-            recordings
+            recordings. If location information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.location.utility import LocationUtility
+from wwdtm.validation import valid_int_id
 
 
 class LocationRecordings:
@@ -52,9 +53,7 @@ class LocationRecordings:
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(location_id)
-        except ValueError:
+        if not valid_int_id(location_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -66,7 +65,7 @@ class LocationRecordings:
                  "SELECT COUNT(lm.showid) FROM ww_showlocationmap lm "
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s ) AS all_shows;")
-        cursor.execute(query, (id_, id_, ))
+        cursor.execute(query, (location_id, location_id, ))
         result = cursor.fetchone()
 
         recording_counts = {
@@ -81,7 +80,7 @@ class LocationRecordings:
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (location_id, ))
         results = cursor.fetchall()
         cursor.close()
 

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -47,13 +47,14 @@ class LocationRecordings:
         :param id: Location ID
         :type id: int
         :return: Dictionary containing recording counts and a list of
-            appearances for a location
+            appearances for a location. If location recordings could
+            not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
@@ -114,11 +115,12 @@ class LocationRecordings:
         :param slug: Location slug string
         :type slug: str
         :return: Dictionary containing recording counts and a list of
-            appearances for a location
+            appearances for a location. If location recordings could
+            not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_recordings_by_id(id)

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -41,19 +41,19 @@ class LocationRecordings:
         self.utility = LocationUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_recordings_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_recordings_by_id(self, location_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing recording
         information for the requested location ID.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :return: Dictionary containing recording counts and a list of
             appearances for a location. If location recordings could
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(location_id)
         except ValueError:
             return {}
 
@@ -66,7 +66,7 @@ class LocationRecordings:
                  "SELECT COUNT(lm.showid) FROM ww_showlocationmap lm "
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id, ))
+        cursor.execute(query, (id_, id_, ))
         result = cursor.fetchone()
 
         recording_counts = {
@@ -81,7 +81,7 @@ class LocationRecordings:
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -109,19 +109,19 @@ class LocationRecordings:
         return recording_info
 
     @lru_cache(typed=True)
-    def retrieve_recordings_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_recordings_by_slug(self, location_slug: str) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing recording
         information for the requested location slug string.
 
-        :param slug: Location slug string
-        :type slug: str
+        :param location_slug: Location slug string
+        :type location_slug: str
         :return: Dictionary containing recording counts and a list of
             appearances for a location. If location recordings could
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(location_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_recordings_by_id(id)
+        return self.retrieve_recordings_by_id(id_)

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Location Recordings Retrieval Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.location.utility import LocationUtility
+
 
 class LocationRecordings:
     """This class contains functions that retrieve location recordings
@@ -65,7 +66,7 @@ class LocationRecordings:
                  "SELECT COUNT(lm.showid) FROM ww_showlocationmap lm "
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id ,))
+        cursor.execute(query, (id, id, ))
         result = cursor.fetchone()
 
         recording_counts = {

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -173,9 +173,11 @@ class LocationUtility:
             return slugify(f"{venue} {city} {state}")
         elif venue and city and not state:
             return slugify(f"{venue} {city}")
-        elif venue and (not city and not state):
-            return slugify(venue)
+        elif id and venue and (not city and not state):
+            return slugify(f"{id}-{venue}")
+        elif id and city and state and not venue:
+            return slugify(f"{id} {city} {state}")
         elif id:
-            return slugify(f"locationid-{id}")
+            return f"location-{id}"
         else:
             raise ValueError("Invalid location information provided")

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from slugify import slugify
+from wwdtm.validation import valid_int_id
 
 
 class LocationUtility:
@@ -49,16 +50,14 @@ class LocationUtility:
         :return: Location slug string, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(location_id)
-        except ValueError:
+        if not valid_int_id(location_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT locationslug FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (location_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -106,16 +105,14 @@ class LocationUtility:
         :return: True or False, based on whether the location ID exists
         :rtype: bool
         """
-        try:
-            id_ = int(location_id)
-        except ValueError:
+        if not valid_int_id(location_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT locationid FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (location_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -40,17 +40,17 @@ class LocationUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> Optional[str]:
+    def convert_id_to_slug(self, location_id: int) -> Optional[str]:
         """Converts a location's ID to the matching location slug
         string value.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :return: Location slug string, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(location_id)
         except ValueError:
             return None
 
@@ -58,7 +58,7 @@ class LocationUtility:
         query = ("SELECT locationslug FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -68,17 +68,17 @@ class LocationUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+    def convert_slug_to_id(self, location_slug: str) -> Optional[int]:
         """Converts a location's slug string to the matching location
         ID value.
 
-        :param slug: Location slug string
-        :type slug: str
+        :param location_slug: Location slug string
+        :type location_slug: str
         :return: Location ID, if a match if found
         :rtype: int
         """
         try:
-            slug = slug.strip()
+            slug = location_slug.strip()
             if not slug:
                 return None
         except ValueError:
@@ -98,16 +98,16 @@ class LocationUtility:
         return None
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, location_id: int) -> bool:
         """Checks to see if a location ID exists.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :return: True or False, based on whether the location ID exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(location_id)
         except ValueError:
             return False
 
@@ -115,24 +115,24 @@ class LocationUtility:
         query = ("SELECT locationid FROM ww_locations "
                  "WHERE locationid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         return bool(result)
 
     @lru_cache(typed=True)
-    def slug_exists(self, slug: str) -> bool:
+    def slug_exists(self, location_slug: str) -> bool:
         """Checks to see if a location slug string exists.
 
-        :param slug: Location slug string
-        :type slug: str
+        :param location_slug: Location slug string
+        :type location_slug: str
         :return: True or False, based on whether the location slug
             string exists
         :rtype: bool
         """
         try:
-            slug = slug.strip()
+            slug = location_slug.strip()
             if not slug:
                 return False
         except ValueError:
@@ -149,7 +149,7 @@ class LocationUtility:
         return bool(result)
 
     @staticmethod
-    def slugify_location(id: int = None,
+    def slugify_location(location_id: int = None,
                          venue: str = None,
                          city: str = None,
                          state: str = None
@@ -157,8 +157,8 @@ class LocationUtility:
         """Generates a slug string based on the location's venue name,
         city, state and/or location ID.
 
-        :param id: Location ID
-        :type id: int
+        :param location_id: Location ID
+        :type location_id: int
         :param venue: Location venue name
         :type venue: str
         :param city: City where the location venue is located
@@ -173,11 +173,11 @@ class LocationUtility:
             return slugify(f"{venue} {city} {state}")
         elif venue and city and not state:
             return slugify(f"{venue} {city}")
-        elif id and venue and (not city and not state):
+        elif location_id and venue and (not city and not state):
             return slugify(f"{id}-{venue}")
-        elif id and city and state and not venue:
+        elif location_id and city and state and not venue:
             return slugify(f"{id} {city} {state}")
-        elif id:
-            return f"location-{id}"
+        elif location_id:
+            return f"location-{location_id}"
         else:
             raise ValueError("Invalid location information provided")

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Location Data Utility Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from slugify import slugify
+
 
 class LocationUtility:
     """This class contains supporting functions used to check whether
@@ -38,9 +39,8 @@ class LocationUtility:
 
             self.database_connection = database_connection
 
-
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> str:
+    def convert_id_to_slug(self, id: int) -> Optional[str]:
         """Converts a location's ID to the matching location slug
         string value.
 
@@ -68,7 +68,7 @@ class LocationUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> int:
+    def convert_slug_to_id(self, slug: str) -> Optional[int]:
         """Converts a location's slug string to the matching location
         ID value.
 
@@ -148,12 +148,12 @@ class LocationUtility:
 
         return bool(result)
 
-    def slugify_location(self,
-                         id: int=None,
-                         venue: str=None,
-                         city: str=None,
-                         state: str=None
-                        ) -> str:
+    @staticmethod
+    def slugify_location(id: int = None,
+                         venue: str = None,
+                         city: str = None,
+                         state: str = None
+                         ) -> str:
         """Generates a slug string based on the location's venue name,
         city, state and/or location ID.
 

--- a/wwdtm/panelist/__init__.py
+++ b/wwdtm/panelist/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Panelist module
 """
 from wwdtm.panelist.appearances import PanelistAppearances

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -41,19 +41,19 @@ class PanelistAppearances:
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_appearances_by_id(self, panelist_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return:  Dictionary containing appearance counts and list of
             appearances for a panelist. If panelist appearances could
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(panelist_id)
         except ValueError:
             return {}
 
@@ -72,7 +72,7 @@ class PanelistAppearances:
                  "s.repeatshowid IS NULL "
                  "AND pm.panelistscore IS NOT NULL ) "
                  "AS shows_with_scores;")
-        cursor.execute(query, (id, id, id, ))
+        cursor.execute(query, (id_, id_, id_, ))
         result = cursor.fetchone()
 
         if result:
@@ -96,7 +96,7 @@ class PanelistAppearances:
                  "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
                  "AND pm.panelistid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
 
         if result and result["first_id"]:
@@ -134,7 +134,7 @@ class PanelistAppearances:
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -166,30 +166,30 @@ class PanelistAppearances:
         return appearance_info
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_appearances_by_slug(self, panelist_slug: str) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return:  Dictionary containing appearance counts and list of
             appearances for a panelist. If panelist appearances could
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_appearances_by_id(id)
+        return self.retrieve_appearances_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_yearly_appearances_by_id(self, id: int) -> Dict[int, int]:
+    def retrieve_yearly_appearances_by_id(self, panelist_id: int) -> Dict[int, int]:
         """Returns a dictionary containing panelist appearances broken
         down by year, for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing scoring breakdown by year. If
             panelist appearances could not be retrieved, an empty
             dictionary is returned.
@@ -219,7 +219,7 @@ class PanelistAppearances:
                  "AND s.repeatshowid IS NULL "
                  "GROUP BY p.panelist, YEAR(s.showdate) "
                  "ORDER BY p.panelist ASC, YEAR(s.showdate) ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -232,19 +232,20 @@ class PanelistAppearances:
         return years
 
     @lru_cache(typed=True)
-    def retrieve_yearly_appearances_by_slug(self, slug: str) -> Dict[int, int]:
+    def retrieve_yearly_appearances_by_slug(self, panelist_slug: str
+                                            ) -> Dict[int, int]:
         """Returns a dictionary containing panelist appearances broken
         down by year, for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing scoring breakdown by year. If
             panelist appearances could not be retrieved, an empty
             dictionary is returned.
         :rtype: Dict[int, int]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_yearly_appearances_by_id(id)
+        return self.retrieve_yearly_appearances_by_id(id_)

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.panelist.utility import PanelistUtility
-
+from wwdtm.validation import valid_int_id
 
 class PanelistAppearances:
     """This class contains functions that retrieve panelist appearance
@@ -52,9 +52,7 @@ class PanelistAppearances:
             not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(panelist_id)
-        except ValueError:
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -72,7 +70,7 @@ class PanelistAppearances:
                  "s.repeatshowid IS NULL "
                  "AND pm.panelistscore IS NOT NULL ) "
                  "AS shows_with_scores;")
-        cursor.execute(query, (id_, id_, id_, ))
+        cursor.execute(query, (panelist_id, panelist_id, panelist_id, ))
         result = cursor.fetchone()
 
         if result:
@@ -96,7 +94,7 @@ class PanelistAppearances:
                  "WHERE s.bestof = 0 AND s.repeatshowid IS NULL "
                  "AND pm.panelistid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (panelist_id, ))
         result = cursor.fetchone()
 
         if result and result["first_id"]:
@@ -134,7 +132,7 @@ class PanelistAppearances:
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -195,6 +193,9 @@ class PanelistAppearances:
             dictionary is returned.
         :rtype: Dict[int, int]
         """
+        if not valid_int_id(panelist_id):
+            return {}
+
         years = {}
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT DISTINCT YEAR(s.showdate) AS year "

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Panelist Appearance Retrieval Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.panelist.utility import PanelistUtility
+
 
 class PanelistAppearances:
     """This class contains functions that retrieve panelist appearance
@@ -197,8 +198,8 @@ class PanelistAppearances:
         years = {}
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT DISTINCT YEAR(s.showdate) AS year "
-                    "FROM ww_shows s "
-                    "ORDER BY YEAR(s.showdate) ASC;")
+                 "FROM ww_shows s "
+                 "ORDER BY YEAR(s.showdate) ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
 

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -139,19 +139,15 @@ class PanelistAppearances:
         if result:
             appearances = []
             for appearance in results:
-                rank = appearance["showpnlrank"]
-                if not rank:
-                    rank = None
-
                 info = {
                     "show_id": appearance["show_id"],
                     "date": appearance["date"].isoformat(),
                     "best_of": bool(appearance["best_of"]),
                     "repeat_show": bool(appearance["repeatshowid"]),
-                    "lightning_round_start": appearance["start"],
-                    "lightning_round_correct": appearance["correct"],
-                    "score": appearance["score"],
-                    "rank": rank,
+                    "lightning_round_start": appearance["start"] if appearance["start"] else None,
+                    "lightning_round_correct": appearance["correct"] if appearance["correct"] else None,
+                    "score": appearance["score"] if appearance["score"] else None,
+                    "rank": appearance["showpnlrank"] if appearance["showpnlrank"] else None,
                 }
                 appearances.append(info)
 

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -47,13 +47,14 @@ class PanelistAppearances:
         :param id: Panelist ID
         :type id: int
         :return:  Dictionary containing appearance counts and list of
-            appearances for a panelist
+            appearances for a panelist. If panelist appearances could
+            not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
@@ -171,12 +172,13 @@ class PanelistAppearances:
         :param slug: Panelist slug string
         :type slug: str
         :return:  Dictionary containing appearance counts and list of
-            appearances for a panelist
+            appearances for a panelist. If panelist appearances could
+            not be retrieved, an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_appearances_by_id(id)
 
@@ -187,7 +189,9 @@ class PanelistAppearances:
 
         :param id: Panelist ID
         :type id: int
-        :return: Dictionary containing scoring breakdown by year
+        :return: Dictionary containing scoring breakdown by year. If
+            panelist appearances could not be retrieved, an empty
+            dictionary is returned.
         :rtype: Dict[int, int]
         """
         years = {}
@@ -199,7 +203,7 @@ class PanelistAppearances:
         results = cursor.fetchall()
 
         if not results:
-            return None
+            return {}
 
         for row in results:
             years[row["year"]] = 0
@@ -219,7 +223,7 @@ class PanelistAppearances:
         cursor.close()
 
         if not results:
-            return None
+            return {}
 
         for row in results:
             years[row["year"]] = row["count"]
@@ -233,11 +237,13 @@ class PanelistAppearances:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: Dictionary containing scoring breakdown by year
+        :return: Dictionary containing scoring breakdown by year. If
+            panelist appearances could not be retrieved, an empty
+            dictionary is returned.
         :rtype: Dict[int, int]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_yearly_appearances_by_id(id)

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -13,6 +13,7 @@ from slugify import slugify
 from wwdtm.panelist.appearances import PanelistAppearances
 from wwdtm.panelist.statistics import PanelistStatistics
 from wwdtm.panelist.utility import PanelistUtility
+from wwdtm.validation import valid_int_id
 
 
 class Panelist:
@@ -181,9 +182,7 @@ class Panelist:
             returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(panelist_id)
-        except ValueError:
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -192,7 +191,7 @@ class Panelist:
                  "FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (panelist_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -245,18 +244,16 @@ class Panelist:
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(panelist_id)
-        except ValueError:
+        if not valid_int_id(panelist_id):
             return {}
 
-        info = self.retrieve_by_id(id_)
+        info = self.retrieve_by_id(panelist_id)
         if not info:
             return {}
 
-        info["statistics"] = self.statistics.retrieve_statistics_by_id(id_)
-        info["bluffs"] = self.statistics.retrieve_bluffs_by_id(id_)
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
+        info["statistics"] = self.statistics.retrieve_statistics_by_id(panelist_id)
+        info["bluffs"] = self.statistics.retrieve_bluffs_by_id(panelist_id)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(panelist_id)
 
         return info
 

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Panelist Data Retrieval Functions
 """
 from functools import lru_cache
@@ -13,6 +13,7 @@ from slugify import slugify
 from wwdtm.panelist.appearances import PanelistAppearances
 from wwdtm.panelist.statistics import PanelistStatistics
 from wwdtm.panelist.utility import PanelistUtility
+
 
 class Panelist:
     """This class contains functions used to retrieve panelist data
@@ -160,7 +161,7 @@ class Panelist:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -104,15 +104,15 @@ class Panelist:
 
         panelists = []
         for row in results:
-            id = row["id"]
+            id_ = row["id"]
             panelist = {
-                "id": id,
+                "id": id_,
                 "name": row["panelist"],
                 "slug": row["slug"] if row["slug"] else slugify(row["panelist"]),
                 "gender": row["gender"],
-                "statistics": self.statistics.retrieve_statistics_by_id(id),
-                "bluff": self.statistics.retrieve_bluffs_by_id(id),
-                "appearances": self.appearances.retrieve_appearances_by_id(id),
+                "statistics": self.statistics.retrieve_statistics_by_id(id_),
+                "bluff": self.statistics.retrieve_bluffs_by_id(id_),
+                "appearances": self.appearances.retrieve_appearances_by_id(id_),
             }
 
             panelists.append(panelist)
@@ -170,19 +170,19 @@ class Panelist:
         return ids
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, panelist_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing panelist ID, name and
         slug string for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing panelist information. If panelist
             information could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(panelist_id)
         except ValueError:
             return {}
 
@@ -192,7 +192,7 @@ class Panelist:
                  "FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -209,79 +209,79 @@ class Panelist:
         return info
 
     @lru_cache(typed=True)
-    def retrieve_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_by_slug(self, panelist_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing panelist ID, name and
         slug string for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing panelist information. If panelist
             information could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = panelist_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, panelist_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing panelist ID, name, slug
         string and appearance information for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing panelist information and their
             appearances. If panelist information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(panelist_id)
         except ValueError:
             return {}
 
-        info = self.retrieve_by_id(id)
+        info = self.retrieve_by_id(id_)
         if not info:
             return {}
 
-        info["statistics"] = self.statistics.retrieve_statistics_by_id(id)
-        info["bluffs"] = self.statistics.retrieve_bluffs_by_id(id)
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
+        info["statistics"] = self.statistics.retrieve_statistics_by_id(id_)
+        info["bluffs"] = self.statistics.retrieve_bluffs_by_id(id_)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
 
         return info
 
     @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_details_by_slug(self, panelist_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing panelist ID, name, slug
         string and appearance information for the requested Panelist slug
         string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing panelist information and their
             appearances. If panelist information could not be retrieved,
             an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = panelist_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -49,7 +49,8 @@ class Panelist:
         name and slug string for all panelists.
 
         :return: List of all panelists and their corresponding
-            information
+            information. If panelists could not be retrieved, an empty
+            list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -63,7 +64,7 @@ class Panelist:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         panelists = []
         for row in results:
@@ -83,7 +84,8 @@ class Panelist:
         name, slug string and appearance information for all panelists.
 
         :return: List of all panelists and their corresponding
-            information and appearances
+            information and appearances. If panelists could not be
+            retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -97,7 +99,7 @@ class Panelist:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         panelists = []
         for row in results:
@@ -120,7 +122,8 @@ class Panelist:
         """Returns a list of all panelist IDs from the database, sorted
         by panelist name.
 
-        :return: List of all panelist IDs
+        :return: List of all panelist IDs. If panelist IDs could not be
+            retrieved, an empty list is returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -132,7 +135,7 @@ class Panelist:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -144,7 +147,8 @@ class Panelist:
         """Returns a list of all panelist slug strings from the
         database, sorted by panelist name.
 
-        :return: List of all panelist slug strings
+        :return: List of all panelist slug strings. If panelist slug
+            strings could not be retrieved, an empty list is returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -171,13 +175,15 @@ class Panelist:
 
         :param id: Panelist ID
         :type id: int
-        :return: Dictionary containing panelist information
+        :return: Dictionary containing panelist information. If panelist
+            information could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT panelistid AS id, panelist, panelistslug AS slug, "
@@ -190,7 +196,7 @@ class Panelist:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         info = {
             "id": result["id"],
@@ -208,19 +214,21 @@ class Panelist:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: Dictionary containing panelist information
+        :return: Dictionary containing panelist information. If panelist
+            information could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -232,17 +240,18 @@ class Panelist:
         :param id: Panelist ID
         :type id: int
         :return: Dictionary containing panelist information and their
-            appearances
+            appearances. If panelist information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.retrieve_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["statistics"] = self.statistics.retrieve_statistics_by_id(id)
         info["bluffs"] = self.statistics.retrieve_bluffs_by_id(id)
@@ -259,18 +268,19 @@ class Panelist:
         :param slug: Panelist slug string
         :type slug: str
         :return: Dictionary containing panelist information and their
-            appearances
+            appearances. If panelist information could not be retrieved,
+            an empty dictionary is returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -41,12 +41,12 @@ class PanelistScores:
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_scores_by_id(self, id: int) -> List[int]:
+    def retrieve_scores_by_id(self, panelist_id: int) -> List[int]:
         """Returns a list of panelist scores for appearances for the
         requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: List containing panelist scores. If panelist scores
             could not be retrieved, an empty list is returned.
         :rtype: List[int]
@@ -58,7 +58,7 @@ class PanelistScores:
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE panelistid = %s "
                  "AND s.bestof = 0 and s.repeatshowid IS NULL;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         result = cursor.fetchall()
         cursor.close()
 
@@ -72,31 +72,31 @@ class PanelistScores:
         return scores
 
     @lru_cache(typed=True)
-    def retrieve_scores_by_slug(self, slug: str
+    def retrieve_scores_by_slug(self, panelist_slug: str
                                 ) -> List[int]:
         """Returns a list of panelist scores for appearances for the
         requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: List containing panelist scores. If panelist scores
             could not be retrieved, an empty list is returned.
         :rtype: List[int]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return []
 
-        return self.retrieve_scores_by_id(id)
+        return self.retrieve_scores_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_scores_grouped_list_by_id(self, id: int
+    def retrieve_scores_grouped_list_by_id(self, panelist_id: int
                                            ) -> Dict[str, List[int]]:
         """Returns a panelist's score grouping for the requested
         panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing two lists, one containing scores
             and one containing counts of those scores. If panelist
             scores could not be retrieved, an empty dictionary is
@@ -131,7 +131,7 @@ class PanelistScores:
                  "AND pm.panelistscore IS NOT NULL "
                  "GROUP BY pm.panelistscore "
                  "ORDER BY pm.panelistscore ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -149,34 +149,34 @@ class PanelistScores:
         return scores_list
 
     @lru_cache(typed=True)
-    def retrieve_scores_grouped_list_by_slug(self, slug: str
+    def retrieve_scores_grouped_list_by_slug(self, panelist_slug: str
                                              ) -> Dict[str, List[int]]:
         """Returns a panelist's score grouping for the requested
         panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing two lists, one containing scores
             and one containing counts of those scores. If panelist
             scores could not be retrieved, an empty dictionary is
             returned.
         :rtype: Dict[str, List[int]]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_scores_grouped_list_by_id(id)
+        return self.retrieve_scores_grouped_list_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_scores_grouped_ordered_pair_by_id(self, id: int
+    def retrieve_scores_grouped_ordered_pair_by_id(self, panelist_id: int
                                                    ) -> List[Tuple[int, int]]:
         """Returns an list of tuples containing a score and the
         corresponding number of instances a panelist has scored that amount
         for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: List of tuples containing scores and score counts. If
             panelist scores could not be retrieved, an empty list is
             returned.
@@ -209,7 +209,7 @@ class PanelistScores:
                  "AND pm.panelistscore IS NOT NULL "
                  "GROUP BY pm.panelistscore "
                  "ORDER BY pm.panelistscore ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -222,34 +222,34 @@ class PanelistScores:
         return list(scores.items())
 
     @lru_cache(typed=True)
-    def retrieve_scores_grouped_ordered_pair_by_slug(self, slug: str,
+    def retrieve_scores_grouped_ordered_pair_by_slug(self, panelist_slug: str,
                                                      ) -> List[Tuple[int, int]]:
         """Returns an list of tuples containing a score and the
         corresponding number of instances a panelist has scored that amount
         for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: List of tuples containing scores and score counts. If
             panelist scores could not be retrieved, an empty list is
             returned.
         :rtype: List[Tuple[int, int]]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return []
 
-        return self.retrieve_scores_grouped_ordered_pair_by_id(id)
+        return self.retrieve_scores_grouped_ordered_pair_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_scores_list_by_id(self, id: int,
+    def retrieve_scores_list_by_id(self, panelist_id: int,
                                    ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing a list show dates and a list
             of scores. If panelist scores could not be retrieved, an
             empty dictionary is returned.
@@ -263,7 +263,7 @@ class PanelistScores:
                  "AND s.bestof = 0 AND s.repeatshowid IS NULL "
                  "AND pm.panelistscore IS NOT NULL "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -284,33 +284,33 @@ class PanelistScores:
         return scores
 
     @lru_cache(typed=True)
-    def retrieve_scores_list_by_slug(self, slug: str,
+    def retrieve_scores_list_by_slug(self, panelist_slug: str,
                                      ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing a list show dates and a list
             of scores. If panelist scores could not be retrieved, an
             empty dictionary is returned.
         :rtype: Dict[str, List]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_scores_list_by_id(id)
+        return self.retrieve_scores_list_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_scores_ordered_pair_by_id(self, id: int
+    def retrieve_scores_ordered_pair_by_id(self, panelist_id: int
                                            ) -> List[Tuple[str, int]]:
         """Returns an list of tuples containing a show date and the
         corresponding score for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: List of tuples containing show dates and scores. If
             panelist scores could not be retrieved, an empty list is
             returned.
@@ -324,7 +324,7 @@ class PanelistScores:
                  "AND s.bestof = 0 AND s.repeatshowid IS NULL "
                  "AND pm.panelistscore IS NOT NULL "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (panelist_id, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -340,20 +340,20 @@ class PanelistScores:
         return scores
 
     @lru_cache(typed=True)
-    def retrieve_scores_ordered_pair_by_slug(self, slug: str,
+    def retrieve_scores_ordered_pair_by_slug(self, panelist_slug: str,
                                              ) -> List[Tuple[str, int]]:
         """Returns an list of tuples containing a show date and the
         corresponding score for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: List of tuples containing show dates and scores. If
             panelist scores could not be retrieved, an empty list is
             returned.
         :rtype: List[Tuple[str, int]]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return []
 
-        return self.retrieve_scores_ordered_pair_by_id(id)
+        return self.retrieve_scores_ordered_pair_by_id(id_)

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -46,7 +46,8 @@ class PanelistScores:
 
         :param id: Panelist ID
         :type id: int
-        :return: List containing panelist scores
+        :return: List containing panelist scores. If panelist scores
+            could not be retrieved, an empty list is returned.
         :rtype: List[int]
         """
         scores = []
@@ -59,6 +60,9 @@ class PanelistScores:
         cursor.execute(query, (id, ))
         result = cursor.fetchall()
         cursor.close()
+
+        if not result:
+            return []
 
         for appearance in result:
             if appearance["panelistscore"]:
@@ -74,12 +78,13 @@ class PanelistScores:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: List containing panelist scores
+        :return: List containing panelist scores. If panelist scores
+            could not be retrieved, an empty list is returned.
         :rtype: List[int]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return []
 
         return self.retrieve_scores_by_id(id)
 
@@ -92,7 +97,9 @@ class PanelistScores:
         :param id: Panelist ID
         :type id: int
         :return: Dictionary containing two lists, one containing scores
-            and one containing counts of those scores
+            and one containing counts of those scores. If panelist
+            scores could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, List[int]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -104,7 +111,7 @@ class PanelistScores:
         result = cursor.fetchone()
 
         if not result:
-            return None
+            return {}
 
         min_score = result["min"]
         max_score = result["max"]
@@ -128,7 +135,7 @@ class PanelistScores:
         cursor.close()
 
         if not results:
-            return None
+            return {}
 
         for row in results:
             scores[row["score"]] = row["score_count"]
@@ -149,12 +156,14 @@ class PanelistScores:
         :param slug: Panelist slug string
         :type slug: str
         :return: Dictionary containing two lists, one containing scores
-            and one containing counts of those scores
+            and one containing counts of those scores. If panelist
+            scores could not be retrieved, an empty dictionary is
+            returned.
         :rtype: Dict[str, List[int]]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_scores_grouped_list_by_id(id)
 
@@ -167,7 +176,9 @@ class PanelistScores:
 
         :param id: Panelist ID
         :type id: int
-        :return: List of tuples containing scores and score counts
+        :return: List of tuples containing scores and score counts. If
+            panelist scores could not be retrieved, an empty list is
+            returned.
         :rtype: List[Tuple[int, int]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -178,7 +189,7 @@ class PanelistScores:
         result = cursor.fetchone()
 
         if not result:
-            return None
+            return []
 
         min_score = result["min"]
         max_score = result["max"]
@@ -202,7 +213,7 @@ class PanelistScores:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         for row in results:
             scores[row["score"]] = row["score_count"]
@@ -218,26 +229,30 @@ class PanelistScores:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: List of tuples containing scores and score counts
+        :return: List of tuples containing scores and score counts. If
+            panelist scores could not be retrieved, an empty list is
+            returned.
         :rtype: List[Tuple[int, int]]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return []
 
         return self.retrieve_scores_grouped_ordered_pair_by_id(id)
 
     @lru_cache(typed=True)
     def retrieve_scores_list_by_id(self, id: int,
-                                  ) -> Dict[str, Any]:
+                                  ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist ID.
 
         :param id: Panelist ID
         :type id: int
-        :return: List of tuples containing show dates and scores
-        :rtype: Dict[str, Any]
+        :return: Dictionary containing a list show dates and a list
+            of scores. If panelist scores could not be retrieved, an
+            empty dictionary is returned.
+        :rtype: Dict[str, List]
         """
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showdate, pm.panelistscore "
@@ -252,7 +267,7 @@ class PanelistScores:
         cursor.close()
 
         if not results:
-            return None
+            return {}
 
         show_list = []
         score_list = []
@@ -269,19 +284,21 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_list_by_slug(self, slug: str,
-                                  ) -> Dict[str, Any]:
+                                  ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist slug string.
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: List of tuples containing show dates and scores
-        :rtype: Dict[str, Any]
+        :return: Dictionary containing a list show dates and a list
+            of scores. If panelist scores could not be retrieved, an
+            empty dictionary is returned.
+        :rtype: Dict[str, List]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_scores_list_by_id(id)
 
@@ -293,7 +310,9 @@ class PanelistScores:
 
         :param id: Panelist ID
         :type id: int
-        :return: List of tuples containing show dates and scores
+        :return: List of tuples containing show dates and scores. If
+            panelist scores could not be retrieved, an empty list is
+            returned.
         :rtype: List[Tuple[str, int]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -309,7 +328,7 @@ class PanelistScores:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         scores = []
         for show in results:
@@ -327,11 +346,13 @@ class PanelistScores:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: List of tuples containing show dates and scores
+        :return: List of tuples containing show dates and scores. If
+            panelist scores could not be retrieved, an empty list is
+            returned.
         :rtype: List[Tuple[str, int]]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return []
 
         return self.retrieve_scores_ordered_pair_by_id(id)

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from mysql.connector import connect
 from wwdtm.panelist.utility import PanelistUtility
+from wwdtm.validation import valid_int_id
 
 
 class PanelistScores:
@@ -51,6 +52,9 @@ class PanelistScores:
             could not be retrieved, an empty list is returned.
         :rtype: List[int]
         """
+        if not valid_int_id(panelist_id):
+            return []
+
         scores = []
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showdate, pm.panelistscore "
@@ -103,6 +107,9 @@ class PanelistScores:
             returned.
         :rtype: Dict[str, List[int]]
         """
+        if not valid_int_id(panelist_id):
+            return {}
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT MIN(pm.panelistscore) AS min, "
                  "MAX(pm.panelistscore) AS max "
@@ -182,6 +189,9 @@ class PanelistScores:
             returned.
         :rtype: List[Tuple[int, int]]
         """
+        if not valid_int_id(panelist_id):
+            return []
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT MIN(pm.panelistscore) AS min, "
                  "MAX(pm.panelistscore) AS max "
@@ -255,6 +265,9 @@ class PanelistScores:
             empty dictionary is returned.
         :rtype: Dict[str, List]
         """
+        if not valid_int_id(panelist_id):
+            return {}
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showdate, pm.panelistscore "
                  "FROM ww_showpnlmap pm "
@@ -316,6 +329,9 @@ class PanelistScores:
             returned.
         :rtype: List[Tuple[str, int]]
         """
+        if not valid_int_id(panelist_id):
+            return []
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showdate, pm.panelistscore "
                  "FROM ww_showpnlmap pm "

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Panelist Scores Retrieval Functions
 """
 from functools import lru_cache
@@ -10,6 +10,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from mysql.connector import connect
 from wwdtm.panelist.utility import PanelistUtility
+
 
 class PanelistScores:
     """This class contains functions used to retrieve panelist scores
@@ -72,7 +73,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_by_slug(self, slug: str
-                               ) -> List[int]:
+                                ) -> List[int]:
         """Returns a list of panelist scores for appearances for the
         requested panelist slug string.
 
@@ -90,7 +91,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_id(self, id: int
-                                          ) -> Dict[str, List[int]]:
+                                           ) -> Dict[str, List[int]]:
         """Returns a panelist's score grouping for the requested
         panelist ID.
 
@@ -149,7 +150,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_slug(self, slug: str
-                                            ) -> Dict[str, List[int]]:
+                                             ) -> Dict[str, List[int]]:
         """Returns a panelist's score grouping for the requested
         panelist slug string.
 
@@ -169,7 +170,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_id(self, id: int
-                                                  ) -> List[Tuple[int, int]]:
+                                                   ) -> List[Tuple[int, int]]:
         """Returns an list of tuples containing a score and the
         corresponding number of instances a panelist has scored that amount
         for the requested panelist ID.
@@ -222,7 +223,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_slug(self, slug: str,
-                                                    ) -> List[Tuple[int, int]]:
+                                                     ) -> List[Tuple[int, int]]:
         """Returns an list of tuples containing a score and the
         corresponding number of instances a panelist has scored that amount
         for the requested panelist slug string.
@@ -242,7 +243,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_list_by_id(self, id: int,
-                                  ) -> Dict[str, List]:
+                                   ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist ID.
@@ -284,7 +285,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_list_by_slug(self, slug: str,
-                                  ) -> Dict[str, List]:
+                                     ) -> Dict[str, List]:
         """Returns a dictionary containing two lists, one with show
         dates and one with corresponding scores for the requested
         panelist slug string.
@@ -304,7 +305,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_id(self, id: int
-                                          ) -> List[Tuple[str, int]]:
+                                           ) -> List[Tuple[str, int]]:
         """Returns an list of tuples containing a show date and the
         corresponding score for the requested panelist ID.
 
@@ -340,7 +341,7 @@ class PanelistScores:
 
     @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_slug(self, slug: str,
-                                            ) -> List[Tuple[str, int]]:
+                                             ) -> List[Tuple[str, int]]:
         """Returns an list of tuples containing a show date and the
         corresponding score for the requested panelist slug string.
 

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -12,6 +12,7 @@ from mysql.connector import connect
 import numpy
 from wwdtm.panelist.scores import PanelistScores
 from wwdtm.panelist.utility import PanelistUtility
+from wwdtm.validation import valid_int_id
 
 
 class PanelistStatistics:
@@ -110,6 +111,9 @@ class PanelistStatistics:
             dictionary will be returned.
         :rtype: Dict[str, int]
         """
+        if not valid_int_id(panelist_id):
+            return {}
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
@@ -181,6 +185,9 @@ class PanelistStatistics:
             be returned.
         :rtype: Dict[str, Any]
         """
+        if not valid_int_id(panelist_id):
+            return {}
+
         score_data = self.scores.retrieve_scores_by_id(panelist_id)
         ranks = self.retrieve_rank_info_by_id(panelist_id)
 

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Panelist Statistics Retrieval Functions
 """
 from functools import lru_cache
@@ -12,6 +12,7 @@ from mysql.connector import connect
 import numpy
 from wwdtm.panelist.scores import PanelistScores
 from wwdtm.panelist.utility import PanelistUtility
+
 
 class PanelistStatistics:
     """This class contains functions used to retrieve data from a copy

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -50,7 +50,9 @@ class PanelistStatistics:
 
         :param id: Panelist ID
         :type id: int
-        :return: Dictionary containing panelist Bluff counts
+        :return: Dictionary containing panelist Bluff counts. If
+            panelist Bluff counts could not be returned, an empty
+            dictionary will be returned.
         :rtype: Dict[str, int]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -68,7 +70,7 @@ class PanelistStatistics:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         bluffs = {
             "chosen": result["chosen"],
@@ -84,12 +86,14 @@ class PanelistStatistics:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: Dictionary containing panelist Bluff counts
+        :return: Dictionary containing panelist Bluff counts. If
+            panelist Bluff counts could not be returned, an empty
+            dictionary will be returned.
         :rtype: Dict[str, int]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_bluffs_by_id(id)
 
@@ -100,7 +104,9 @@ class PanelistStatistics:
 
         :param id: Panelist ID
         :type id: int
-        :return: Dictionary containing panelist ranking information
+        :return: Dictionary containing panelist ranking information. If
+            panelist ranking information could not be returned, an empty
+            dictionary will be returned.
         :rtype: Dict[str, int]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -130,6 +136,9 @@ class PanelistStatistics:
         result = cursor.fetchone()
         cursor.close()
 
+        if not result:
+            return {}
+
         rank_info = {
             "first": result["1"],
             "first_tied":  result["1t"],
@@ -147,12 +156,14 @@ class PanelistStatistics:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: Dictionary containing panelist ranking information
+        :return: Dictionary containing panelist ranking information. If
+            panelist ranking information could not be returned, an empty
+            dictionary will be returned.
         :rtype: Dict[str, int]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_rank_info_by_id(id)
 
@@ -163,14 +174,16 @@ class PanelistStatistics:
 
         :param id: Panelist ID
         :type id: int
-        :return: Dictionary containing panelist statistics
+        :return: Dictionary containing panelist statistics. If panelist
+            statistics could not be returned, an empty dictionary will
+            be returned.
         :rtype: Dict[str, Any]
         """
         score_data = self.scores.retrieve_scores_by_id(id)
         ranks = self.retrieve_rank_info_by_id(id)
 
         if not score_data or not ranks:
-            return None
+            return {}
 
         appearance_count = len(score_data)
         scoring = {
@@ -215,11 +228,13 @@ class PanelistStatistics:
 
         :param slug: Panelist slug string
         :type slug: str
-        :return: Dictionary containing panelist statistics
+        :return: Dictionary containing panelist statistics. If panelist
+            statistics could not be returned, an empty dictionary will
+            be returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_statistics_by_id(id)

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -45,12 +45,12 @@ class PanelistStatistics:
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_bluffs_by_id(self, id: int) -> Dict[str, int]:
+    def retrieve_bluffs_by_id(self, panelist_id: int) -> Dict[str, int]:
         """Returns a dictionary containing the number of chosen Bluffs
         and correct Bluffs for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing panelist Bluff counts. If
             panelist Bluff counts could not be returned, an empty
             dictionary will be returned.
@@ -66,7 +66,7 @@ class PanelistStatistics:
                  "JOIN ww_shows s ON s.showid = blm.showid "
                  "WHERE s.repeatshowid IS NULL AND blm.correctbluffpnlid = %s "
                  ") AS correct;")
-        cursor.execute(query, (id, id, ))
+        cursor.execute(query, (panelist_id, panelist_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -81,30 +81,30 @@ class PanelistStatistics:
         return bluffs
 
     @lru_cache(typed=True)
-    def retrieve_bluffs_by_slug(self, slug: str) -> Dict[str, int]:
+    def retrieve_bluffs_by_slug(self, panelist_slug: str) -> Dict[str, int]:
         """Returns a dictionary containing the number of chosen Bluffs
         and correct Bluffs for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing panelist Bluff counts. If
             panelist Bluff counts could not be returned, an empty
             dictionary will be returned.
         :rtype: Dict[str, int]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_bluffs_by_id(id)
+        return self.retrieve_bluffs_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_rank_info_by_id(self, id: int) -> Dict[str, int]:
+    def retrieve_rank_info_by_id(self, panelist_id: int) -> Dict[str, int]:
         """Returns a dictionary with ranking information for the
         requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing panelist ranking information. If
             panelist ranking information could not be returned, an empty
             dictionary will be returned.
@@ -133,7 +133,8 @@ class PanelistStatistics:
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '3' AND "
                  "s.bestof = 0 and s.repeatshowid IS NULL "
                  ") as '3';")
-        cursor.execute(query, (id, id, id, id, id, ))
+        cursor.execute(query, (panelist_id, panelist_id, panelist_id,
+                               panelist_id, panelist_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -151,37 +152,37 @@ class PanelistStatistics:
         return rank_info
 
     @lru_cache(typed=True)
-    def retrieve_rank_info_by_slug(self, slug: str) -> Dict[str, int]:
+    def retrieve_rank_info_by_slug(self, panelist_slug: str) -> Dict[str, int]:
         """Returns a dictionary with ranking information for the
         requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing panelist ranking information. If
             panelist ranking information could not be returned, an empty
             dictionary will be returned.
         :rtype: Dict[str, int]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_rank_info_by_id(id)
+        return self.retrieve_rank_info_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_statistics_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_statistics_by_id(self, panelist_id: int) -> Dict[str, Any]:
         """Returns a dictionary containing panelist statistics, ranking
         data, and scoring data for the requested panelist ID.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Dictionary containing panelist statistics. If panelist
             statistics could not be returned, an empty dictionary will
             be returned.
         :rtype: Dict[str, Any]
         """
-        score_data = self.scores.retrieve_scores_by_id(id)
-        ranks = self.retrieve_rank_info_by_id(id)
+        score_data = self.scores.retrieve_scores_by_id(panelist_id)
+        ranks = self.retrieve_rank_info_by_id(panelist_id)
 
         if not score_data or not ranks:
             return {}
@@ -223,19 +224,19 @@ class PanelistStatistics:
         return statistics
 
     @lru_cache(typed=True)
-    def retrieve_statistics_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_statistics_by_slug(self, panelist_slug: str) -> Dict[str, Any]:
         """Returns a dictionary containing panelist statistics, ranking
         data, and scoring data for the requested panelist slug string.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Dictionary containing panelist statistics. If panelist
             statistics could not be returned, an empty dictionary will
             be returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(panelist_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_statistics_by_id(id)
+        return self.retrieve_statistics_by_id(id_)

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -2,13 +2,14 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Panelist Data Utility Functions
 """
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+
 
 class PanelistUtility:
     """This class contains supporting functions used to check whether
@@ -38,7 +39,7 @@ class PanelistUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> str:
+    def convert_id_to_slug(self, id: int) -> Optional[str]:
         """Converts a panelist's ID to the matching panelist slug
         string value.
 
@@ -66,8 +67,9 @@ class PanelistUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> int:
-        """Converts a panelist's slug string to the matching panelist ID value.
+    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+        """Converts a panelist's slug string to the matching panelist ID
+        value.
 
         :param slug: Panelist slug string
         :type slug: str

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -39,17 +39,17 @@ class PanelistUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> Optional[str]:
+    def convert_id_to_slug(self, panelist_id: int) -> Optional[str]:
         """Converts a panelist's ID to the matching panelist slug
         string value.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: Panelist slug string, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(panelist_id)
         except ValueError:
             return None
 
@@ -57,7 +57,7 @@ class PanelistUtility:
         query = ("SELECT panelistslug FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -67,17 +67,17 @@ class PanelistUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+    def convert_slug_to_id(self, panelist_slug: str) -> Optional[int]:
         """Converts a panelist's slug string to the matching panelist ID
         value.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: Panelists ID, if a match is found
         :rtype: int
         """
         try:
-            slug = slug.strip()
+            slug = panelist_slug.strip()
             if not slug:
                 return None
         except ValueError:
@@ -97,16 +97,16 @@ class PanelistUtility:
         return None
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, panelist_id: int) -> bool:
         """Checks to see if a panelist ID exists.
 
-        :param id: Panelist ID
-        :type id: int
+        :param panelist_id: Panelist ID
+        :type panelist_id: int
         :return: True or False, based on whether the panelist ID exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(panelist_id)
         except ValueError:
             return False
 
@@ -114,24 +114,24 @@ class PanelistUtility:
         query = ("SELECT panelistid FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         return bool(result)
 
     @lru_cache(typed=True)
-    def slug_exists(self, slug: str) -> bool:
+    def slug_exists(self, panelist_slug: str) -> bool:
         """Checks to see if a panelist slug string exists.
 
-        :param slug: Panelist slug string
-        :type slug: str
+        :param panelist_slug: Panelist slug string
+        :type panelist_slug: str
         :return: True or False, based on whether the panelist slug
             string exists
         :rtype: bool
         """
         try:
-            slug = slug.strip()
+            slug = panelist_slug.strip()
             if not slug:
                 return False
         except ValueError:

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+from wwdtm.validation import valid_int_id
 
 
 class PanelistUtility:
@@ -48,16 +49,14 @@ class PanelistUtility:
         :return: Panelist slug string, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(panelist_id)
-        except ValueError:
+        if not valid_int_id(panelist_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT panelistslug FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (panelist_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -105,16 +104,14 @@ class PanelistUtility:
         :return: True or False, based on whether the panelist ID exists
         :rtype: bool
         """
-        try:
-            id_ = int(panelist_id)
-        except ValueError:
+        if not valid_int_id(panelist_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT panelistid FROM ww_panelists "
                  "WHERE panelistid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (panelist_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/scorekeeper/__init__.py
+++ b/wwdtm/scorekeeper/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Scorekeeper module
 """
 from wwdtm.scorekeeper.appearances import ScorekeeperAppearances

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
+from wwdtm.validation import valid_int_id
 
 
 class ScorekeeperAppearances:
@@ -54,9 +55,7 @@ class ScorekeeperAppearances:
             returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(scorekeeper_id)
-        except ValueError:
+        if not valid_int_id(scorekeeper_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -68,7 +67,7 @@ class ScorekeeperAppearances:
                  "SELECT COUNT(skm.showid) FROM ww_showskmap skm "
                  "JOIN ww_shows s ON s.showid = skm.showid "
                  "WHERE skm.scorekeeperid = %s ) AS all_shows;")
-        cursor.execute(query, (id_, id_, ))
+        cursor.execute(query, (scorekeeper_id, scorekeeper_id, ))
         result = cursor.fetchone()
 
         if result:
@@ -90,7 +89,7 @@ class ScorekeeperAppearances:
                  "JOIN ww_shows s ON s.showid = skm.showid "
                  "WHERE sk.scorekeeperid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (scorekeeper_id, ))
         results = cursor.fetchall()
         cursor.close()
 

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -42,12 +42,12 @@ class ScorekeeperAppearances:
         self.utility = ScorekeeperUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_appearances_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested scorekeeper ID.
 
-        :param id: Scorekeeper ID
-        :type id: int
+        :param scorekeeper_id: Scorekeeper ID
+        :type scorekeeper_id: int
         :return: Dictionary containing appearance counts and list of
             appearances for a scorekeeper. If scorekeeper appearances
             could not be retrieved, an empty dictionary would be
@@ -55,7 +55,7 @@ class ScorekeeperAppearances:
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(scorekeeper_id)
         except ValueError:
             return {}
 
@@ -68,7 +68,7 @@ class ScorekeeperAppearances:
                  "SELECT COUNT(skm.showid) FROM ww_showskmap skm "
                  "JOIN ww_shows s ON s.showid = skm.showid "
                  "WHERE skm.scorekeeperid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id, ))
+        cursor.execute(query, (id_, id_, ))
         result = cursor.fetchone()
 
         if result:
@@ -90,7 +90,7 @@ class ScorekeeperAppearances:
                  "JOIN ww_shows s ON s.showid = skm.showid "
                  "WHERE sk.scorekeeperid = %s "
                  "ORDER BY s.showdate ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         results = cursor.fetchall()
         cursor.close()
 
@@ -121,20 +121,20 @@ class ScorekeeperAppearances:
         return appearance_info
 
     @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_appearances_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing appearance
         information for the requested scorekeeper ID.
 
-        :param slug: Scorekeeper slug string
-        :type slug: str
+        :param scorekeeper_slug: Scorekeeper slug string
+        :type scorekeeper_slug: str
         :return: Dictionary containing appearance counts and list of
             appearances for a scorekeeper. If scorekeeper appearances
             could not be retrieved, an empty dictionary would be
             returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(scorekeeper_slug)
+        if not id_:
             return {}
 
-        return self.retrieve_appearances_by_id(id)
+        return self.retrieve_appearances_by_id(id_)

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -48,13 +48,15 @@ class ScorekeeperAppearances:
         :param id: Scorekeeper ID
         :type id: int
         :return: Dictionary containing appearance counts and list of
-            appearances for a scorekeeper
+            appearances for a scorekeeper. If scorekeeper appearances
+            could not be retrieved, an empty dictionary would be
+            returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT ( "
@@ -125,11 +127,13 @@ class ScorekeeperAppearances:
         :param slug: Scorekeeper slug string
         :type slug: str
         :return: Dictionary containing appearance counts and list of
-            appearances for a scorekeeper
+            appearances for a scorekeeper. If scorekeeper appearances
+            could not be retrieved, an empty dictionary would be
+            returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_appearances_by_id(id)

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Scorekeeper Appearance Retrieval
 Functions
 """
@@ -11,6 +11,7 @@ from typing import Any, Dict, Optional
 
 from mysql.connector import connect
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
+
 
 class ScorekeeperAppearances:
     """This class contains functions that retrieve scorekeeper
@@ -67,7 +68,7 @@ class ScorekeeperAppearances:
                  "SELECT COUNT(skm.showid) FROM ww_showskmap skm "
                  "JOIN ww_shows s ON s.showid = skm.showid "
                  "WHERE skm.scorekeeperid = %s ) AS all_shows;")
-        cursor.execute(query, (id, id ,))
+        cursor.execute(query, (id, id, ))
         result = cursor.fetchone()
 
         if result:

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Scorekeeper Data Retrieval Functions
 """
 from functools import lru_cache
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
+
 
 class Scorekeeper:
     """This class contains functions used to retrieve scorekeeper data

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -47,7 +47,8 @@ class Scorekeeper:
         ID, name and slug string for all scorekeepers.
 
         :return: List of all scorekeepers and their corresponding
-            information
+            information. If scorekeeper information could not be
+            retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -61,7 +62,7 @@ class Scorekeeper:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         scorekeepers = []
         for row in results:
@@ -82,7 +83,8 @@ class Scorekeeper:
         scorekeepers.
 
         :return: List of all scorekeepers and their corresponding
-            information and appearances
+            information and appearances. If scorekeeper information
+            could not be retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -96,7 +98,7 @@ class Scorekeeper:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         scorekeepers = []
         for row in results:
@@ -117,7 +119,8 @@ class Scorekeeper:
         """Returns a list of all scorekeeper IDs from the database,
         sorted by scorekeeper name.
 
-        :return: List of all scorekeeper IDs
+        :return: List of all scorekeeper IDs. If scorekeeper IDs could
+            not be retrieved, an empty list would be returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -129,7 +132,7 @@ class Scorekeeper:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -141,7 +144,9 @@ class Scorekeeper:
         """Returns a list of all scorekeeper slug strings from the
         database, sorted by scorekeeper name.
 
-        :return: List of all scorekeeper slug strings
+        :return: List of all scorekeeper slug strings. If scorekeeper
+            slug strings could not be retrieved, an empty list will be
+            returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -153,7 +158,7 @@ class Scorekeeper:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -168,13 +173,15 @@ class Scorekeeper:
 
         :param id: Scorekeeper ID
         :type id: int
-        :return: Dictionary containing scorekeeper information
+        :return: Dictionary containing scorekeeper information. If
+            scorekeeper information could not be retrieved, an empty
+            dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT scorekeeperid AS id, scorekeeper, "
@@ -187,7 +194,7 @@ class Scorekeeper:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         info = {
             "id": result["id"],
@@ -205,19 +212,21 @@ class Scorekeeper:
 
         :param slug: Scorekeeper slug string
         :type slug: str
-        :return: Dictionary containing scorekeeper information
+        :return: Dictionary containing scorekeeper information. If
+            scorekeeper information could not be retrieved, an empty
+            dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -230,17 +239,18 @@ class Scorekeeper:
         :param id: Scorekeeper ID
         :type id: int
         :return: Dictionary containing scorekeeper information and
-            their appearances
+            their appearances. If scorekeeper information could not be
+            retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.retrieve_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
 
@@ -255,18 +265,19 @@ class Scorekeeper:
         :param slug: Scorekeeper slug string
         :type slug: str
         :return: Dictionary containing scorekeeper information and
-            their appearances
+            their appearances. If scorekeeper information could not be
+            retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             slug = slug.strip()
             if not slug:
-                return False
+                return {}
         except AttributeError:
-            return False
+            return {}
 
         id = self.utility.convert_slug_to_id(slug)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -12,6 +12,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
+from wwdtm.validation import valid_int_id
 
 
 class Scorekeeper:
@@ -179,9 +180,7 @@ class Scorekeeper:
             dictionary will be returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(scorekeeper_id)
-        except ValueError:
+        if not valid_int_id(scorekeeper_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -190,7 +189,7 @@ class Scorekeeper:
                  "FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (scorekeeper_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -244,16 +243,14 @@ class Scorekeeper:
             retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(scorekeeper_id)
-        except ValueError:
+        if not valid_int_id(scorekeeper_id):
             return {}
 
-        info = self.retrieve_by_id(id_)
+        info = self.retrieve_by_id(scorekeeper_id)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(scorekeeper_id)
 
         return info
 

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -168,19 +168,19 @@ class Scorekeeper:
         return ids
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing scorekeeper ID, name
         and slug string for the requested scorekeeper ID.
 
-        :param id: Scorekeeper ID
-        :type id: int
+        :param scorekeeper_id: Scorekeeper ID
+        :type scorekeeper_id: int
         :return: Dictionary containing scorekeeper information. If
             scorekeeper information could not be retrieved, an empty
             dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(scorekeeper_id)
         except ValueError:
             return {}
 
@@ -190,7 +190,7 @@ class Scorekeeper:
                  "FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -207,78 +207,78 @@ class Scorekeeper:
         return info
 
     @lru_cache(typed=True)
-    def retrieve_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing scorekeeper ID, name
         and slug string for the requested scorekeeper slug string.
 
-        :param slug: Scorekeeper slug string
-        :type slug: str
+        :param scorekeeper_slug: Scorekeeper slug string
+        :type scorekeeper_slug: str
         :return: Dictionary containing scorekeeper information. If
             scorekeeper information could not be retrieved, an empty
             dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = scorekeeper_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing scorekeeper ID, name,
         slug string and appearance information for the requested
         scorekeeper ID.
 
-        :param id: Scorekeeper ID
-        :type id: int
+        :param scorekeeper_id: Scorekeeper ID
+        :type scorekeeper_id: int
         :return: Dictionary containing scorekeeper information and
             their appearances. If scorekeeper information could not be
             retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(scorekeeper_id)
         except ValueError:
             return {}
 
-        info = self.retrieve_by_id(id)
+        info = self.retrieve_by_id(id_)
         if not info:
             return {}
 
-        info["appearances"] = self.appearances.retrieve_appearances_by_id(id)
+        info["appearances"] = self.appearances.retrieve_appearances_by_id(id_)
 
         return info
 
     @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, slug: str) -> Dict[str, Any]:
+    def retrieve_details_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
         """Returns a dictionary object containing scorekeeper ID, name,
         slug string and appearance information for the requested
         scorekeeper slug string.
 
-        :param slug: Scorekeeper slug string
-        :type slug: str
+        :param scorekeeper_slug: Scorekeeper slug string
+        :type scorekeeper_slug: str
         :return: Dictionary containing scorekeeper information and
             their appearances. If scorekeeper information could not be
             retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            slug = slug.strip()
+            slug = scorekeeper_slug.strip()
             if not slug:
                 return {}
         except AttributeError:
             return {}
 
-        id = self.utility.convert_slug_to_id(slug)
-        if not id:
+        id_ = self.utility.convert_slug_to_id(slug)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -9,6 +9,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+from wwdtm.validation import valid_int_id
 
 
 class ScorekeeperUtility:
@@ -48,16 +49,14 @@ class ScorekeeperUtility:
         :return: Scorekeeper slug string, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(scorekeeper_id)
-        except ValueError:
+        if not valid_int_id(scorekeeper_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperslug FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (scorekeeper_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -106,16 +105,14 @@ class ScorekeeperUtility:
             exists
         :rtype: bool
         """
-        try:
-            id_ = int(scorekeeper_id)
-        except ValueError:
+        if not valid_int_id(scorekeeper_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperid FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (scorekeeper_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -2,13 +2,14 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Scorekeeper Data Utility Functions
 """
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+
 
 class ScorekeeperUtility:
     """This class contains supporting functions used to check whether
@@ -38,7 +39,7 @@ class ScorekeeperUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> str:
+    def convert_id_to_slug(self, id: int) -> Optional[str]:
         """Converts a scorekeeper's ID to the matching scorekeeper slug
         string value.
 
@@ -66,7 +67,7 @@ class ScorekeeperUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> int:
+    def convert_slug_to_id(self, slug: str) -> Optional[int]:
         """Converts a scorekeeper's slug string to the matching
         scorekeeper ID value.
 

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -39,17 +39,17 @@ class ScorekeeperUtility:
             self.database_connection = database_connection
 
     @lru_cache(typed=True)
-    def convert_id_to_slug(self, id: int) -> Optional[str]:
+    def convert_id_to_slug(self, scorekeeper_id: int) -> Optional[str]:
         """Converts a scorekeeper's ID to the matching scorekeeper slug
         string value.
 
-        :param id: Scorekeeper ID
-        :type id: int
+        :param scorekeeper_id: Scorekeeper ID
+        :type scorekeeper_id: int
         :return: Scorekeeper slug string, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(scorekeeper_id)
         except ValueError:
             return None
 
@@ -57,7 +57,7 @@ class ScorekeeperUtility:
         query = ("SELECT scorekeeperslug FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -67,17 +67,17 @@ class ScorekeeperUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_slug_to_id(self, slug: str) -> Optional[int]:
+    def convert_slug_to_id(self, scorekeeper_slug: str) -> Optional[int]:
         """Converts a scorekeeper's slug string to the matching
         scorekeeper ID value.
 
-        :param slug: Scorekeeper slug string
-        :type slug: str
+        :param scorekeeper_slug: Scorekeeper slug string
+        :type scorekeeper_slug: str
         :return: Scorekeeper ID, if a match is found
         :rtype: int
         """
         try:
-            slug = slug.strip()
+            slug = scorekeeper_slug.strip()
             if not slug:
                 return None
         except ValueError:
@@ -97,17 +97,17 @@ class ScorekeeperUtility:
         return None
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, scorekeeper_id: int) -> bool:
         """Checks to see if a scorekeeper ID exists.
 
-        :param id: Scorekeeper ID
-        :type id: int
+        :param scorekeeper_id: Scorekeeper ID
+        :type scorekeeper_id: int
         :return: True or False, based on whether the scorekeeper ID
             exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(scorekeeper_id)
         except ValueError:
             return False
 
@@ -115,24 +115,24 @@ class ScorekeeperUtility:
         query = ("SELECT scorekeeperid FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
         return bool(result)
 
     @lru_cache(typed=True)
-    def slug_exists(self, slug: str) -> bool:
+    def slug_exists(self, scorekeeper_slug: str) -> bool:
         """Checks to see if a scorekeeper slug string exists.
 
-        :param slug: Scorekeeper slug string
-        :type slug: str
+        :param scorekeeper_slug: Scorekeeper slug string
+        :type scorekeeper_slug: str
         :return: True or False, based on whether the scorekeeper slug
             string exists
         :rtype: bool
         """
         try:
-            slug = slug.strip()
+            slug = scorekeeper_slug.strip()
             if not slug:
                 return False
         except ValueError:

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Show module
 """
 from wwdtm.show.info import ShowInfo

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Supplemental Show Information
 Retrieval Functions
 """
@@ -10,10 +10,10 @@ from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
 from mysql.connector import connect
-from mysql.connector.errors import DatabaseError, ProgrammingError
 from slugify import slugify
 from wwdtm.show.utility import ShowUtility
 from wwdtm.location.location import LocationUtility
+
 
 class ShowInfo:
     """This class contains functions that retrieve show supplemental

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -249,8 +249,8 @@ class ShowInfo:
                 "id": guest["id"],
                 "name": guest["name"],
                 "slug": guest["slug"] if guest["slug"] else slugify(guest["name"]),
-                "score": guest["score"],
-                "score_exception": guest["score_exception"],
+                "score": guest["score"] if guest["score"] else None,
+                "score_exception": bool(guest["score_exception"]),
             }
 
             guests.append(info)
@@ -295,10 +295,10 @@ class ShowInfo:
                 "id": row["id"],
                 "name": row["name"],
                 "slug": row["slug"] if row["slug"] else slugify(row["name"]),
-                "lightning_round_start": row["start"],
-                "lightning_round_correct": row["correct"],
-                "score": row["score"],
-                "rank": row["rank"],
+                "lightning_round_start": row["start"] if row["start"] else None,
+                "lightning_round_correct": row["correct"] if row["correct"] else None,
+                "score": row["score"] if row["score"] else None,
+                "rank": row["rank"] if row["rank"] else None,
             }
 
             panelists.append(info)

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -53,7 +53,7 @@ class ShowInfo:
         :param id: Show ID
         :type id: int
         :return: Dictionary containing correct and chosen Bluff the
-            Listener information
+            Listener information.
         :rtype: Dict[str, Any]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -111,7 +111,8 @@ class ShowInfo:
         :param id: Show ID
         :type id: int
         :return: Dictionary containing host, scorekeeper, location,
-            description and notes
+            description and notes. If show core information could not be
+            retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -138,7 +139,7 @@ class ShowInfo:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         location_info = {
             "id": result["locationid"],
@@ -211,7 +212,9 @@ class ShowInfo:
 
         :param id: Show ID
         :type id: int
-        :return: Dictionary containing Not My Job guest information
+        :return: Dictionary containing Not My Job guest information. If
+            Not My Job information could not be retrieved, an empty list
+            will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -228,7 +231,7 @@ class ShowInfo:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         guests = []
         for guest in result:
@@ -252,7 +255,8 @@ class ShowInfo:
         :param id: Show ID
         :type id: int
         :return: List of panelists with corresponding scores and
-            ranking information
+            ranking information. If panelist information could not be
+            retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -270,7 +274,7 @@ class ShowInfo:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         panelists = []
         for row in result:

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -46,12 +46,12 @@ class ShowInfo:
         self.loc_util = LocationUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
-    def retrieve_bluff_info_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_bluff_info_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a dictionary containing Bluff the Listener information
         for the requested show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Dictionary containing correct and chosen Bluff the
             Listener information.
         :rtype: Dict[str, Any]
@@ -64,7 +64,7 @@ class ShowInfo:
                  "JOIN ww_panelists p ON "
                  "p.panelistid = blm.chosenbluffpnlid "
                  "WHERE s.showid = %s;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (show_id, ))
         chosen_result = cursor.fetchone()
 
         if chosen_result:
@@ -83,7 +83,7 @@ class ShowInfo:
                  "JOIN ww_panelists p ON "
                  "p.panelistid = blm.correctbluffpnlid "
                  "WHERE s.showid = %s;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (show_id, ))
         correct_result = cursor.fetchone()
         cursor.close()
 
@@ -104,12 +104,12 @@ class ShowInfo:
         return bluff_info
 
     @lru_cache(typed=True)
-    def retrieve_core_info_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_core_info_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a dictionary with core information for the requested
         show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Dictionary containing host, scorekeeper, location,
             description and notes. If show core information could not be
             retrieved, an empty dictionary will be returned.
@@ -134,7 +134,7 @@ class ShowInfo:
                  "JOIN ww_showdescriptions sd ON sd.showid = s.showid "
                  "JOIN ww_shownotes sn ON sn.showid = s.showid "
                  "WHERE s.showid = %s;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -150,7 +150,7 @@ class ShowInfo:
         }
 
         if not result["locationslug"]:
-            location_info["slug"] = self.loc_util.slugify_location(id=result["locationid"],
+            location_info["slug"] = self.loc_util.slugify_location(location_id=result["locationid"],
                                                                    venue=result["venue"],
                                                                    city=result["city"],
                                                                    state=result["state"])
@@ -181,7 +181,7 @@ class ShowInfo:
             notes = None
 
         show_info = {
-            "id": id,
+            "id": show_id,
             "date": result["showdate"].isoformat(),
             "best_of": bool(result["bestof"]),
             "repeat_show": bool(result["repeatshowid"]),
@@ -206,12 +206,12 @@ class ShowInfo:
         return show_info
 
     @lru_cache(typed=True)
-    def retrieve_guest_info_by_id(self, id: int) -> List[Dict[str, Any]]:
+    def retrieve_guest_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing Not My Job
         guest information for the requested show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Dictionary containing Not My Job guest information. If
             Not My Job information could not be retrieved, an empty list
             will be returned.
@@ -226,7 +226,7 @@ class ShowInfo:
                  "JOIN ww_shows s on s.showid = gm.showid "
                  "WHERE gm.showid = %s "
                  "ORDER by gm.showguestmapid ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchall()
         cursor.close()
 
@@ -248,12 +248,12 @@ class ShowInfo:
         return guests
 
     @lru_cache(typed=True)
-    def retrieve_panelist_info_by_id(self, id: int) -> List[Dict[str, Any]]:
+    def retrieve_panelist_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing panelist
         information for the requested show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: List of panelists with corresponding scores and
             ranking information. If panelist information could not be
             retrieved, an empty list will be returned.
@@ -269,7 +269,7 @@ class ShowInfo:
                  "JOIN ww_panelists p on p.panelistid = pm.panelistid "
                  "WHERE pm.showid = %s "
                  "ORDER by pm.panelistscore DESC, pm.showpnlmapid ASC;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchall()
         cursor.close()
 

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -13,6 +13,7 @@ from mysql.connector import connect
 from slugify import slugify
 from wwdtm.show.utility import ShowUtility
 from wwdtm.location.location import LocationUtility
+from wwdtm.validation import valid_int_id
 
 
 class ShowInfo:
@@ -56,6 +57,9 @@ class ShowInfo:
             Listener information.
         :rtype: Dict[str, Any]
         """
+        if not valid_int_id(show_id):
+            return {}
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT blm.chosenbluffpnlid AS id, "
                  "p.panelist AS name, p.panelistslug As slug "
@@ -115,6 +119,9 @@ class ShowInfo:
             retrieved, an empty dictionary will be returned.
         :rtype: Dict[str, Any]
         """
+        if not valid_int_id(show_id):
+            return {}
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showid, s.showdate, s.bestof, "
                  "s.repeatshowid, l.locationid, l.city, l.state, "
@@ -217,6 +224,9 @@ class ShowInfo:
             will be returned.
         :rtype: List[Dict[str, Any]]
         """
+        if not valid_int_id(show_id):
+            return []
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT gm.guestid AS id, g.guest AS name, "
                  "g.guestslug AS slug, gm.guestscore AS score, "
@@ -259,6 +269,9 @@ class ShowInfo:
             retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
+        if not valid_int_id(show_id):
+            return []
+
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT pm.panelistid AS id, p.panelist AS name, "
                  "p.panelistslug AS slug, "

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from mysql.connector import connect
 from wwdtm.show.info import ShowInfo
 from wwdtm.show.utility import ShowUtility
+from wwdtm.validation import valid_int_id
 
 
 class Show:
@@ -304,9 +305,7 @@ class Show:
             be returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(show_id)
-        except ValueError:
+        if not valid_int_id(show_id):
             return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
@@ -315,7 +314,7 @@ class Show:
                  "FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -476,18 +475,16 @@ class Show:
             will be returned.
         :rtype: Dict[str, Any]
         """
-        try:
-            id_ = int(show_id)
-        except ValueError:
+        if not valid_int_id(show_id):
             return {}
 
-        info = self.info.retrieve_core_info_by_id(id_)
+        info = self.info.retrieve_core_info_by_id(show_id)
         if not info:
             return {}
 
-        info["panelists"] = self.info.retrieve_panelist_info_by_id(id_)
-        info["bluff"] = self.info.retrieve_bluff_info_by_id(id_)
-        info["guests"] = self.info.retrieve_guest_info_by_id(id_)
+        info["panelists"] = self.info.retrieve_panelist_info_by_id(show_id)
+        info["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
+        info["guests"] = self.info.retrieve_guest_info_by_id(show_id)
 
         return info
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Show Data Retrieval Functions
 """
 import datetime
@@ -13,6 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from mysql.connector import connect
 from wwdtm.show.info import ShowInfo
 from wwdtm.show.utility import ShowUtility
+
 
 class Show:
     """This class contains functions used to retrieve show data from a
@@ -549,9 +550,9 @@ class Show:
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
-                "WHERE YEAR(showdate) = %s "
-                "AND MONTH(showdate) = %s "
-                "ORDER BY showdate ASC;")
+                 "WHERE YEAR(showdate) = %s "
+                 "AND MONTH(showdate) = %s "
+                 "ORDER BY showdate ASC;")
         cursor.execute(query, (parsed_year_month.year,
                                parsed_year_month.month, ))
         result = cursor.fetchall()
@@ -653,7 +654,7 @@ class Show:
     def retrieve_recent_details(self,
                                 include_days_ahead: int = 7,
                                 include_days_back: int = 32
-                               ) -> List[Dict[str, Any]]:
+                                ) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing show ID,
         show date, host, scorekeeper, panelist and guest information
         for recent shows.
@@ -683,8 +684,8 @@ class Show:
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
-                "WHERE showdate >= %s AND "
-                "showdate <= %s ORDER BY showdate ASC;")
+                 "WHERE showdate >= %s AND "
+                 "showdate <= %s ORDER BY showdate ASC;")
         cursor.execute(query, (past_date.isoformat(),
                                future_date.isoformat(), ))
         result = cursor.fetchall()
@@ -700,7 +701,7 @@ class Show:
         return shows
 
     @lru_cache(typed=True)
-    def retrieve_scores_by_year(self, year: int) -> List[Tuple[str, int, int, int]]:
+    def retrieve_scores_by_year(self, year: int) -> List[Tuple]: #List[Tuple[str, int, int, int]]:
         """Returns a list of tuples containing panelist scores for all
         shows in the requested year, sorted by show date.
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -105,12 +105,12 @@ class Show:
 
         shows = []
         for row in results:
-            id = row["id"]
-            info = self.info.retrieve_core_info_by_id(id)
+            id_ = row["id"]
+            info = self.info.retrieve_core_info_by_id(id_)
             if info:
-                info["panelists"] = self.info.retrieve_panelist_info_by_id(id)
-                info["bluff"] = self.info.retrieve_bluff_info_by_id(id)
-                info["guests"] = self.info.retrieve_guest_info_by_id(id)
+                info["panelists"] = self.info.retrieve_panelist_info_by_id(id_)
+                info["bluff"] = self.info.retrieve_bluff_info_by_id(id_)
+                info["guests"] = self.info.retrieve_guest_info_by_id(id_)
 
             shows.append(info)
 
@@ -261,11 +261,11 @@ class Show:
             be returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_date_to_id(year, month, day)
-        if not id:
+        id_ = self.utility.convert_date_to_id(year, month, day)
+        if not id_:
             return {}
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
     def retrieve_by_date_string(self,
@@ -286,26 +286,26 @@ class Show:
         except ValueError:
             return {}
 
-        id = self.utility.convert_date_to_id(parsed_date_string.year,
-                                             parsed_date_string.month,
-                                             parsed_date_string.day)
+        id_ = self.utility.convert_date_to_id(parsed_date_string.year,
+                                              parsed_date_string.month,
+                                              parsed_date_string.day)
 
-        return self.retrieve_by_id(id)
+        return self.retrieve_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a dictionary object containing show ID, show date,
         Best Of and Repeat Show information for the requested show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Dictionary containing show information. If show
             information could not be retrieved, an empty dictionary will
             be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(show_id)
         except ValueError:
             return {}
 
@@ -315,7 +315,7 @@ class Show:
                  "FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -432,11 +432,11 @@ class Show:
             will be returned.
         :rtype: Dict[str, Any]
         """
-        id = self.utility.convert_date_to_id(year, month, day)
-        if not id:
+        id_ = self.utility.convert_date_to_id(year, month, day)
+        if not id_:
             return {}
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)
 
     @lru_cache(typed=True)
     def retrieve_details_by_date_string(self,
@@ -457,37 +457,37 @@ class Show:
         except ValueError:
             return {}
 
-        id = self.utility.convert_date_to_id(parsed_date_string.year,
-                                             parsed_date_string.month,
-                                             parsed_date_string.day)
+        id_ = self.utility.convert_date_to_id(parsed_date_string.year,
+                                              parsed_date_string.month,
+                                              parsed_date_string.day)
 
-        return self.retrieve_details_by_id(id)
+        return self.retrieve_details_by_id(id_)
 
     @lru_cache(typed=True)
-    def retrieve_details_by_id(self, id: int) -> Dict[str, Any]:
+    def retrieve_details_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a list of dictionary objects containing show ID,
         show date, host, scorekeeper, panelist and guest information
         for the requested show ID.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Dictionary containing show information and details. If
             show information could not be retrieved, an empty dictionary
             will be returned.
         :rtype: Dict[str, Any]
         """
         try:
-            id = int(id)
+            id_ = int(show_id)
         except ValueError:
             return {}
 
-        info = self.info.retrieve_core_info_by_id(id)
+        info = self.info.retrieve_core_info_by_id(id_)
         if not info:
             return {}
 
-        info["panelists"] = self.info.retrieve_panelist_info_by_id(id)
-        info["bluff"] = self.info.retrieve_bluff_info_by_id(id)
-        info["guests"] = self.info.retrieve_guest_info_by_id(id)
+        info["panelists"] = self.info.retrieve_panelist_info_by_id(id_)
+        info["bluff"] = self.info.retrieve_bluff_info_by_id(id_)
+        info["guests"] = self.info.retrieve_guest_info_by_id(id_)
 
         return info
 
@@ -701,7 +701,7 @@ class Show:
         return shows
 
     @lru_cache(typed=True)
-    def retrieve_scores_by_year(self, year: int) -> List[Tuple]: #List[Tuple[str, int, int, int]]:
+    def retrieve_scores_by_year(self, year: int) -> List[Tuple]:
         """Returns a list of tuples containing panelist scores for all
         shows in the requested year, sorted by show date.
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -47,7 +47,9 @@ class Show:
         """Returns a list of dictionary objects containing show ID,
         show date, Best Of and Repeat Show information for all shows.
 
-        :return: List of all shows and their corresponding information
+        :return: List of all shows and their corresponding information.
+            If show information could not be retrieved, an empty list
+            will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -60,7 +62,7 @@ class Show:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         shows = []
         for row in results:
@@ -85,7 +87,9 @@ class Show:
         show date, host, scorekeeper, panelist and guest information
         for all shows.
 
-        :return: List of all shows and their corresponding details
+        :return: List of all shows and their corresponding details.
+            If show information could not be retrieved, an empty list
+            will be returned.
         :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=True)
@@ -96,7 +100,7 @@ class Show:
         cursor.close()
 
         if not results:
-            return None
+            return []
 
         shows = []
         for row in results:
@@ -115,7 +119,8 @@ class Show:
         """Returns a list of all show IDs from the database, sorted by
         show date.
 
-        :return: List of all show IDs
+        :return: List of all show IDs. If show IDs could not be
+            retrieved, an empty list will be returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -126,7 +131,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -138,7 +143,8 @@ class Show:
         """Returns a list of all show dates from the database, sorted
         by show date.
 
-        :return: List of all show date strings
+        :return: List of all show date strings. If show dates could not
+            be retrieved, an empty list will be returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -149,7 +155,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         ids = []
         for row in result:
@@ -162,7 +168,8 @@ class Show:
         and day, sorted by show date.
 
         :return: List of allow show dates as a tuple of year, month
-            and day
+            and day. If show dates could not be retrieved, an empty list
+            will be returned.
         :rtype: List[Tuple[int, int, int]]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -172,6 +179,9 @@ class Show:
         cursor.execute(query)
         result = cursor.fetchall()
         cursor.close()
+
+        if not result:
+            return []
 
         show_dates = []
         for show in result:
@@ -183,7 +193,9 @@ class Show:
         """Returns a list of all show years and months as a string,
         sorted by year and month.
 
-        :return: List of all show years and month in ``YYYY-MM`` format
+        :return: List of all show years and month in ``YYYY-MM`` format.
+            If show dates could not be retrieved, an empty list will be
+            returned.
         :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -193,6 +205,9 @@ class Show:
         cursor.execute(query)
         result = cursor.fetchall()
         cursor.close()
+
+        if not result:
+            return []
 
         show_years_months = []
         for row in result:
@@ -204,7 +219,9 @@ class Show:
         """Returns a list of all show years and months as a tuple of
         year and month, sorted by year and month.
 
-        :return: List of allow show dates as a tuple of year and month
+        :return: List of allow show dates as a tuple of year and month.
+            If show dates could not be retrieved, an empty list will be
+            returned.
         :rtype: List[Tuple[int, int]]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -214,6 +231,9 @@ class Show:
         cursor.execute(query)
         result = cursor.fetchall()
         cursor.close()
+
+        if not result:
+            return []
 
         show_years_months = []
         for row in result:
@@ -235,12 +255,14 @@ class Show:
         :type month: int
         :param day: One or two digit day
         :type day: int
-        :return: Dictionary containing show information
+        :return: Dictionary containing show information. If show
+            information could not be retrieved, an empty dictionary will
+            be returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_date_to_id(year, month, day)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_by_id(id)
 
@@ -253,13 +275,15 @@ class Show:
 
         :param date_string: Show date in ``YYYY-MM-DD`` format
         :type date_string: str
-        :return: Dictionary containing show information
+        :return: Dictionary containing show information. If show
+            information could not be retrieved, an empty dictionary will
+            be returned.
         :rtype: Dict[str, Any]
         """
         try:
             parsed_date_string = date_parser.parse(date_string)
         except ValueError:
-            return None
+            return {}
 
         id = self.utility.convert_date_to_id(parsed_date_string.year,
                                              parsed_date_string.month,
@@ -274,13 +298,15 @@ class Show:
 
         :param id: Show ID
         :type id: int
-        :return: Show information
+        :return: Dictionary containing show information. If show
+            information could not be retrieved, an empty dictionary will
+            be returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id, showdate AS date, "
@@ -293,7 +319,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return {}
 
         repeat_show_id = result["repeatshowid"]
         info = {
@@ -317,13 +343,14 @@ class Show:
         :param year: Four digit year
         :type year: int
         :return: List of shows for the requested year and corresponding
-            information
+            information. If show information could not be retrieved,
+            an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid FROM ww_shows "
@@ -334,7 +361,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -356,13 +383,14 @@ class Show:
         :param month: One or two digit month
         :type month: int
         :return: List of shows for the requested year and month, and
-            corresponding information
+            corresponding information. If show information could not be
+            retrieved, an list dictionary will be returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid FROM ww_shows "
@@ -374,7 +402,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -398,12 +426,14 @@ class Show:
         :type month: int
         :param day: One or two digit day
         :type day: int
-        :return: Dictionary containing show information and details
+        :return: Dictionary containing show information and details. If
+            show information could not be retrieved, an empty dictionary
+            will be returned.
         :rtype: Dict[str, Any]
         """
         id = self.utility.convert_date_to_id(year, month, day)
         if not id:
-            return None
+            return {}
 
         return self.retrieve_details_by_id(id)
 
@@ -416,13 +446,15 @@ class Show:
 
         :param date_string: Show date in ``YYYY-MM-DD`` format
         :type date_string: str
-        :return: Dictionary containing show information and details
+        :return: Dictionary containing show information and details. If
+            show information could not be retrieved, an empty dictionary
+            will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             parsed_date_string = date_parser.parse(date_string)
         except ValueError:
-            return None
+            return {}
 
         id = self.utility.convert_date_to_id(parsed_date_string.year,
                                              parsed_date_string.month,
@@ -438,17 +470,19 @@ class Show:
 
         :param id: Show ID
         :type id: int
-        :return: Dictionary containing show information and details
+        :return: Dictionary containing show information and details. If
+            show information could not be retrieved, an empty dictionary
+            will be returned.
         :rtype: Dict[str, Any]
         """
         try:
             id = int(id)
         except ValueError:
-            return None
+            return {}
 
         info = self.info.retrieve_core_info_by_id(id)
         if not info:
-            return None
+            return {}
 
         info["panelists"] = self.info.retrieve_panelist_info_by_id(id)
         info["bluff"] = self.info.retrieve_bluff_info_by_id(id)
@@ -465,13 +499,14 @@ class Show:
         :param year: Four digit year
         :type year: int
         :return: List of shows for the requested year and corresponding
-            details
+            details. If show information could not be retrieved, an
+            empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
@@ -482,7 +517,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -503,13 +538,14 @@ class Show:
         :param month: One or two digit month
         :type month: int
         :return: List of shows for the requested year and month, and
-            corresponding details
+            corresponding details. If show information could not be
+            retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
@@ -522,7 +558,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -538,13 +574,14 @@ class Show:
 
         :param year: Four digit year
         :type year: int
-        :return: List of months
+        :return: List of available show months. If show information
+            could not be retrieved, an empty list will be returned.
         :rtype: List[int]
         """
         try:
             _ = date_parser.parse(f"{year:04d}")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT MONTH(showdate) "
@@ -556,7 +593,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         months = []
         for row in result:
@@ -577,20 +614,22 @@ class Show:
         :param include_days_back: Number of days in the past to
             include, defaults to 32
         :type include_days_back: int, optional
-        :return: List of recent shows and corresponding information
+        :return: List of recent shows and corresponding information. If
+            show information could not be retrieved, an empty list will
+            be returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             past_days = int(include_days_back)
             future_days = int(include_days_ahead)
         except ValueError:
-            return None
+            return []
 
         try:
             past_date = datetime.datetime.now() - datetime.timedelta(days=past_days)
             future_date = datetime.datetime.now() + datetime.timedelta(days=future_days)
         except OverflowError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
@@ -602,7 +641,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -625,20 +664,22 @@ class Show:
         :param include_days_back: Number of days in the past to
             include, defaults to 32
         :type include_days_back: int, optional
-        :return: List of recent shows and corresponding details
+        :return: List of recent shows and corresponding details. If show
+            information could not be retrieved, an empty list will be
+            returned.
         :rtype: List[Dict[str, Any]]
         """
         try:
             past_days = int(include_days_back)
             future_days = int(include_days_ahead)
         except ValueError:
-            return None
+            return []
 
         try:
             past_date = datetime.datetime.now() - datetime.timedelta(days=past_days)
             future_date = datetime.datetime.now() + datetime.timedelta(days=future_days)
         except OverflowError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT showid AS id FROM ww_shows "
@@ -650,7 +691,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         shows = []
         for show in result:
@@ -666,13 +707,14 @@ class Show:
         :param year: Four digit year
         :type year: int
         :return: List of tuples each containing show date and panelist
-            scores
+            scores. If show scores could not be retrieved, an empty list
+            will be returned.
         :rtype: List[Tuple[str, int, int, int]]
         """
         try:
             _ = date_parser.parse(f"{year:04d}")
         except ValueError:
-            return None
+            return []
 
         cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT s.showdate AS date, pm.panelistscore AS score "
@@ -686,7 +728,7 @@ class Show:
         result = cursor.fetchall()
 
         if not result:
-            return None
+            return []
 
         shows = {}
         for row in result:
@@ -707,7 +749,8 @@ class Show:
     def retrieve_years(self) -> List[int]:
         """Returns a list of available show years, sorted by year.
 
-        :return: List of all show years
+        :return: List of available show years. If show dates could not
+            be retrieved, an empty list will be returned.
         :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
@@ -719,7 +762,7 @@ class Show:
         cursor.close()
 
         if not result:
-            return None
+            return []
 
         years = []
         for row in result:

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -10,6 +10,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+from wwdtm.validation import valid_int_id
 
 
 class ShowUtility:
@@ -82,16 +83,14 @@ class ShowUtility:
         :return: Show date, if a match is found
         :rtype: str
         """
-        try:
-            id_ = int(show_id)
-        except ValueError:
+        if not valid_int_id(show_id):
             return None
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showdate FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -140,16 +139,14 @@ class ShowUtility:
         :return: True or False, based on whether the show ID exists
         :rtype: bool
         """
-        try:
-            id_ = int(show_id)
-        except ValueError:
+        if not valid_int_id(show_id):
             return False
 
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showid FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id_, ))
+        cursor.execute(query, (show_id, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -2,7 +2,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
 # Copyright (c) 2018-2021 Linh Pham
-# wwdtm is relased under the terms of the Apache License 2.0
+# wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Don't Tell Me! Stats Show Data Utility Functions
 """
 import datetime
@@ -10,6 +10,7 @@ from functools import lru_cache
 from typing import Any, Dict, Optional
 
 from mysql.connector import connect
+
 
 class ShowUtility:
     """This class contains supporting functions used to check whether
@@ -42,7 +43,7 @@ class ShowUtility:
     def convert_date_to_id(self,
                            year: int,
                            month: int,
-                           day: int) -> int:
+                           day: int) -> Optional[int]:
         """Converts a show date to the matching show ID value.
 
         :param year: Year portion of a show date
@@ -73,7 +74,7 @@ class ShowUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_id_to_date(self, id: int) -> str:
+    def convert_id_to_date(self, id: int) -> Optional[str]:
         """Converts a show's ID to the matching show date.
 
         :param id: Show ID

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -74,16 +74,16 @@ class ShowUtility:
         return None
 
     @lru_cache(typed=True)
-    def convert_id_to_date(self, id: int) -> Optional[str]:
+    def convert_id_to_date(self, show_id: int) -> Optional[str]:
         """Converts a show's ID to the matching show date.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: Show date, if a match is found
         :rtype: str
         """
         try:
-            id = int(id)
+            id_ = int(show_id)
         except ValueError:
             return None
 
@@ -91,7 +91,7 @@ class ShowUtility:
         query = ("SELECT showdate FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 
@@ -132,16 +132,16 @@ class ShowUtility:
         return bool(result)
 
     @lru_cache(typed=True)
-    def id_exists(self, id: int) -> bool:
+    def id_exists(self, show_id: int) -> bool:
         """Checks to see if a show ID exists.
 
-        :param id: Show ID
-        :type id: int
+        :param show_id: Show ID
+        :type show_id: int
         :return: True or False, based on whether the show ID exists
         :rtype: bool
         """
         try:
-            id = int(id)
+            id_ = int(show_id)
         except ValueError:
             return False
 
@@ -149,7 +149,7 @@ class ShowUtility:
         query = ("SELECT showid FROM ww_shows "
                  "WHERE showid = %s "
                  "LIMIT 1;")
-        cursor.execute(query, (id, ))
+        cursor.execute(query, (id_, ))
         result = cursor.fetchone()
         cursor.close()
 

--- a/wwdtm/validation.py
+++ b/wwdtm/validation.py
@@ -16,6 +16,9 @@ def valid_int_id(id: int) -> bool:
     :rtype: bool
     """
     try:
+        if not id:
+            return False
+
         id_ = int(id)
     except ValueError:
         return False

--- a/wwdtm/validation.py
+++ b/wwdtm/validation.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2021 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+"""Type validation module"""
+
+def valid_int_id(id: int) -> bool:
+    """Validates an ID value as an signed 32-bit inteeger used
+    in ID fields in MySQL tables.
+
+    :param id: ID number to validate
+    :type id: int
+    :return: True or False, based on if the integer falls inclusively
+        between 0 and 2147483647
+    :rtype: bool
+    """
+    try:
+        id_ = int(id)
+    except ValueError:
+        return False
+
+    # Minimum value of a signed INT in MySQL/MariaDB is 0 and the
+    # maximum value of signed INT type in MySQL/MariaDB is (2**31) - 1,
+    # or 2147483647
+    return 0 <= id_ <= (2**31 - 1)


### PR DESCRIPTION
Combines the refactoring and standardizing of object output to match the return type hints that would be used upstream for projects that make use of Pydantic, mypy, etc.

Also, cleanup code and fix PEP-8 issues that are reported by flake8.