### PR TITLE
Rework modules and documentation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 # Include example configuration file
-include config.dist.json
+include config.json.dist
 
 # Include pytest configuration file
 include pytest.ini

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,15 +1,20 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 
 @media all {
     body, input {
-        font-family: "IBM Plex Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
+        font-family: "IBM Plex Sans", "Fira Sans", Calibri, sans-serif;
         font-size: 1.05rem;
     }
 
+    h1, h2, h3, h4, h5, h6 {
+        font-family: "IBM Plex Serif", Georgia, Cambria, serif;
+    }
+
     code, kbd, pre, textarea {
-        font-family: "IBM Plex Mono", "Courier New", Courier, monospace;
-        font-size: 1.05rem;
+        font-family: "IBM Plex Mono", "Fira Code", Consolas, monospace;
+        font-size: 1rem;
     }
 
     div.sphinxsidebar {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,7 +6,7 @@
 import os
 import sys
 
-from pallets_sphinx_themes import ProjectLink # type: ignore
+from pallets_sphinx_themes import ProjectLink  # type: ignore
 
 sys.path.insert(0, os.path.abspath('../'))
 
@@ -19,7 +19,10 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
     "sphinx.ext.coverage",
+    "sphinx.ext.napoleon",
     "sphinx_copybutton",
+    "sphinx_toolbox.more_autodoc.typehints",
+    "sphinx_autodoc_typehints",
 ]
 
 templates_path = [
@@ -72,5 +75,7 @@ html_css_files = [
 html_show_sourcelink = False
 
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3", None)
+    "python": ("https://docs.python.org/3", None),
 }
+
+always_document_param_types = True

--- a/docs/migrating/show.rst
+++ b/docs/migrating/show.rst
@@ -16,6 +16,10 @@ changed to become methods under :py:class:`wwdtm.show.ShowInfo`:
 
 * :py:func:`retrieve_bluff_info_by_id`
 * :py:func:`retrieve_core_info_by_id`
+
+  * Renamed to :py:meth:`retrieve_core_info_by_ids`
+  * Changed the ``show_id`` (:py:class:`int`) parameter to ``show_ids``
+    (:py:class:`list` [:py:class:`int`])
 * :py:func:`retrieve_guest_info_by_id`
 * :py:func:`retrieve_panelist_info_by_id`
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -10,5 +10,7 @@ pytz==2021.3
 
 Sphinx==4.3.2
 sphinx-autobuild==2021.3.14
+sphinx-autodoc-typehints==1.13.0
 sphinx-copybutton==0.4.0
+sphinx-toolbox==2.15.2
 Pallets-Sphinx-Themes==2.0.2

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -32,7 +31,6 @@ def test_guest_appearances_retrieve_appearances_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_id`
 
     :param guest_id: Guest ID to test retrieving guest appearances
-    :type guest_id: int
     """
     appearances = GuestAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(guest_id)
@@ -46,7 +44,6 @@ def test_guest_appearances_retrieve_appearances_by_slug(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_slug`
 
     :param guest_slug: Guest slug string to test retrieving guest appearances
-    :type guest_slug: str
     """
     appearances = GuestAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(guest_slug)

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -72,7 +71,6 @@ def test_guest_retrieve_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_id`
 
     :param guest_id: Guest ID to test retrieving guest information
-    :type guest_id: int
     """
     guest = Guest(connect_dict=get_connect_dict())
     info = guest.retrieve_by_id(guest_id)
@@ -87,7 +85,6 @@ def test_guest_retrieve_by_slug(guest_slug: str):
 
     :param guest_slug: Guest slug string to test retrieving guest
         information
-    :type guest_slug: str
     """
     guest = Guest(connect_dict=get_connect_dict())
     info = guest.retrieve_by_slug(guest_slug)
@@ -101,7 +98,6 @@ def test_guest_retrieve_details_by_id(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_id`
 
     :param guest_id: Guest ID to test retrieving guest details
-    :type guest_id: int
     """
     guest = Guest(connect_dict=get_connect_dict())
     info = guest.retrieve_details_by_id(guest_id)
@@ -116,7 +112,6 @@ def test_guest_guest_retrieve_details_by_slug(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_slug`
 
     :param guest_slug: Guest slug string to test retrieving guest details
-    :type guest_slug: str
     """
     guest = Guest(connect_dict=get_connect_dict())
     info = guest.retrieve_details_by_slug(guest_slug)

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -32,7 +31,6 @@ def test_guest_utility_convert_id_to_slug(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
 
     :param guest_id: Guest ID to test converting into guest slug string
-    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(guest_id)
@@ -47,7 +45,6 @@ def test_guest_utility_convert_invalid_id_to_slug(guest_id: int):
 
     :param guest_id: Guest ID to test failing to convert into guest slug
         string
-    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(guest_id)
@@ -61,7 +58,6 @@ def test_guest_utility_convert_slug_to_id(guest_slug: str):
 
     :param guest_slug: Guest slug string to test converting into guest
         ID
-    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(guest_slug)
@@ -76,7 +72,6 @@ def test_guest_utility_convert_invalid_slug_to_id(guest_slug: str):
 
     :param guest_slug: Guest slug string to test failing to convert into
         guest ID
-    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(guest_slug)
@@ -89,7 +84,6 @@ def test_guest_utility_id_exists(guest_id: int):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
 
     :param guest_id: Guest ID to test if a guest exists
-    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(guest_id)
@@ -102,7 +96,6 @@ def test_guest_utility_id_not_exists(guest_id: int):
     """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
 
     :param guest_id: Guest ID to test if a guest does not exist
-    :type guest_id: int
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(guest_id)
@@ -115,7 +108,6 @@ def test_guest_utility_slug_exists(guest_slug: str):
     """Testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
 
     :param guest_slug: Guest slug string to test if a guest exists
-    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(guest_slug)
@@ -129,7 +121,6 @@ def test_guest_utility_slug_not_exists(guest_slug: str):
 
     :param guest_slug: Guest slug string to test if a guest does not
         exist
-    :type guest_slug: str
     """
     utility = GuestUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(guest_slug)

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -32,7 +31,6 @@ def test_host_appearances_retrieve_appearances_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_id`
 
     :param host_id: Host ID to test retrieving host appearances
-    :type host_id: int
     """
     appearances = HostAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(host_id)
@@ -47,7 +45,6 @@ def test_host_appearances_retrieve_appearances_by_slug(host_slug: str):
 
     :param host_slug: Host slug string to test retrieving host
         appearances
-    :type host_slug: str
     """
     appearances = HostAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(host_slug)

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -72,7 +71,6 @@ def test_host_retrieve_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_id`
 
     :param host_id: Host ID to test retrieving host information
-    :type host_id: int
     """
     host = Host(connect_dict=get_connect_dict())
     info = host.retrieve_by_id(host_id)
@@ -86,7 +84,6 @@ def test_host_retrieve_details_by_id(host_id: int):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`
 
     :param host_id: Host ID to test retrieving host details
-    :type host_id: int
     """
     host = Host(connect_dict=get_connect_dict())
     info = host.retrieve_details_by_id(host_id)
@@ -102,7 +99,6 @@ def test_host_retrieve_by_slug(host_slug: str):
 
     :param host_slug: Host slug string to test retrieving host
         information
-    :type host_slug: str
     """
     host = Host(connect_dict=get_connect_dict())
     info = host.retrieve_by_slug(host_slug)
@@ -116,7 +112,6 @@ def test_host_retrieve_details_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_slug`
 
     :param host_slug: Host slug string to test retrieving host details
-    :type host_slug: str
     """
     host = Host(connect_dict=get_connect_dict())
     info = host.retrieve_details_by_slug(host_slug)

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -32,7 +31,6 @@ def test_host_utility_convert_id_to_slug(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
 
     :param host_id: Host ID to test converting into host slug string
-    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(host_id)
@@ -47,7 +45,6 @@ def test_host_utility_convert_invalid_id_to_slug(host_id: int):
 
     :param host_id: Host ID to test failing to convert into host slug
         string
-    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(host_id)
@@ -60,7 +57,6 @@ def test_host_utility_convert_slug_to_id(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
 
     :param host_slug: Host slug string to test converting into host ID
-    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(host_slug)
@@ -75,7 +71,6 @@ def test_host_utility_convert_invalid_slug_to_id(host_slug: str):
 
     :param host_slug: Host slug string to test failing to convert into
         host ID
-    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     result = utility.convert_slug_to_id(host_slug)
@@ -88,7 +83,6 @@ def test_host_utility_id_exists(host_id: int):
     """Testing for :py:meth:`wwdtm.host.HostUtility.id_exists`
 
     :param host_id: Host ID to test if a host exists
-    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(host_id)
@@ -101,7 +95,6 @@ def test_host_utility_id_not_exists(host_id: int):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.id_exists()`
 
     :param host_id: Host ID to test if a host does not exist
-    :type host_id: int
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(host_id)
@@ -114,7 +107,6 @@ def test_host_utility_slug_exists(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
 
     :param host_slug: Host slug string to test if a host exists
-    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(host_slug)
@@ -127,7 +119,6 @@ def test_host_utility_slug_not_exists(host_slug: str):
     """Negative testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
 
     :param host_slug: Host slug string to test if a host does not exist
-    :type host_slug: str
     """
     utility = HostUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(host_slug)

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -73,7 +72,6 @@ def test_location_retrieve_by_id(location_id: int):
 
     :param location_id: Location ID to test retrieving location
         information
-    :type location_id: int
     """
     location = Location(connect_dict=get_connect_dict())
     info = location.retrieve_by_id(location_id)
@@ -87,7 +85,6 @@ def test_location_retrieve_details_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`
 
     :param location_id: Location ID to test retrieving location details
-    :type location_id: int
     """
     location = Location(connect_dict=get_connect_dict())
     info = location.retrieve_details_by_id(location_id)
@@ -103,7 +100,6 @@ def test_location_retrieve_by_slug(location_slug: str):
 
     :param location_slug: Location slug string to test retrieving
         location information
-    :type location_slug: str
     """
     location = Location(connect_dict=get_connect_dict())
     info = location.retrieve_by_slug(location_slug)
@@ -118,7 +114,6 @@ def test_location_retrieve_details_by_slug(location_slug: str):
 
     :param location_slug: Location slug string to test retrieving
         location details
-    :type location_slug: str
     """
     location = Location(connect_dict=get_connect_dict())
     info = location.retrieve_details_by_slug(location_slug)

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_location_recordings_retrieve_recordings_by_id(location_id: int):
 
     :param location_id: Location ID to test retrieving location
         recordings
-    :type location_id: int
     """
     recordings = LocationRecordings(connect_dict=get_connect_dict())
     recording = recordings.retrieve_recordings_by_id(location_id)
@@ -48,7 +46,6 @@ def test_location_recordings_retrieve_recordings_by_slug(location_slug: str):
 
     :param location_slug: Location slug string to test retrieving
         location recordings
-    :type location_slug: str
     """
     recordings = LocationRecordings(connect_dict=get_connect_dict())
     recording = recordings.retrieve_recordings_by_slug(location_slug)

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_location_utility_convert_id_to_slug(location_id: int):
 
     :param location_id: Location ID to test converting into location
         slug string
-    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(location_id)
@@ -47,7 +45,6 @@ def test_location_utility_convert_invalid_id_to_slug(location_id: int):
 
     :param location_id: Location ID to test failing to convert into
         location slug string
-    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(location_id)
@@ -61,7 +58,6 @@ def test_location_utility_convert_slug_to_id(location_slug: str):
 
     :param location_slug: Location slug string to test converting into
         location ID
-    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(location_slug)
@@ -75,7 +71,6 @@ def test_location_utility_convert_invalid_slug_to_id(location_slug: str):
 
     :param location_slug: Location slug string to test failing to
         convert into location ID
-    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(location_slug)
@@ -88,7 +83,6 @@ def test_location_utility_id_exists(location_id: int):
     """Testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
 
     :param location_id: Location ID to test if a location exists
-    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(location_id)
@@ -101,7 +95,6 @@ def test_location_utility_id_not_exists(location_id: int):
     """Negative testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
 
     :param location_id: Location ID to test if a location does not exist
-    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(location_id)
@@ -115,7 +108,6 @@ def test_location_utility_slug_exists(location_slug: str):
 
     :param location_slug: Location slug string to test if a location
         exists
-    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(location_slug)
@@ -130,7 +122,6 @@ def test_location_utility_slug_not_exists(location_slug: str):
 
     :param location_slug: Location slug string to test if a location
         does not exists
-    :type location_slug: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(location_slug)
@@ -145,7 +136,6 @@ def test_location_utility_slugify_location_city(city: str):
     with city name
 
     :param city: City to include in the slug string
-    :type city: str
     """
     with pytest.raises(ValueError):
         utility = LocationUtility(connect_dict=get_connect_dict())
@@ -162,9 +152,7 @@ def test_location_utility_slugify_location_city_state(city: str, state: str):
     with city and state names
 
     :param city: City to include in the slug string
-    :type city: str
     :param state: State to include in the slug string
-    :type state: str
     """
     with pytest.raises(ValueError):
         utility = LocationUtility(connect_dict=get_connect_dict())
@@ -184,13 +172,9 @@ def test_location_utility_slugify_location_full(location_id: int,
     with location ID, venue, city and state names
 
     :param location_id: Location ID to include in the slug string
-    :type location_id: int
     :param venue: Venue name to include in the slug string
-    :type venue: str
     :param city: City to include in the slug string
-    :type city: str
     :param state: State to include in the slug string
-    :type state: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.slugify_location(location_id=location_id, venue=venue,
@@ -207,9 +191,7 @@ def test_location_utility_slugify_location_venue(location_id: int,
     with venue name
 
     :param location_id: Location ID to include in the slug string
-    :type location_id: int
     :param venue: Venue name to include in the slug string
-    :type venue: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.slugify_location(location_id=location_id, venue=venue)
@@ -226,11 +208,8 @@ def test_location_utility_slugify_location_venue_city_state(venue: str,
     """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
 
     :param venue: Venue name to include in the slug string
-    :type venue: str
     :param city: City to include in the slug string
-    :type city: str
     :param state: State to include in the slug string
-    :type state: str
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.slugify_location(venue=venue, city=city, state=state)
@@ -245,7 +224,6 @@ def test_location_utility_slugify_location_id(location_id: int):
     with venue, city and state names
 
     :param location_id: Location ID to include in the slug string
-    :type location_id: int
     """
     utility = LocationUtility(connect_dict=get_connect_dict())
     slug = utility.slugify_location(location_id=location_id)

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         appearances
-    :type panelist_id: int
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(panelist_id)
@@ -48,7 +46,6 @@ def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances
-    :type panelist_slug: str
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(panelist_slug)
@@ -63,7 +60,6 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int
 
     :param panelist_id: Panelist ID to test retrieving a panelist's
         appearances
-    :type panelist_id: int
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_id(panelist_id)
@@ -77,7 +73,6 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_slug(panelist_slug:
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances
-    :type panelist_slug: str
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_slug(panelist_slug)

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -73,7 +72,6 @@ def test_panelist_retrieve_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     panelist = Panelist(connect_dict=get_connect_dict())
     info = panelist.retrieve_by_id(panelist_id)
@@ -87,7 +85,6 @@ def test_panelist_retrieve_details_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist details
-    :type panelist_id: int
     """
     panelist = Panelist(connect_dict=get_connect_dict())
     info = panelist.retrieve_details_by_id(panelist_id)
@@ -103,7 +100,6 @@ def test_panelist_retrieve_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     panelist = Panelist(connect_dict=get_connect_dict())
     info = panelist.retrieve_by_slug(panelist_slug)
@@ -118,7 +114,6 @@ def test_panelist_retrieve_details_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist details
-    :type panelist_slug: str
     """
     panelist = Panelist(connect_dict=get_connect_dict())
     info = panelist.retrieve_details_by_slug(panelist_slug)

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_by_id(panelist_id)
@@ -47,7 +45,6 @@ def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_by_slug(panelist_slug)
@@ -61,7 +58,6 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_grouped_list_by_id(panelist_id)
@@ -76,7 +72,6 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_grouped_list_by_slug(panelist_slug)
@@ -91,7 +86,6 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id:
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_grouped_ordered_pair_by_id(panelist_id)
@@ -106,7 +100,6 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(panelist_s
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_grouped_ordered_pair_by_slug(panelist_slug)
@@ -120,7 +113,6 @@ def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist information
-    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_list_by_id(panelist_id)
@@ -135,7 +127,6 @@ def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_list_by_slug(panelist_slug)
@@ -150,7 +141,6 @@ def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_ordered_pair_by_id(panelist_id)
@@ -164,7 +154,6 @@ def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(panelist_slug: str
 
     :param panelist_slug: Panelist slug string to test retrieving panelist
         information
-    :type panelist_slug: str
     """
     scores = PanelistScores(connect_dict=get_connect_dict())
     scoring = scores.retrieve_scores_ordered_pair_by_slug(panelist_slug)

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_panelist_statistics_retrieve_bluffs_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     bluffs = statistics.retrieve_bluffs_by_id(panelist_id)
@@ -48,7 +46,6 @@ def test_panelist_statistics_retrieve_bluffs_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     bluffs = statistics.retrieve_bluffs_by_slug(panelist_slug)
@@ -63,7 +60,6 @@ def test_panelist_statistics_retrieve_rank_info_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     ranks = statistics.retrieve_rank_info_by_id(panelist_id)
@@ -77,7 +73,6 @@ def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     ranks = statistics.retrieve_rank_info_by_slug(panelist_slug)
@@ -91,7 +86,6 @@ def test_panelist_statistics_retrieve_statistics_by_id(panelist_id: int):
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    :type panelist_id: int
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_id(panelist_id)
@@ -106,7 +100,6 @@ def test_panelist_statistics_retrieve_statistics_by_slug(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    :type panelist_slug: str
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_slug(panelist_slug)

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -19,7 +19,6 @@ def get_connect_dict() -> Dict[str, Any]:
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
     with open("config.json", "r") as config_file:
         config_dict = json.load(config_file)
@@ -33,7 +32,6 @@ def test_panelist_utility_convert_id_to_slug(panelist_id: int):
 
     :param panelist_id: Panelist ID to test converting into panelist
         slug string
-    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
     slug = utility.convert_id_to_slug(panelist_id)
@@ -48,7 +46,6 @@ def test_panelist_utility_convert_invalid_id_to_slug(panelist_id: int):
 
     :param panelist_id: Panelist ID to test failing to convert into
         panelist slug string
-    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
     slug = utility.convert_id_to_slug(panelist_id)
@@ -62,7 +59,6 @@ def test_panelist_utility_convert_slug_to_id(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test converting into
         panelist ID
-    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
     id_ = utility.convert_slug_to_id(panelist_slug)
@@ -77,7 +73,6 @@ def test_panelist_utility_convert_invalid_slug_to_id(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test failing to
         convert into panelist ID
-    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
     id_ = utility.convert_slug_to_id(panelist_slug)
@@ -90,7 +85,6 @@ def test_panelist_utility_id_exists(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
 
     :param panelist_id: Panelist ID to test if a panelist exists
-    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
     result = utility.id_exists(panelist_id)
@@ -103,7 +97,6 @@ def test_panelist_utility_id_not_exists(panelist_id: int):
     """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
 
     :param panelist_id: Panelist ID to test if a panelist does not exist
-    :type panelist_id: int
     """
     utility = PanelistUtility(get_connect_dict())
     result = utility.id_exists(panelist_id)
@@ -117,7 +110,6 @@ def test_panelist_utility_slug_exists(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test if a panelist
         exists
-    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
     result = utility.slug_exists(panelist_slug)
@@ -131,7 +123,6 @@ def test_panelist_utility_slug_not_exists(panelist_slug: str):
 
     :param panelist_slug: Panelist slug string to test if a panelist
         does not exist
-    :type panelist_slug: str
     """
     utility = PanelistUtility(get_connect_dict())
     result = utility.slug_exists(panelist_slug)

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -29,7 +29,6 @@ def test_scorekeeper_appearance_retrieve_appearances_by_id(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         appearances
-    :type scorekeeper_id: int
     """
     appearances = ScorekeeperAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(scorekeeper_id)
@@ -44,7 +43,6 @@ def test_scorekeeper_appearance_retrieve_appearances_by_slug(scorekeeper_slug: s
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper appearances
-    :type scorekeeper_slug: str
     """
     appearances = ScorekeeperAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(scorekeeper_slug)

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -69,7 +69,6 @@ def test_scorekeeper_retrieve_by_id(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         information
-    :type scorekeeper_id: int
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     info = scorekeeper.retrieve_by_id(scorekeeper_id)
@@ -84,7 +83,6 @@ def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         details
-    :type scorekeeper_id: int
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     info = scorekeeper.retrieve_details_by_id(scorekeeper_id)
@@ -100,7 +98,6 @@ def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper information
-    :type scorekeeper_slug: str
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     info = scorekeeper.retrieve_by_slug(scorekeeper_slug)
@@ -115,7 +112,6 @@ def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper details
-    :type scorekeeper_slug: str
     """
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     info = scorekeeper.retrieve_details_by_slug(scorekeeper_slug)

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -29,7 +29,6 @@ def test_scorekeeper_utility_convert_id_to_slug(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test converting into
         scorekeeper slug string
-    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(scorekeeper_id)
@@ -44,7 +43,6 @@ def test_scorekeeper_utility_convert_invalid_id_to_slug(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test failing to convert
         into scorekeeper slug string
-    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     slug = utility.convert_id_to_slug(scorekeeper_id)
@@ -58,7 +56,6 @@ def test_scorekeeper_utility_convert_slug_to_id(scorekeeper_slug: str):
 
     :param scorekeeper_slug: Scorekeeper slug string to test converting
         into scorekeeper ID
-    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(scorekeeper_slug)
@@ -73,7 +70,6 @@ def test_scorekeeper_utility_convert_invalid_slug_to_id(scorekeeper_slug: str):
 
     :param scorekeeper_slug: Scorekeeper slug string to test failing to
         convert into scorekeeper ID
-    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_slug_to_id(scorekeeper_slug)
@@ -87,7 +83,6 @@ def test_scorekeeper_utility_id_exists(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper
         exists
-    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(scorekeeper_id)
@@ -101,7 +96,6 @@ def test_scorekeeper_utility_id_not_exists(scorekeeper_id: int):
 
     :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper does
         not exist
-    :type scorekeeper_id: int
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(scorekeeper_id)
@@ -115,7 +109,6 @@ def test_scorekeeper_utility_slug_exists(scorekeeper_slug: str):
 
     :param scorekeeper_slug: Scorekeeper slug string to test if a
         scorekeeper exists
-    :type scorekeeper_slug: str
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(scorekeeper_slug)
@@ -128,9 +121,7 @@ def test_scorekeeper_utility_slug_not_exists(scorekeeper_slug: str):
     """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
 
     :param scorekeeper_slug: Scorekeeper slug string to test if a
-        scorekeeper does
-        not exist
-    :type scorekeeper_slug: str
+        scorekeeper does not exist
     """
     utility = ScorekeeperUtility(connect_dict=get_connect_dict())
     result = utility.slug_exists(scorekeeper_slug)

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -29,7 +29,6 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
 
     :param show_id: Show ID to test retrieving show Bluff the Listener
         information
-    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
     bluff = info.retrieve_bluff_info_by_id(show_id)
@@ -43,14 +42,13 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
 
 
 @pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_core_info_by_id(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
+def test_show_info_retrieve_core_info_by_ids(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_ids`
 
     :param show_id: Show ID to test retrieving show core information
-    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    core = info.retrieve_core_info_by_id([show_id])
+    core = info.retrieve_core_info_by_ids([show_id])
 
     assert core, f"Core information for show ID {show_id} could not be retrieved"
     show = core[0]
@@ -66,7 +64,6 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_guest_info_by_id`
 
     :param show_id: Show ID to test retrieving show guest information
-    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
     guests = info.retrieve_guest_info_by_id(show_id)
@@ -83,7 +80,6 @@ def test_show_info_retrieve_panelist_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
 
     :param show_id: Show ID to test retrieving show panelist information
-    :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
     panelists = info.retrieve_panelist_info_by_id(show_id)

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -50,12 +50,14 @@ def test_show_info_retrieve_core_info_by_id(show_id: int):
     :type show_id: int
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    core = info.retrieve_core_info_by_id(show_id)
+    core = info.retrieve_core_info_by_id([show_id])
 
     assert core, f"Core information for show ID {show_id} could not be retrieved"
-    assert "id" in core, (f"'id' was not returned with core information for "
+    show = core[0]
+
+    assert "id" in show, (f"'id' was not returned with core information for "
                           f"show ID {show_id}")
-    assert "description" in core, (f"'description' was not returned with show "
+    assert "description" in show, (f"'description' was not returned with show "
                                    f"information for show ID {show_id}")
 
 

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -97,13 +97,10 @@ def test_show_retrieve_by_date(year: int, month: int, day: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date`
 
     :param year: Four digit year to test retrieving a show's information
-    :type year: int
     :param month: One or two digit month to test retrieving a show's
         information
-    :type month: int
     :param day: One or two digit day to test retrieving a show's
         information
-    :type day: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_by_date(year, month, day)
@@ -119,7 +116,6 @@ def test_show_retrieve_by_date_string(date: str):
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving a show's information
-    :type date: str
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_by_date_string(date)
@@ -133,7 +129,6 @@ def test_show_retrieve_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_id`
 
     :param show_id: Show ID to test retrieving show information
-    :type show_id: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_by_id(show_id)
@@ -147,7 +142,6 @@ def test_show_retrieve_by_year(year: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year`
 
     :param year: Four digit year to test retrieving show information
-    :type year: int
     """
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_by_year(year)
@@ -162,10 +156,8 @@ def test_show_retrieve_by_year_month(year: int, month: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year_month`
 
     :param year: Four digit year to test retrieving show information
-    :type year: int
     :param month: One or two digit month to test retrieving show
         information
-    :type month: int
     """
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_by_year_month(year, month)
@@ -181,11 +173,8 @@ def test_show_retrieve_details_by_date(year: int, month: int, day: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
 
     :param year: Four digit year to test retrieving show details
-    :type year: int
     :param month: One or two digit month to test retrieving show details
-    :type month: int
     :param day: One or two digit day to test retrieving show details
-    :type day: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_date(year, month, day)
@@ -203,7 +192,6 @@ def test_show_retrieve_details_by_date_string(date: str):
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
-    :type date: str
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_date_string(date)
@@ -218,7 +206,6 @@ def test_show_retrieve_details_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
 
     :param show_id: Show ID to test retrieving show details
-    :type show_id: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_id(show_id)
@@ -233,7 +220,6 @@ def test_show_retrieve_details_by_year(year: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
 
     :param year: Four digit year to test retrieving show details
-    :type year: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_year(year)
@@ -250,9 +236,7 @@ def test_show_retrieve_details_by_year_month(year: int, month: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
 
     :param year: Four digit year to test retrieving show details
-    :type year: int
     :param month: One or two digit year to test retrieving show details
-    :type month: int
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_year_month(year, month)
@@ -270,7 +254,6 @@ def test_show_retrieve_months_by_year(year: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_months_by_year`
 
     :param year: Four digit year to test retrieving a list of months
-    :type year: int
     """
     show = Show(connect_dict=get_connect_dict())
     months = show.retrieve_months_by_year(year)
@@ -305,7 +288,6 @@ def test_show_retrieve_scores_by_year(year: int):
 
     :param year: Four digit year to test retrieving scores for a show
         year
-    :type year: int
     """
     show = Show(connect_dict=get_connect_dict())
     scores = show.retrieve_scores_by_year(year)

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -30,11 +30,8 @@ def test_show_utility_convert_date_to_id(year: int,
     """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`
 
     :param year: Four digit year to test converting into show ID
-    :type year: int
     :param month: One or two digit month to test converting into show ID
-    :type month: int
     :param day: One or two digit day to test converting into show ID
-    :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_date_to_id(year, month, day)
@@ -51,13 +48,10 @@ def test_show_utility_convert_invalid_date_to_id(year: int,
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`
 
     :param year: Four digit year to test failing to convert into show ID
-    :type year: int
     :param month: One or two digit month to test failing to convert
         into show ID
-    :type month: int
     :param day: One or two digit day to test failing to convert into
         show ID
-    :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     id_ = utility.convert_date_to_id(year, month, day)
@@ -70,7 +64,6 @@ def test_show_utility_convert_id_to_date(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
 
     :param show_id: Show ID to test converting into show date
-    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     date = utility.convert_id_to_date(show_id)
@@ -84,7 +77,6 @@ def test_show_utility_convert_invalid_id_to_date(show_id: int):
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
 
     :param show_id: Show ID to test failing to convert into show date
-    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     date = utility.convert_id_to_date(show_id)
@@ -99,11 +91,8 @@ def test_show_utility_date_exists(year: int,
     """Testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`
 
     :param year: Four digit year to test if a show exists
-    :type year: int
     :param month: One or two digit month to test if a show exists
-    :type month: int
     :param day: One or two digit day to test if a show exists
-    :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     result = utility.date_exists(year, month, day)
@@ -118,12 +107,9 @@ def test_show_utility_date_not_exists(year: int,
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`
 
     :param year: Four digit year to test if a show does not exist
-    :type year: int
     :param month: One or two digit month to test if a show does not
         exist
-    :type month: int
     :param day: One or two digit day to test if a show does not exist
-    :type day: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     result = utility.date_exists(year, month, day)
@@ -136,7 +122,6 @@ def test_show_utility_id_exists(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
 
     :param show_id: Show ID to test if a show exists
-    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(show_id)
@@ -149,7 +134,6 @@ def test_show_utility_id_not_exists(show_id: int):
     """Negative testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
 
     :param show_id: Show ID to test if a show does not exist
-    :type show_id: int
     """
     utility = ShowUtility(connect_dict=get_connect_dict())
     result = utility.id_exists(show_id)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -6,7 +6,6 @@
 """Testing for object: :py:class:`wdtm.validation`
 """
 import json
-from typing import Any, Dict
 
 import pytest
 from wwdtm.validation import valid_int_id
@@ -17,7 +16,6 @@ def test_validation_valid_int_id(test_id: int):
     """Testing for :py:meth:`wwdtm.validation.valid_int_id`
 
     :param test_id: ID to test ID validation
-    :type test_id: int
     """
     assert valid_int_id(test_id), f"Provided ID {test_id} was not valid"
 
@@ -27,6 +25,5 @@ def test_validation_invalid_int_id(test_id: int):
     """Negative testing for :py:meth:`wwdtm.validation.valid_int_id`
 
     :param test_id: ID to test failing ID validation
-    :type test_id: int
     """
     assert not valid_int_id(test_id), f"Provided ID {test_id} was valid"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.6"
+VERSION = "2.0.0-alpha.7+exp.7"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.4"
+VERSION = "2.0.0-alpha.7+exp.6"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.6"
+VERSION = "2.0.0-alpha.7+exp.2"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.8"
+VERSION = "2.0.0-alpha.7+exp.9"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.3"
+VERSION = "2.0.0-alpha.7+exp.4"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.7"
+VERSION = "2.0.0-alpha.7+exp.8"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.9"
+VERSION = "2.0.0-beta.1"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,4 +25,4 @@ from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
 
-VERSION = "2.0.0-alpha.7+exp.2"
+VERSION = "2.0.0-alpha.7+exp.3"

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -19,10 +19,8 @@ class GuestAppearances:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -47,11 +45,9 @@ class GuestAppearances:
         information for the requested guest ID.
 
         :param guest_id: Guest ID
-        :type guest_id: int
         :return: Dictionary containing appearance counts and list of
             appearances for a guest. If guest appearances could not be
             retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(guest_id):
             return {}
@@ -121,11 +117,9 @@ class GuestAppearances:
         information for the requested guest slug string.
 
         :param guest_slug: Guest slug string
-        :type guest_slug: str
         :return: Dictionary containing appearance counts and list of
             appearances for a guest. If guest appearances could not be
             retrieved, empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(guest_slug)
         if not id_:

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -56,7 +56,7 @@ class GuestAppearances:
         if not valid_int_id(guest_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(gm.showid) FROM ww_showguestmap gm "
                  "JOIN ww_shows s ON s.showid = gm.showid "
@@ -70,8 +70,8 @@ class GuestAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result["regular_shows"],
-                "all_shows": result["all_shows"]
+                "regular_shows": result.regular_shows,
+                "all_shows": result.all_shows,
             }
         else:
             appearance_counts = {
@@ -79,9 +79,9 @@ class GuestAppearances:
                 "all_shows": 0,
             }
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT gm.showid AS show_id, s.showdate AS date, "
-                 "s.bestof AS best_of, s.repeatshowid, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
                  "gm.guestscore AS score, gm.exception AS score_exception "
                  "FROM ww_showguestmap gm "
                  "JOIN ww_guests g ON g.guestid = gm.guestid "
@@ -96,26 +96,24 @@ class GuestAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance["show_id"],
-                    "date": appearance["date"].isoformat(),
-                    "best_of": bool(appearance["best_of"]),
-                    "repeat_show": bool(appearance["repeatshowid"]),
-                    "score": appearance["score"] if appearance["score"] else None,
-                    "score_exception": bool(appearance["score_exception"]),
+                    "show_id": appearance.show_id,
+                    "date": appearance.date.isoformat(),
+                    "best_of": bool(appearance.best_of),
+                    "repeat_show": bool(appearance.repeat_show_id),
+                    "score": appearance.score if appearance.score else None,
+                    "score_exception": bool(appearance.score_exception),
                 }
                 appearances.append(info)
 
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": appearances,
             }
         else:
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": [],
             }
-
-        return appearance_info
 
     @lru_cache(typed=True)
     def retrieve_appearances_by_slug(self, guest_slug: str) -> Dict[str, Any]:

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -21,10 +21,8 @@ class Guest:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -51,7 +49,6 @@ class Guest:
         :return: List of all guests and their corresponding
             information. If guests could not be retrieved, an empty list
             is returned.
-        :rtype: List[Dict[str, Any]]
         """
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -83,7 +80,6 @@ class Guest:
         :return: List of all guests and their corresponding
             information and appearances. If guests could not be
             retrieved, an empty list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT guestid AS id, guest AS name, guestslug AS slug "
@@ -114,7 +110,6 @@ class Guest:
 
         :return: List of all guest IDs. If guest IDs could not be
             retrieved, an emtpy list is returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT guestid FROM ww_guests "
@@ -135,7 +130,6 @@ class Guest:
 
         :return: List of all guest slug strings. If guest slug strings
             could not be retrieved, an emtpy list is returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT guestslug FROM ww_guests "
@@ -156,11 +150,9 @@ class Guest:
         slug string for the requested guest ID.
 
         :param guest_id: Guest ID
-        :type guest_id: int
         :return: Dictionary containing guest information. If guest
             information could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(guest_id):
             return {}
@@ -189,11 +181,9 @@ class Guest:
         slug string for the requested guest slug string.
 
         :param guest_slug: Guest slug string
-        :type guest_slug: str
         :return: Dictionary containing guest information. If guest
             information could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = guest_slug.strip()
@@ -214,11 +204,9 @@ class Guest:
         string and appearance information for the requested Guest ID.
 
         :param guest_id: Guest ID
-        :type guest_id: int
         :return: Dictionary containing guest information and their
             appearances. If guest information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(guest_id):
             return {}
@@ -238,11 +226,9 @@ class Guest:
         string.
 
         :param guest_slug: Guest slug string
-        :type guest_slug: str
         :return: Dictionary containing guest information and their
             appearances. If guest information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = guest_slug.strip()

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -54,8 +54,8 @@ class Guest:
         :rtype: List[Dict[str, Any]]
         """
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT guestid AS id, guest, guestslug AS slug "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT guestid AS id, guest AS name, guestslug AS slug "
                  "FROM ww_guests "
                  "WHERE guestslug != 'none' "
                  "ORDER BY guest ASC;")
@@ -68,13 +68,11 @@ class Guest:
 
         guests = []
         for row in results:
-            guest = {
-                "id": row["id"],
-                "name": row["guest"],
-                "slug": row["slug"] if row["slug"] else slugify(row["guest"]),
-            }
-
-            guests.append(guest)
+            guests.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+            })
 
         return guests
 
@@ -87,8 +85,8 @@ class Guest:
             retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT guestid AS id, guest, guestslug AS slug "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT guestid AS id, guest AS name, guestslug AS slug "
                  "FROM ww_guests "
                  "WHERE guestslug != 'none' "
                  "ORDER BY guest ASC;")
@@ -101,15 +99,12 @@ class Guest:
 
         guests = []
         for row in results:
-            appearances = self.appearances.retrieve_appearances_by_id(row["id"])
-            guest = {
-                "id": row["id"],
-                "name": row["guest"],
-                "slug": row["slug"] if row["slug"] else slugify(row["guest"]),
-                "appearances": appearances,
-            }
-
-            guests.append(guest)
+            guests.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+            })
 
         return guests
 
@@ -126,17 +121,13 @@ class Guest:
                  "WHERE guestslug != 'none' "
                  "ORDER BY guest ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     def retrieve_all_slugs(self) -> List[str]:
         """Returns a list of all guest slug strings from the database,
@@ -151,17 +142,13 @@ class Guest:
                  "WHERE guestslug != 'none' "
                  "ORDER BY guest ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     @lru_cache(typed=True)
     def retrieve_by_id(self, guest_id: int) -> Dict[str, Any]:
@@ -178,8 +165,8 @@ class Guest:
         if not valid_int_id(guest_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT guestid AS id, guest, guestslug AS slug "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT guestid AS id, guest AS name, guestslug AS slug "
                  "FROM ww_guests "
                  "WHERE guestid = %s "
                  "LIMIT 1;")
@@ -190,13 +177,11 @@ class Guest:
         if not result:
             return {}
 
-        info = {
-            "id": result["id"],
-            "name": result["guest"],
-            "slug": result["slug"] if result["slug"] else slugify(result["guest"]),
+        return {
+            "id": result.id,
+            "name": result.name,
+            "slug": result.slug if result.slug else slugify(result.name),
         }
-
-        return info
 
     @lru_cache(typed=True)
     def retrieve_by_slug(self, guest_slug: str) -> Dict[str, Any]:

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -19,10 +19,8 @@ class GuestUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -44,9 +42,7 @@ class GuestUtility:
         """Converts a guest's ID to the matching guest slug string.
 
         :param guest_id: Guest ID
-        :type guest_id: int
         :return: Guest slug string, if a match is found
-        :rtype: str
         """
         if not valid_int_id(guest_id):
             return None
@@ -70,9 +66,7 @@ class GuestUtility:
         a match is found. If no match is found, None is returned.
 
         :param guest_slug: Guest slug string
-        :type guest_slug: str
         :return: Guest ID, if a match is found
-        :rtype: int
         """
         try:
             slug = guest_slug.strip()
@@ -99,9 +93,7 @@ class GuestUtility:
         """Checks to see if a guest ID exists.
 
         :param guest_id: Guest ID
-        :type guest_id: int
         :return: True or False, based on whether the guest ID exists
-        :rtype: bool
         """
         if not valid_int_id(guest_id):
             return False
@@ -121,10 +113,8 @@ class GuestUtility:
         """Checks to see if a guest slug string exists.
 
         :param guest_slug: Guest slug string
-        :type guest_slug: str
         :return: True or False, based on whether the guest slug string
             exists
-        :rtype: bool
         """
         try:
             slug = guest_slug.strip()

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -19,10 +19,8 @@ class HostAppearances:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -47,11 +45,9 @@ class HostAppearances:
         information for the requested host ID.
 
         :param host_id: Host ID
-        :type host_id: int
         :return:  Dictionary containing appearance counts and list of
             appearances for a host. If host appearances could not be
             retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(host_id):
             return {}
@@ -118,11 +114,9 @@ class HostAppearances:
         information for the requested host ID.
 
         :param host_slug: Host slug string
-        :type host_slug: str
         :return:  Dictionary containing appearance counts and list of
             appearances for a host. If host appearances could not be
             retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(host_slug)
         if not id_:

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -56,7 +56,7 @@ class HostAppearances:
         if not valid_int_id(host_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(hm.showid) FROM ww_showhostmap hm "
                  "JOIN ww_shows s ON s.showid = hm.showid "
@@ -70,8 +70,8 @@ class HostAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result["regular_shows"],
-                "all_shows": result["all_shows"],
+                "regular_shows": result.regular_shows,
+                "all_shows": result.all_shows,
             }
         else:
             appearance_counts = {
@@ -79,9 +79,8 @@ class HostAppearances:
                 "all_shows": 0,
             }
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT hm.showid AS show_id, s.showdate AS date, "
-                 "s.bestof AS best_of, s.repeatshowid, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
                  "hm.guest FROM ww_showhostmap hm "
                  "JOIN ww_hosts h ON h.hostid = hm.hostid "
                  "JOIN ww_shows s ON s.showid = hm.showid "
@@ -95,25 +94,23 @@ class HostAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance["show_id"],
-                    "date": appearance["date"].isoformat(),
-                    "best_of": bool(appearance["best_of"]),
-                    "repeat_show": bool(appearance["repeatshowid"]),
-                    "guest": bool(appearance["guest"]),
+                    "show_id": appearance.show_id,
+                    "date": appearance.date.isoformat(),
+                    "best_of": bool(appearance.best_of),
+                    "repeat_show": bool(appearance.repeat_show_id),
+                    "guest": bool(appearance.guest),
                 }
                 appearances.append(info)
 
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": appearances,
             }
         else:
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": [],
             }
-
-        return appearance_info
 
     @lru_cache(typed=True)
     def retrieve_appearances_by_slug(self, host_slug: str) -> Dict[str, Any]:

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -102,6 +102,7 @@ class Host:
             hosts.append({
                 "id": row.id,
                 "name": row.name,
+                "gender": row.gender,
                 "slug": row.slug if row.slug else slugify(row.name),
                 "appearances": self.appearances.retrieve_appearances_by_id(row.id),
             })
@@ -181,6 +182,7 @@ class Host:
         return {
             "id": result.id,
             "name": result.name,
+            "gender": result.gender,
             "slug": result.slug if result.slug else slugify(result.name),
         }
 

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -70,6 +70,7 @@ class Host:
             hosts.append({
                 "id": row.id,
                 "name": row.name,
+                "gender": row.gender,
                 "slug": row.slug if row.slug else slugify(row.name),
             })
 

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -52,8 +52,8 @@ class Host:
             If hosts could not be retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT hostid AS id, host, hostslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
                  "hostgender AS gender "
                  "FROM ww_hosts "
                  "WHERE hostslug != 'tbd' "
@@ -67,14 +67,11 @@ class Host:
 
         hosts = []
         for row in results:
-            host = {
-                "id": row["id"],
-                "name": row["host"],
-                "slug": row["slug"] if row["slug"] else slugify(row["host"]),
-                "gender": row["gender"],
-            }
-
-            hosts.append(host)
+            hosts.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+            })
 
         return hosts
 
@@ -87,8 +84,8 @@ class Host:
             list is returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT hostid AS id, host, hostslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
                  "hostgender AS gender "
                  "FROM ww_hosts "
                  "WHERE hostslug != 'tbd' "
@@ -102,16 +99,12 @@ class Host:
 
         hosts = []
         for row in results:
-            appearances = self.appearances.retrieve_appearances_by_id(row["id"])
-            host = {
-                "id": row["id"],
-                "name": row["host"],
-                "slug": row["slug"] if row["slug"] else slugify(row["host"]),
-                "gender": row["gender"],
-                "appearances": appearances,
-            }
-
-            hosts.append(host)
+            hosts.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+            })
 
         return hosts
 
@@ -128,17 +121,13 @@ class Host:
                  "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     def retrieve_all_slugs(self) -> List[str]:
         """Returns a list of all host slug strings from the database,
@@ -153,17 +142,13 @@ class Host:
                  "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     @lru_cache(typed=True)
     def retrieve_by_id(self, host_id: int) -> Dict[str, Any]:
@@ -180,8 +165,8 @@ class Host:
         if not valid_int_id(host_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT hostid AS id, host, hostslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
                  "hostgender AS gender "
                  "FROM ww_hosts "
                  "WHERE hostid = %s "
@@ -193,14 +178,11 @@ class Host:
         if not result:
             return {}
 
-        info = {
-            "id": result["id"],
-            "name": result["host"],
-            "slug": result["slug"] if result["slug"] else slugify(result["host"]),
-            "gender": result["gender"],
+        return {
+            "id": result.id,
+            "name": result.name,
+            "slug": result.slug if result.slug else slugify(result.name),
         }
-
-        return info
 
     @lru_cache(typed=True)
     def retrieve_by_slug(self, host_slug: str) -> Dict[str, Any]:

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -53,7 +53,6 @@ class Host:
         query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
                  "hostgender AS gender "
                  "FROM ww_hosts "
-                 "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -85,7 +84,6 @@ class Host:
         query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
                  "hostgender AS gender "
                  "FROM ww_hosts "
-                 "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -115,7 +113,6 @@ class Host:
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostid FROM ww_hosts "
-                 "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -135,7 +132,6 @@ class Host:
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostslug FROM ww_hosts "
-                 "WHERE hostslug != 'tbd' "
                  "ORDER BY host ASC;")
         cursor.execute(query)
         results = cursor.fetchall()

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -21,10 +21,8 @@ class Host:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -50,7 +48,6 @@ class Host:
 
         :return: List of all hosts and their corresponding information.
             If hosts could not be retrieved, an empty list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
@@ -83,7 +80,6 @@ class Host:
         :return: List of all hosts and their corresponding information
             and appearances. If hosts could not be retrieved, an empty
             list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT hostid AS id, host AS name, hostslug AS slug, "
@@ -116,7 +112,6 @@ class Host:
 
         :return: List of all host IDs. If host IDs could not be
             retrieved, an empty list is returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostid FROM ww_hosts "
@@ -137,7 +132,6 @@ class Host:
 
         :return: List of all host slug strings. If host slug strings
             could not be retrieved, an empty list is returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT hostslug FROM ww_hosts "
@@ -158,11 +152,9 @@ class Host:
         slug string for the requested host ID.
 
         :param host_id: Host ID
-        :type host_id: int
         :return: Dictionary containing host information. If host
             information could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(host_id):
             return {}
@@ -193,11 +185,9 @@ class Host:
         slug string for the requested host slug string.
 
         :param host_slug: Host slug string
-        :type host_slug: str
         :return: Dictionary containing host information. If host
             information could be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = host_slug.strip()
@@ -218,11 +208,9 @@ class Host:
         string and appearance information for the requested host ID.
 
         :param host_id: Host ID
-        :type host_id: int
         :return: Dictionary containing host information and their
             appearances. If host information could be retrieved, an
             empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(host_id):
             return {}
@@ -242,11 +230,9 @@ class Host:
         string.
 
         :param host_slug: Host slug string
-        :type host_slug: str
         :return: Dictionary containing host information and their
             appearances. If host information could be retrieved, an
             empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = host_slug.strip()

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -19,10 +19,8 @@ class HostUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -44,9 +42,7 @@ class HostUtility:
         """Converts a host's ID to the matching host slug string value.
 
         :param host_id: Host ID
-        :type host_id: int
         :return: Host slug string, if a match is found
-        :rtype: str
         """
         if not valid_int_id(host_id):
             return None
@@ -69,9 +65,7 @@ class HostUtility:
         """Converts a host's slug string to the matching host ID value.
 
         :param host_slug: Host slug string
-        :type host_slug: str
         :return: Host ID, if a match is found
-        :rtype: int
         """
         try:
             slug = host_slug.strip()
@@ -98,9 +92,7 @@ class HostUtility:
         """Checks to see if a host ID exists.
 
         :param host_id: Host ID
-        :type host_id: int
         :return: True or False, based on whether the host ID exists
-        :rtype: bool
         """
         if not valid_int_id(host_id):
             return False
@@ -120,10 +112,8 @@ class HostUtility:
         """Checks to see if a host slug string exists.
 
         :param host_slug: Host slug string
-        :type host_slug: str
         :return: True or False, based on whether the host slug string
             exists
-        :rtype: bool
         """
         try:
             slug = host_slug.strip()

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -54,8 +54,7 @@ class Location:
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT locationid AS id, city, state, venue, "
                  "locationslug AS slug "
-                 "FROM ww_locations "
-                 "WHERE locationslug != 'tbd' ")
+                 "FROM ww_locations ")
         if sort_by_venue:
             query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:
@@ -98,8 +97,7 @@ class Location:
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT locationid AS id, city, state, venue, "
                  "locationslug AS slug "
-                 "FROM ww_locations "
-                 "WHERE locationslug != 'tbd' ")
+                 "FROM ww_locations ")
         if sort_by_venue:
             query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:
@@ -136,8 +134,7 @@ class Location:
             retrieved, an empty list is returned.
         """
         cursor = self.database_connection.cursor(dictionary=False)
-        query = ("SELECT locationid FROM ww_locations "
-                 "WHERE locationslug != 'tbd' ")
+        query = ("SELECT locationid FROM ww_locations ")
         if sort_by_venue:
             query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:
@@ -161,8 +158,7 @@ class Location:
             strings could not be retrieved, an empty list is returned.
         """
         cursor = self.database_connection.cursor(dictionary=False)
-        query = ("SELECT locationslug FROM ww_locations "
-                 "WHERE locationslug != 'tbd' ")
+        query = ("SELECT locationslug FROM ww_locations ")
         if sort_by_venue:
             query = query + "ORDER BY venue ASC, city ASC, state ASC;"
         else:

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -20,10 +20,8 @@ class Location:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -49,11 +47,9 @@ class Location:
 
         :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
-        :type sort_by_venue: bool
         :return: List of all locations and their corresponding
             information. If locations could not be retrieved, an empty
             list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT locationid AS id, city, state, venue, "
@@ -95,11 +91,9 @@ class Location:
 
         :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
-        :type sort_by_venue: bool
         :return: List of all locations and their corresponding
             information and recordings. If locations could not be
             retrieved, an empty list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT locationid AS id, city, state, venue, "
@@ -138,10 +132,8 @@ class Location:
 
         :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
-        :type sort_by_venue: bool
         :return: List of all location IDs. If location IDs could not be
             retrieved, an empty list is returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT locationid FROM ww_locations "
@@ -165,10 +157,8 @@ class Location:
 
         :param sort_by_venue: Sets whether to sort by venue first, or
             by state and city first
-        :type sort_by_venue: bool
         :return: List of all location slug strings. If location slug
             strings could not be retrieved, an empty list is returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT locationslug FROM ww_locations "
@@ -192,11 +182,9 @@ class Location:
         city, state and slug string for the requested location ID.
 
         :param location_id: Location ID
-        :type location_id: int
         :return: Dictionary containing location information. If
             location information could not be retrieved, an empty
             dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(location_id):
             return {}
@@ -231,11 +219,9 @@ class Location:
         city, state and slug string for the requested location ID.
 
         :param location_slug: Location slug string
-        :type location_slug: str
         :return: Dictionary containing location information. If
             location information could not be retrieved, an empty
             dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = location_slug.strip()
@@ -257,11 +243,9 @@ class Location:
         requested location ID.
 
         :param location_id: Location ID
-        :type location_id: int
         :return: Dictionary containing location information and their
             recordings. If location information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(location_id):
             return {}
@@ -281,11 +265,9 @@ class Location:
         requested location slug string.
 
         :param location_slug: Location slug string
-        :type location_slug: str
         :return: Dictionary containing location information and their
             recordings. If location information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = location_slug.strip()

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -56,7 +56,7 @@ class LocationRecordings:
         if not valid_int_id(location_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(lm.showid) FROM ww_showlocationmap lm "
                  "JOIN ww_shows s ON s.showid = lm.showid "
@@ -69,13 +69,12 @@ class LocationRecordings:
         result = cursor.fetchone()
 
         recording_counts = {
-            "regular_shows": result["regular_shows"],
-            "all_shows": result["all_shows"],
+            "regular_shows": result.regular_shows,
+            "all_shows": result.all_shows,
         }
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT lm.showid AS show_id, s.showdate AS date, "
-                 "s.bestof AS best_of, s.repeatshowid "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id "
                  "FROM ww_showlocationmap lm "
                  "JOIN ww_shows s ON s.showid = lm.showid "
                  "WHERE lm.locationid = %s "
@@ -88,24 +87,22 @@ class LocationRecordings:
             recordings = []
             for recording in results:
                 info = {
-                    "show_id": recording["show_id"],
-                    "date": recording["date"].isoformat(),
-                    "best_of": bool(recording["best_of"]),
-                    "repeat_show": bool(recording["repeatshowid"]),
+                    "show_id": recording.show_id,
+                    "date": recording.date.isoformat(),
+                    "best_of": bool(recording.best_of),
+                    "repeat_show": bool(recording.repeat_show_id),
                 }
                 recordings.append(info)
 
-            recording_info = {
+            return {
                 "count": recording_counts,
                 "shows": recordings,
             }
         else:
-            recording_info = {
+            return {
                 "count": recording_counts,
                 "shows": [],
             }
-
-        return recording_info
 
     @lru_cache(typed=True)
     def retrieve_recordings_by_slug(self, location_slug: str) -> Dict[str, Any]:

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -19,10 +19,8 @@ class LocationRecordings:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -47,11 +45,9 @@ class LocationRecordings:
         information for the requested location ID.
 
         :param location_id: Location ID
-        :type location_id: int
         :return: Dictionary containing recording counts and a list of
             appearances for a location. If location recordings could
             not be retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(location_id):
             return {}
@@ -110,11 +106,9 @@ class LocationRecordings:
         information for the requested location slug string.
 
         :param location_slug: Location slug string
-        :type location_slug: str
         :return: Dictionary containing recording counts and a list of
             appearances for a location. If location recordings could
             not be retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(location_slug)
         if not id_:

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -20,10 +20,8 @@ class LocationUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -46,9 +44,7 @@ class LocationUtility:
         string value.
 
         :param location_id: Location ID
-        :type location_id: int
         :return: Location slug string, if a match is found
-        :rtype: str
         """
         if not valid_int_id(location_id):
             return None
@@ -72,9 +68,7 @@ class LocationUtility:
         ID value.
 
         :param location_slug: Location slug string
-        :type location_slug: str
         :return: Location ID, if a match is found
-        :rtype: int
         """
         try:
             slug = location_slug.strip()
@@ -101,9 +95,7 @@ class LocationUtility:
         """Checks to see if a location ID exists.
 
         :param location_id: Location ID
-        :type location_id: int
         :return: True or False, based on whether the location ID exists
-        :rtype: bool
         """
         if not valid_int_id(location_id):
             return False
@@ -123,10 +115,8 @@ class LocationUtility:
         """Checks to see if a location slug string exists.
 
         :param location_slug: Location slug string
-        :type location_slug: str
         :return: True or False, based on whether the location slug
             string exists
-        :rtype: bool
         """
         try:
             slug = location_slug.strip()
@@ -146,24 +136,19 @@ class LocationUtility:
         return bool(result)
 
     @staticmethod
-    def slugify_location(location_id: int = None,
-                         venue: str = None,
-                         city: str = None,
-                         state: str = None
+    def slugify_location(location_id: Optional[int] = None,
+                         venue: Optional[str] = None,
+                         city: Optional[str] = None,
+                         state: Optional[str] = None
                          ) -> str:
         """Generates a slug string based on the location's venue name,
         city, state and/or location ID.
 
         :param location_id: Location ID
-        :type location_id: int
         :param venue: Location venue name
-        :type venue: str
         :param city: City where the location venue is located
-        :type city: str
         :param state: State where the location venue is located
-        :type state: str
         :return: Location slug string
-        :rtype: str
         :raises: ValueError
         """
         if venue and city and state:

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -56,7 +56,7 @@ class PanelistAppearances:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(pm.showid) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
@@ -76,9 +76,9 @@ class PanelistAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result["regular_shows"],
-                "all_shows": result["all_shows"],
-                "shows_with_scores": result["shows_with_scores"],
+                "regular_shows": result.regular_shows,
+                "all_shows": result.all_shows,
+                "shows_with_scores": result.shows_with_scores,
             }
         else:
             appearance_counts = {
@@ -87,7 +87,6 @@ class PanelistAppearances:
                 "shows_with_scores": 0,
             }
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT MIN(s.showid) AS first_id, MIN(s.showdate) AS first, "
                  "MAX(s.showid) AS most_recent_id, MAX(s.showdate) AS most_recent "
                  "FROM ww_showpnlmap pm "
@@ -98,15 +97,15 @@ class PanelistAppearances:
         cursor.execute(query, (panelist_id, ))
         result = cursor.fetchone()
 
-        if result and result["first_id"]:
+        if result and result.first_id:
             first = {
-                "show_id": result["first_id"],
-                "show_date": result["first"].isoformat(),
+                "show_id": result.first_id,
+                "show_date": result.first.isoformat(),
             }
 
             most_recent = {
-                "show_id": result["most_recent_id"],
-                "show_date": result["most_recent"].isoformat(),
+                "show_id": result.most_recent_id,
+                "show_date": result.most_recent.isoformat(),
             }
 
             milestones = {
@@ -122,13 +121,12 @@ class PanelistAppearances:
                 "milestones": None,
             }
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT pm.showid AS show_id, s.showdate AS date, "
-                 "s.bestof AS best_of, s.repeatshowid, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
                  "pm.panelistlrndstart AS start, "
                  "pm.panelistlrndcorrect AS correct, "
                  "pm.panelistscore AS score, "
-                 "pm.showpnlrank FROM ww_showpnlmap pm "
+                 "pm.showpnlrank AS rank FROM ww_showpnlmap pm "
                  "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
@@ -141,14 +139,14 @@ class PanelistAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance["show_id"],
-                    "date": appearance["date"].isoformat(),
-                    "best_of": bool(appearance["best_of"]),
-                    "repeat_show": bool(appearance["repeatshowid"]),
-                    "lightning_round_start": appearance["start"] if appearance["start"] else None,
-                    "lightning_round_correct": appearance["correct"] if appearance["correct"] else None,
-                    "score": appearance["score"] if appearance["score"] else None,
-                    "rank": appearance["showpnlrank"] if appearance["showpnlrank"] else None,
+                    "show_id": appearance.show_id,
+                    "date": appearance.date.isoformat(),
+                    "best_of": bool(appearance.best_of),
+                    "repeat_show": bool(appearance.repeat_show_id),
+                    "lightning_round_start": appearance.start if appearance.start else None,
+                    "lightning_round_correct": appearance.correct if appearance.correct else None,
+                    "score": appearance.score if appearance.score else None,
+                    "rank": appearance.rank if appearance.rank else None,
                 }
                 appearances.append(info)
 
@@ -194,7 +192,7 @@ class PanelistAppearances:
             return {}
 
         years = {}
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT DISTINCT YEAR(s.showdate) AS year "
                  "FROM ww_shows s "
                  "ORDER BY YEAR(s.showdate) ASC;")
@@ -205,9 +203,8 @@ class PanelistAppearances:
             return {}
 
         for row in results:
-            years[row["year"]] = 0
+            years[row.year] = 0
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT YEAR(s.showdate) AS year, "
                  "COUNT(p.panelist) AS count "
                  "FROM ww_showpnlmap pm "
@@ -225,7 +222,7 @@ class PanelistAppearances:
             return {}
 
         for row in results:
-            years[row["year"]] = row["count"]
+            years[row.year] = row.count
 
         return years
 

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -19,10 +19,8 @@ class PanelistAppearances:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -47,11 +45,9 @@ class PanelistAppearances:
         information for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
-        :return:  Dictionary containing appearance counts and list of
+        :return: Dictionary containing appearance counts and list of
             appearances for a panelist. If panelist appearances could
             not be retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -164,11 +160,9 @@ class PanelistAppearances:
         information for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
-        :return:  Dictionary containing appearance counts and list of
+        :return: Dictionary containing appearance counts and list of
             appearances for a panelist. If panelist appearances could
             not be retrieved, an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -182,11 +176,9 @@ class PanelistAppearances:
         down by year, for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing scoring breakdown by year. If
             panelist appearances could not be retrieved, an empty
             dictionary is returned.
-        :rtype: Dict[int, int]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -233,11 +225,9 @@ class PanelistAppearances:
         down by year, for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing scoring breakdown by year. If
             panelist appearances could not be retrieved, an empty
             dictionary is returned.
-        :rtype: Dict[int, int]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -109,7 +109,7 @@ class Panelist:
                 "slug": row.slug if row.slug else slugify(row.name),
                 "gender": row.gender,
                 "statistics": self.statistics.retrieve_statistics_by_id(row.id),
-                "bluff": self.statistics.retrieve_bluffs_by_id(row.id),
+                "bluffs": self.statistics.retrieve_bluffs_by_id(row.id),
                 "appearances": self.appearances.retrieve_appearances_by_id(row.id),
             })
 

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -22,10 +22,8 @@ class Panelist:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -53,7 +51,6 @@ class Panelist:
         :return: List of all panelists and their corresponding
             information. If panelists could not be retrieved, an empty
             list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT panelistid AS id, panelist AS name, panelistslug AS slug, "
@@ -86,7 +83,6 @@ class Panelist:
         :return: List of all panelists and their corresponding
             information and appearances. If panelists could not be
             retrieved, an empty list is returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT panelistid AS id, panelist AS name, panelistslug AS slug, "
@@ -121,7 +117,6 @@ class Panelist:
 
         :return: List of all panelist IDs. If panelist IDs could not be
             retrieved, an empty list is returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT panelistid FROM ww_panelists "
@@ -142,7 +137,6 @@ class Panelist:
 
         :return: List of all panelist slug strings. If panelist slug
             strings could not be retrieved, an empty list is returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT panelistslug FROM ww_panelists "
@@ -163,11 +157,9 @@ class Panelist:
         slug string for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing panelist information. If panelist
             information could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -198,11 +190,9 @@ class Panelist:
         slug string for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing panelist information. If panelist
             information could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = panelist_slug.strip()
@@ -223,11 +213,9 @@ class Panelist:
         string and appearance information for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing panelist information and their
             appearances. If panelist information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -249,11 +237,9 @@ class Panelist:
         string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing panelist information and their
             appearances. If panelist information could not be retrieved,
             an empty dictionary is returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = panelist_slug.strip()

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -55,8 +55,8 @@ class Panelist:
             list is returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT panelistid AS id, panelist, panelistslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT panelistid AS id, panelist AS name, panelistslug AS slug, "
                  "panelistgender AS gender "
                  "FROM ww_panelists "
                  "WHERE panelistslug != 'multiple' "
@@ -70,14 +70,12 @@ class Panelist:
 
         panelists = []
         for row in results:
-            panelist = {
-                "id": row["id"],
-                "name": row["panelist"],
-                "slug": row["slug"] if row["slug"] else slugify(row["panelist"]),
-                "gender": row["gender"],
-            }
-
-            panelists.append(panelist)
+            panelists.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "gender": row.gender,
+            })
 
         return panelists
 
@@ -90,8 +88,8 @@ class Panelist:
             retrieved, an empty list is returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT panelistid AS id, panelist, panelistslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT panelistid AS id, panelist AS name, panelistslug AS slug, "
                  "panelistgender AS gender "
                  "FROM ww_panelists "
                  "WHERE panelistslug != 'multiple' "
@@ -105,18 +103,15 @@ class Panelist:
 
         panelists = []
         for row in results:
-            id_ = row["id"]
-            panelist = {
-                "id": id_,
-                "name": row["panelist"],
-                "slug": row["slug"] if row["slug"] else slugify(row["panelist"]),
-                "gender": row["gender"],
-                "statistics": self.statistics.retrieve_statistics_by_id(id_),
-                "bluff": self.statistics.retrieve_bluffs_by_id(id_),
-                "appearances": self.appearances.retrieve_appearances_by_id(id_),
-            }
-
-            panelists.append(panelist)
+            panelists.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "gender": row.gender,
+                "statistics": self.statistics.retrieve_statistics_by_id(row.id),
+                "bluff": self.statistics.retrieve_bluffs_by_id(row.id),
+                "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+            })
 
         return panelists
 
@@ -133,17 +128,13 @@ class Panelist:
                  "WHERE panelistslug != 'multiple' "
                  "ORDER BY panelist ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     def retrieve_all_slugs(self) -> List[str]:
         """Returns a list of all panelist slug strings from the
@@ -158,17 +149,13 @@ class Panelist:
                  "WHERE panelistslug != 'multiple' "
                  "ORDER BY panelist ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     @lru_cache(typed=True)
     def retrieve_by_id(self, panelist_id: int) -> Dict[str, Any]:
@@ -185,8 +172,8 @@ class Panelist:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT panelistid AS id, panelist, panelistslug AS slug, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT panelistid AS id, panelist AS name, panelistslug AS slug, "
                  "panelistgender AS gender "
                  "FROM ww_panelists "
                  "WHERE panelistid = %s "
@@ -198,14 +185,12 @@ class Panelist:
         if not result:
             return {}
 
-        info = {
-            "id": result["id"],
-            "name": result["panelist"],
-            "slug": result["slug"] if result["slug"] else slugify(result["panelist"]),
-            "gender": result["gender"],
+        return {
+            "id": result.id,
+            "name": result.name,
+            "slug": result.slug if result.slug else slugify(result.name),
+            "gender": result.gender,
         }
-
-        return info
 
     @lru_cache(typed=True)
     def retrieve_by_slug(self, panelist_slug: str) -> Dict[str, Any]:

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -56,12 +56,13 @@ class PanelistScores:
             return []
 
         scores = []
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT s.showdate, pm.panelistscore "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT pm.panelistscore AS score "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE panelistid = %s "
-                 "AND s.bestof = 0 and s.repeatshowid IS NULL;")
+                 "AND s.bestof = 0 and s.repeatshowid IS NULL "
+                 "ORDER BY s.showdate ASC;")
         cursor.execute(query, (panelist_id, ))
         result = cursor.fetchall()
         cursor.close()
@@ -70,8 +71,8 @@ class PanelistScores:
             return []
 
         for appearance in result:
-            if appearance["panelistscore"]:
-                scores.append(appearance["panelistscore"])
+            if appearance.score:
+                scores.append(appearance.score)
 
         return scores
 
@@ -110,7 +111,7 @@ class PanelistScores:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT MIN(pm.panelistscore) AS min, "
                  "MAX(pm.panelistscore) AS max "
                  "FROM ww_showpnlmap pm "
@@ -121,14 +122,13 @@ class PanelistScores:
         if not result:
             return {}
 
-        min_score = result["min"]
-        max_score = result["max"]
+        min_score = result.min
+        max_score = result.max
 
         scores = {}
         for score in range(min_score, max_score + 1):
             scores[score] = 0
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT pm.panelistscore AS score, "
                  "COUNT(pm.panelistscore) AS score_count "
                  "FROM ww_showpnlmap pm "
@@ -146,14 +146,12 @@ class PanelistScores:
             return {}
 
         for row in results:
-            scores[row["score"]] = row["score_count"]
+            scores[row.score] = row.score_count
 
-        scores_list = {
+        return {
             "score": list(scores.keys()),
             "count": list(scores.values()),
         }
-
-        return scores_list
 
     @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_slug(self, panelist_slug: str
@@ -192,7 +190,7 @@ class PanelistScores:
         if not valid_int_id(panelist_id):
             return []
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT MIN(pm.panelistscore) AS min, "
                  "MAX(pm.panelistscore) AS max "
                  "FROM ww_showpnlmap pm;")
@@ -202,14 +200,13 @@ class PanelistScores:
         if not result:
             return []
 
-        min_score = result["min"]
-        max_score = result["max"]
+        min_score = result.min
+        max_score = result.max
 
         scores = {}
         for score in range(min_score, max_score + 1):
             scores[score] = 0
 
-        cursor = self.database_connection.cursor(dictionary=True)
         query = ("SELECT pm.panelistscore AS score, "
                  "COUNT(pm.panelistscore) AS score_count "
                  "FROM ww_showpnlmap pm "
@@ -227,7 +224,7 @@ class PanelistScores:
             return []
 
         for row in results:
-            scores[row["score"]] = row["score_count"]
+            scores[row.score] = row.score_count
 
         return list(scores.items())
 
@@ -268,8 +265,8 @@ class PanelistScores:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT s.showdate, pm.panelistscore "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showdate AS date, pm.panelistscore AS score "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
@@ -286,15 +283,13 @@ class PanelistScores:
         show_list = []
         score_list = []
         for shows in results:
-            show_list.append(shows["showdate"].isoformat())
-            score_list.append(shows["panelistscore"])
+            show_list.append(shows.date.isoformat())
+            score_list.append(shows.score)
 
-        scores = {
+        return {
             "shows": show_list,
             "scores": score_list,
         }
-
-        return scores
 
     @lru_cache(typed=True)
     def retrieve_scores_list_by_slug(self, panelist_slug: str,
@@ -332,8 +327,8 @@ class PanelistScores:
         if not valid_int_id(panelist_id):
             return []
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT s.showdate, pm.panelistscore "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showdate AS date, pm.panelistscore AS score "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
@@ -349,8 +344,8 @@ class PanelistScores:
 
         scores = []
         for show in results:
-            show_date = show["showdate"].isoformat()
-            score = show["panelistscore"]
+            show_date = show.date.isoformat()
+            score = show.score
             scores.append((show_date, score))
 
         return scores

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -19,10 +19,8 @@ class PanelistScores:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -47,10 +45,8 @@ class PanelistScores:
         requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: List containing panelist scores. If panelist scores
             could not be retrieved, an empty list is returned.
-        :rtype: List[int]
         """
         if not valid_int_id(panelist_id):
             return []
@@ -83,10 +79,8 @@ class PanelistScores:
         requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: List containing panelist scores. If panelist scores
             could not be retrieved, an empty list is returned.
-        :rtype: List[int]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -101,12 +95,10 @@ class PanelistScores:
         panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing two lists, one containing scores
             and one containing counts of those scores. If panelist
             scores could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, List[int]]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -160,12 +152,10 @@ class PanelistScores:
         panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing two lists, one containing scores
             and one containing counts of those scores. If panelist
             scores could not be retrieved, an empty dictionary is
             returned.
-        :rtype: Dict[str, List[int]]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -181,11 +171,9 @@ class PanelistScores:
         for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: List of tuples containing scores and score counts. If
             panelist scores could not be retrieved, an empty list is
             returned.
-        :rtype: List[Tuple[int, int]]
         """
         if not valid_int_id(panelist_id):
             return []
@@ -236,11 +224,9 @@ class PanelistScores:
         for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: List of tuples containing scores and score counts. If
             panelist scores could not be retrieved, an empty list is
             returned.
-        :rtype: List[Tuple[int, int]]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -256,11 +242,9 @@ class PanelistScores:
         panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing a list show dates and a list
             of scores. If panelist scores could not be retrieved, an
             empty dictionary is returned.
-        :rtype: Dict[str, List]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -299,11 +283,9 @@ class PanelistScores:
         panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing a list show dates and a list
             of scores. If panelist scores could not be retrieved, an
             empty dictionary is returned.
-        :rtype: Dict[str, List]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -318,11 +300,9 @@ class PanelistScores:
         corresponding score for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: List of tuples containing show dates and scores. If
             panelist scores could not be retrieved, an empty list is
             returned.
-        :rtype: List[Tuple[str, int]]
         """
         if not valid_int_id(panelist_id):
             return []
@@ -357,11 +337,9 @@ class PanelistScores:
         corresponding score for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: List of tuples containing show dates and scores. If
             panelist scores could not be retrieved, an empty list is
             returned.
-        :rtype: List[Tuple[str, int]]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -22,10 +22,8 @@ class PanelistStatistics:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -51,11 +49,9 @@ class PanelistStatistics:
         and correct Bluffs for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing panelist Bluff counts. If
             panelist Bluff counts could not be returned, an empty
             dictionary will be returned.
-        :rtype: Dict[str, int]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
@@ -85,11 +81,9 @@ class PanelistStatistics:
         and correct Bluffs for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing panelist Bluff counts. If
             panelist Bluff counts could not be returned, an empty
             dictionary will be returned.
-        :rtype: Dict[str, int]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -103,11 +97,9 @@ class PanelistStatistics:
         requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing panelist ranking information. If
             panelist ranking information could not be returned, an empty
             dictionary will be returned.
-        :rtype: Dict[str, int]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -157,11 +149,9 @@ class PanelistStatistics:
         requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing panelist ranking information. If
             panelist ranking information could not be returned, an empty
             dictionary will be returned.
-        :rtype: Dict[str, int]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -175,11 +165,9 @@ class PanelistStatistics:
         data, and scoring data for the requested panelist ID.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Dictionary containing panelist statistics. If panelist
             statistics could not be returned, an empty dictionary will
             be returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -230,11 +218,9 @@ class PanelistStatistics:
         data, and scoring data for the requested panelist slug string.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Dictionary containing panelist statistics. If panelist
             statistics could not be returned, an empty dictionary will
             be returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -57,7 +57,7 @@ class PanelistStatistics:
             dictionary will be returned.
         :rtype: Dict[str, int]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(blm.chosenbluffpnlid) FROM ww_showbluffmap blm "
                  "JOIN ww_shows s ON s.showid = blm.showid "
@@ -74,12 +74,10 @@ class PanelistStatistics:
         if not result:
             return {}
 
-        bluffs = {
-            "chosen": result["chosen"],
-            "correct": result["correct"],
+        return {
+            "chosen": result.chosen,
+            "correct": result.correct,
         }
-
-        return bluffs
 
     @lru_cache(typed=True)
     def retrieve_bluffs_by_slug(self, panelist_slug: str) -> Dict[str, int]:
@@ -114,29 +112,29 @@ class PanelistStatistics:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '1' AND "
-                 "s.bestof = 0 and s.repeatshowid IS NULL) as '1', ( "
+                 "s.bestof = 0 and s.repeatshowid IS NULL) as 'first', ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '1t' AND "
-                 "s.bestof = 0 and s.repeatshowid IS NULL) as '1t', ( "
+                 "s.bestof = 0 and s.repeatshowid IS NULL) as 'first_tied', ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '2' AND "
-                 "s.bestof = 0 and s.repeatshowid IS NULL) as '2', ( "
+                 "s.bestof = 0 and s.repeatshowid IS NULL) as 'second', ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '2t' AND "
-                 "s.bestof = 0 and s.repeatshowid IS NULL) as '2t', ( "
+                 "s.bestof = 0 and s.repeatshowid IS NULL) as 'second_tied', ( "
                  "SELECT COUNT(pm.showpnlrank) FROM ww_showpnlmap pm "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s AND pm.showpnlrank = '3' AND "
                  "s.bestof = 0 and s.repeatshowid IS NULL "
-                 ") as '3';")
+                 ") as 'third';")
         cursor.execute(query, (panelist_id, panelist_id, panelist_id,
                                panelist_id, panelist_id, ))
         result = cursor.fetchone()
@@ -145,15 +143,13 @@ class PanelistStatistics:
         if not result:
             return {}
 
-        rank_info = {
-            "first": result["1"],
-            "first_tied":  result["1t"],
-            "second": result["2"],
-            "second_tied": result["2t"],
-            "third": result["3"],
+        return {
+            "first": result.first,
+            "first_tied": result.first_tied,
+            "second": result.second,
+            "second_tied": result.second_tied,
+            "third": result.third,
         }
-
-        return rank_info
 
     @lru_cache(typed=True)
     def retrieve_rank_info_by_slug(self, panelist_slug: str) -> Dict[str, int]:
@@ -223,12 +219,10 @@ class PanelistStatistics:
             "percentage": ranks_percentage,
         }
 
-        statistics = {
+        return {
             "scoring": scoring,
             "ranking": ranking,
         }
-
-        return statistics
 
     @lru_cache(typed=True)
     def retrieve_statistics_by_slug(self, panelist_slug: str) -> Dict[str, Any]:

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -19,10 +19,8 @@ class PanelistUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -45,9 +43,7 @@ class PanelistUtility:
         string value.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: Panelist slug string, if a match is found
-        :rtype: str
         """
         if not valid_int_id(panelist_id):
             return None
@@ -71,9 +67,7 @@ class PanelistUtility:
         value.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: Panelists ID, if a match is found
-        :rtype: int
         """
         try:
             slug = panelist_slug.strip()
@@ -100,9 +94,7 @@ class PanelistUtility:
         """Checks to see if a panelist ID exists.
 
         :param panelist_id: Panelist ID
-        :type panelist_id: int
         :return: True or False, based on whether the panelist ID exists
-        :rtype: bool
         """
         if not valid_int_id(panelist_id):
             return False
@@ -122,10 +114,8 @@ class PanelistUtility:
         """Checks to see if a panelist slug string exists.
 
         :param panelist_slug: Panelist slug string
-        :type panelist_slug: str
         :return: True or False, based on whether the panelist slug
             string exists
-        :rtype: bool
         """
         try:
             slug = panelist_slug.strip()

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -20,10 +20,8 @@ class ScorekeeperAppearances:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -48,12 +46,10 @@ class ScorekeeperAppearances:
         information for the requested scorekeeper ID.
 
         :param scorekeeper_id: Scorekeeper ID
-        :type scorekeeper_id: int
         :return: Dictionary containing appearance counts and list of
             appearances for a scorekeeper. If scorekeeper appearances
             could not be retrieved, an empty dictionary would be
             returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -123,12 +119,10 @@ class ScorekeeperAppearances:
         information for the requested scorekeeper ID.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :type scorekeeper_slug: str
         :return: Dictionary containing appearance counts and list of
             appearances for a scorekeeper. If scorekeeper appearances
             could not be retrieved, an empty dictionary would be
             returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_slug_to_id(scorekeeper_slug)
         if not id_:

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -58,7 +58,7 @@ class ScorekeeperAppearances:
         if not valid_int_id(scorekeeper_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
+        cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT ( "
                  "SELECT COUNT(skm.showid) FROM ww_showskmap skm "
                  "JOIN ww_shows s ON s.showid = skm.showid "
@@ -72,8 +72,8 @@ class ScorekeeperAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result["regular_shows"],
-                "all_shows": result["all_shows"],
+                "regular_shows": result.regular_shows,
+                "all_shows": result.all_shows,
             }
         else:
             appearance_counts = {
@@ -81,9 +81,9 @@ class ScorekeeperAppearances:
                 "all_shows": 0,
             }
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT skm.showid AS show_id, s.showdate AS date, s.bestof AS best_of, "
-                 "s.repeatshowid, skm.guest, skm.description "
+        query = ("SELECT skm.showid AS show_id, s.showdate AS date, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
+                 "skm.guest, skm.description "
                  "FROM ww_showskmap skm "
                  "JOIN ww_scorekeepers sk ON sk.scorekeeperid = skm.scorekeeperid "
                  "JOIN ww_shows s ON s.showid = skm.showid "
@@ -97,27 +97,25 @@ class ScorekeeperAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance["show_id"],
-                    "date": appearance["date"].isoformat(),
-                    "best_of": bool(appearance["best_of"]),
-                    "repeat_show": bool(appearance["repeatshowid"]),
-                    "guest": bool(appearance["guest"]),
-                    "description": appearance["description"],
+                    "show_id": appearance.show_id,
+                    "date": appearance.date.isoformat(),
+                    "best_of": bool(appearance.best_of),
+                    "repeat_show": bool(appearance.repeat_show_id),
+                    "guest": bool(appearance.guest),
+                    "description": appearance.description,
                 }
                 appearances.append(info)
 
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": appearances,
             }
 
         else:
-            appearance_info = {
+            return {
                 "count": appearance_counts,
                 "shows": [],
             }
-
-        return appearance_info
 
     @lru_cache(typed=True)
     def retrieve_appearances_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -73,7 +73,6 @@ class Scorekeeper:
                 "name": row.name,
                 "gender": row.gender,
                 "slug": row.slug if row.slug else slugify(row.name),
-                "gender": row.gender,
             })
 
         return scorekeepers

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -71,6 +71,7 @@ class Scorekeeper:
             scorekeepers.append({
                 "id": row.id,
                 "name": row.name,
+                "gender": row.gender,
                 "slug": row.slug if row.slug else slugify(row.name),
                 "gender": row.gender,
             })

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -53,8 +53,8 @@ class Scorekeeper:
             retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT scorekeeperid AS id, scorekeeper, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
                  "scorekeeperslug AS slug, scorekeepergender AS gender "
                  "FROM ww_scorekeepers "
                  "WHERE scorekeeperslug != 'tbd' "
@@ -68,14 +68,12 @@ class Scorekeeper:
 
         scorekeepers = []
         for row in results:
-            scorekeeper = {
-                "id": row["id"],
-                "name": row["scorekeeper"],
-                "slug": row["slug"] if row["slug"] else slugify(row["scorekeeper"]),
-                "gender": row["gender"],
-            }
-
-            scorekeepers.append(scorekeeper)
+            scorekeepers.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "gender": row.gender,
+            })
 
         return scorekeepers
 
@@ -89,8 +87,8 @@ class Scorekeeper:
             could not be retrieved, an empty list will be returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT scorekeeperid AS id, scorekeeper, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
                  "scorekeeperslug AS slug, scorekeepergender AS gender "
                  "FROM ww_scorekeepers "
                  "WHERE scorekeeperslug != 'tbd' "
@@ -104,16 +102,13 @@ class Scorekeeper:
 
         scorekeepers = []
         for row in results:
-            appearance = self.appearances.retrieve_appearances_by_id(row["id"])
-            scorekeeper = {
-                "id": row["id"],
-                "name": row["scorekeeper"],
-                "slug": row["slug"] if row["slug"] else slugify(row["scorekeeper"]),
-                "gender": row["gender"],
-                "appearances": appearance,
-            }
-
-            scorekeepers.append(scorekeeper)
+            scorekeepers.append({
+                "id": row.id,
+                "name": row.name,
+                "slug": row.slug if row.slug else slugify(row.name),
+                "gender": row.gender,
+                "appearances": self.appearances.retrieve_appearances_by_id(row.id)
+            })
 
         return scorekeepers
 
@@ -130,17 +125,13 @@ class Scorekeeper:
                  "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     def retrieve_all_slugs(self) -> List[str]:
         """Returns a list of all scorekeeper slug strings from the
@@ -156,17 +147,13 @@ class Scorekeeper:
                  "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
-        result = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not result:
+        if not results:
             return []
 
-        ids = []
-        for row in result:
-            ids.append(row[0])
-
-        return ids
+        return [v[0] for v in results]
 
     @lru_cache(typed=True)
     def retrieve_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
@@ -183,8 +170,8 @@ class Scorekeeper:
         if not valid_int_id(scorekeeper_id):
             return {}
 
-        cursor = self.database_connection.cursor(dictionary=True)
-        query = ("SELECT scorekeeperid AS id, scorekeeper, "
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
                  "scorekeeperslug AS slug, scorekeepergender AS gender "
                  "FROM ww_scorekeepers "
                  "WHERE scorekeeperid = %s "
@@ -196,14 +183,12 @@ class Scorekeeper:
         if not result:
             return {}
 
-        info = {
-            "id": result["id"],
-            "name": result["scorekeeper"],
-            "slug": result["slug"] if result["slug"] else slugify(result["scorekeeper"]),
-            "gender": result["gender"],
+        return {
+            "id": result.id,
+            "name": result.name,
+            "slug": result.slug if result.slug else slugify(result.name),
+            "gender": result.gender,
         }
-
-        return info
 
     @lru_cache(typed=True)
     def retrieve_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -21,10 +21,8 @@ class Scorekeeper:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -51,7 +49,6 @@ class Scorekeeper:
         :return: List of all scorekeepers and their corresponding
             information. If scorekeeper information could not be
             retrieved, an empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
@@ -85,7 +82,6 @@ class Scorekeeper:
         :return: List of all scorekeepers and their corresponding
             information and appearances. If scorekeeper information
             could not be retrieved, an empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
@@ -118,7 +114,6 @@ class Scorekeeper:
 
         :return: List of all scorekeeper IDs. If scorekeeper IDs could
             not be retrieved, an empty list would be returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperid FROM ww_scorekeepers "
@@ -140,7 +135,6 @@ class Scorekeeper:
         :return: List of all scorekeeper slug strings. If scorekeeper
             slug strings could not be retrieved, an empty list will be
             returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperslug FROM ww_scorekeepers "
@@ -161,11 +155,9 @@ class Scorekeeper:
         and slug string for the requested scorekeeper ID.
 
         :param scorekeeper_id: Scorekeeper ID
-        :type scorekeeper_id: int
         :return: Dictionary containing scorekeeper information. If
             scorekeeper information could not be retrieved, an empty
             dictionary will be returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -196,11 +188,9 @@ class Scorekeeper:
         and slug string for the requested scorekeeper slug string.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :type scorekeeper_slug: str
         :return: Dictionary containing scorekeeper information. If
             scorekeeper information could not be retrieved, an empty
             dictionary will be returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = scorekeeper_slug.strip()
@@ -222,11 +212,9 @@ class Scorekeeper:
         scorekeeper ID.
 
         :param scorekeeper_id: Scorekeeper ID
-        :type scorekeeper_id: int
         :return: Dictionary containing scorekeeper information and
             their appearances. If scorekeeper information could not be
             retrieved, an empty dictionary will be returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -246,11 +234,9 @@ class Scorekeeper:
         scorekeeper slug string.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :type scorekeeper_slug: str
         :return: Dictionary containing scorekeeper information and
             their appearances. If scorekeeper information could not be
             retrieved, an empty dictionary will be returned.
-        :rtype: Dict[str, Any]
         """
         try:
             slug = scorekeeper_slug.strip()

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -54,7 +54,6 @@ class Scorekeeper:
         query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
                  "scorekeeperslug AS slug, scorekeepergender AS gender "
                  "FROM ww_scorekeepers "
-                 "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -87,7 +86,6 @@ class Scorekeeper:
         query = ("SELECT scorekeeperid AS id, scorekeeper AS name, "
                  "scorekeeperslug AS slug, scorekeepergender AS gender "
                  "FROM ww_scorekeepers "
-                 "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -117,7 +115,6 @@ class Scorekeeper:
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperid FROM ww_scorekeepers "
-                 "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
@@ -138,7 +135,6 @@ class Scorekeeper:
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT scorekeeperslug FROM ww_scorekeepers "
-                 "WHERE scorekeeperslug != 'tbd' "
                  "ORDER BY scorekeeper ASC;")
         cursor.execute(query)
         results = cursor.fetchall()

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -19,10 +19,8 @@ class ScorekeeperUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -45,9 +43,7 @@ class ScorekeeperUtility:
         string value.
 
         :param scorekeeper_id: Scorekeeper ID
-        :type scorekeeper_id: int
         :return: Scorekeeper slug string, if a match is found
-        :rtype: str
         """
         if not valid_int_id(scorekeeper_id):
             return None
@@ -71,9 +67,7 @@ class ScorekeeperUtility:
         scorekeeper ID value.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :type scorekeeper_slug: str
         :return: Scorekeeper ID, if a match is found
-        :rtype: int
         """
         try:
             slug = scorekeeper_slug.strip()
@@ -100,10 +94,8 @@ class ScorekeeperUtility:
         """Checks to see if a scorekeeper ID exists.
 
         :param scorekeeper_id: Scorekeeper ID
-        :type scorekeeper_id: int
         :return: True or False, based on whether the scorekeeper ID
             exists
-        :rtype: bool
         """
         if not valid_int_id(scorekeeper_id):
             return False
@@ -123,10 +115,8 @@ class ScorekeeperUtility:
         """Checks to see if a scorekeeper slug string exists.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :type scorekeeper_slug: str
         :return: True or False, based on whether the scorekeeper slug
             string exists
-        :rtype: bool
         """
         try:
             slug = scorekeeper_slug.strip()

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -136,8 +136,8 @@ class ShowInfo:
                  "sk.scorekeeperid = skm.scorekeeperid "
                  "JOIN ww_showdescriptions sd ON sd.showid = s.showid "
                  "JOIN ww_shownotes sn ON sn.showid = s.showid "
-                 "WHERE s.showid IN "
-                 "({ids});".format(ids=", ".join(str(v) for v in show_ids)))
+                 "WHERE s.showid IN ({ids}) "
+                 "ORDER BY s.showdate ASC;".format(ids=", ".join(str(v) for v in show_ids)))
         cursor.execute(query)
         result = cursor.fetchall()
         cursor.close()

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -23,10 +23,8 @@ class ShowInfo:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -52,10 +50,8 @@ class ShowInfo:
         for the requested show ID.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: Dictionary containing correct and chosen Bluff the
             Listener information.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(show_id):
             return {}
@@ -105,17 +101,14 @@ class ShowInfo:
             "correct_panelist": correct_bluff_info,
         }
 
-    # @lru_cache(typed=True)
-    def retrieve_core_info_by_id(self, show_ids: List[int]) -> Dict[str, Any]:
+    def retrieve_core_info_by_ids(self, show_ids: List[int]) -> Dict[str, Any]:
         """Returns a dictionary with core information for the requested
         show ID.
 
-        :param show_id: Show IDs
-        :type show_id: List[int]
+        :param show_ids: List of show IDs
         :return: Dictionary containing host, scorekeeper, location,
             description and notes. If show core information could not be
             retrieved, an empty dictionary will be returned.
-        :rtype: Dict[str, Any]
         """
         for show_id in show_ids:
             if not valid_int_id(show_id):
@@ -226,11 +219,9 @@ class ShowInfo:
         guest information for the requested show ID.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: Dictionary containing Not My Job guest information. If
             Not My Job information could not be retrieved, an empty list
             will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         if not valid_int_id(show_id):
             return []
@@ -269,11 +260,9 @@ class ShowInfo:
         information for the requested show ID.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: List of panelists with corresponding scores and
             ranking information. If panelist information could not be
             retrieved, an empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         if not valid_int_id(show_id):
             return []

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -22,10 +22,8 @@ class Show:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -52,7 +50,6 @@ class Show:
         :return: List of all shows and their corresponding information.
             If show information could not be retrieved, an empty list
             will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT showid AS id, showdate AS date, "
@@ -91,7 +88,6 @@ class Show:
         :return: List of all shows and their corresponding details.
             If show information could not be retrieved, an empty list
             will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showid AS id FROM ww_shows "
@@ -104,7 +100,7 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_id(show_ids)
+        shows = self.info.retrieve_core_info_by_ids(show_ids)
 
         if not shows:
             return []
@@ -123,7 +119,6 @@ class Show:
 
         :return: List of all show IDs. If show IDs could not be
             retrieved, an empty list will be returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showid FROM ww_shows "
@@ -143,7 +138,6 @@ class Show:
 
         :return: List of all show date strings. If show dates could not
             be retrieved, an empty list will be returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showdate FROM ww_shows "
@@ -164,7 +158,6 @@ class Show:
         :return: List of allow show dates as a tuple of year, month
             and day. If show dates could not be retrieved, an empty list
             will be returned.
-        :rtype: List[Tuple[int, int, int]]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT YEAR(showdate), MONTH(showdate), DAY(showdate) "
@@ -186,7 +179,6 @@ class Show:
         :return: List of all show years and month in ``YYYY-MM`` format.
             If show dates could not be retrieved, an empty list will be
             returned.
-        :rtype: List[str]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT YEAR(showdate), MONTH(showdate) "
@@ -208,7 +200,6 @@ class Show:
         :return: List of allow show dates as a tuple of year and month.
             If show dates could not be retrieved, an empty list will be
             returned.
-        :rtype: List[Tuple[int, int]]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT YEAR(showdate), MONTH(showdate) "
@@ -232,15 +223,11 @@ class Show:
         Best Of and Repeat Show information for the requested show date.
 
         :param year: Four-digit year
-        :type year: int
         :param month: One or two-digit month
-        :type month: int
         :param day: One or two-digit day
-        :type day: int
         :return: Dictionary containing show information. If show
             information could not be retrieved, an empty dictionary will
             be returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_date_to_id(year, month, day)
         if not id_:
@@ -256,11 +243,9 @@ class Show:
         string.
 
         :param date_string: Show date in ``YYYY-MM-DD`` format
-        :type date_string: str
         :return: Dictionary containing show information. If show
             information could not be retrieved, an empty dictionary will
             be returned.
-        :rtype: Dict[str, Any]
         """
         try:
             parsed_date_string = date_parser.parse(date_string)
@@ -279,11 +264,9 @@ class Show:
         Best Of and Repeat Show information for the requested show ID.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: Dictionary containing show information. If show
             information could not be retrieved, an empty dictionary will
             be returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(show_id):
             return {}
@@ -320,11 +303,9 @@ class Show:
         information for the requested year, sorted by show date.
 
         :param year: Four-digit year
-        :type year: int
         :return: List of shows for the requested year and corresponding
             information. If show information could not be retrieved,
             an empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
@@ -353,13 +334,10 @@ class Show:
         date.
 
         :param year: Four-digit year
-        :type year: int
         :param month: One or two-digit month
-        :type month: int
         :return: List of shows for the requested year and month, and
             corresponding information. If show information could not be
             retrieved, a list of dictionaries will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
@@ -390,15 +368,11 @@ class Show:
         for the requested show date.
 
         :param year: Four-digit year
-        :type year: int
         :param month: One or two-digit month
-        :type month: int
         :param day: One or two digit day
-        :type day: int
         :return: Dictionary containing show information and details. If
             show information could not be retrieved, an empty dictionary
             will be returned.
-        :rtype: Dict[str, Any]
         """
         id_ = self.utility.convert_date_to_id(year, month, day)
         if not id_:
@@ -414,11 +388,9 @@ class Show:
         for the requested show date string.
 
         :param date_string: Show date in ``YYYY-MM-DD`` format
-        :type date_string: str
         :return: Dictionary containing show information and details. If
             show information could not be retrieved, an empty dictionary
             will be returned.
-        :rtype: Dict[str, Any]
         """
         try:
             parsed_date_string = date_parser.parse(date_string)
@@ -438,16 +410,14 @@ class Show:
         for the requested show ID.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: Dictionary containing show information and details. If
             show information could not be retrieved, an empty dictionary
             will be returned.
-        :rtype: Dict[str, Any]
         """
         if not valid_int_id(show_id):
             return {}
 
-        info = self.info.retrieve_core_info_by_id([show_id])
+        info = self.info.retrieve_core_info_by_ids([show_id])
         if not info:
             return {}
 
@@ -464,11 +434,9 @@ class Show:
         the requested year, sorted by show date.
 
         :param year: Four-digit year
-        :type year: int
         :return: List of shows for the requested year and corresponding
             details. If show information could not be retrieved, an
             empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
@@ -487,7 +455,7 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_id(show_ids)
+        shows = self.info.retrieve_core_info_by_ids(show_ids)
 
         if not shows:
             return []
@@ -509,13 +477,10 @@ class Show:
         the requested year and month, sorted by show date.
 
         :param year: Four-digit year
-        :type year: int
         :param month: One or two-digit month
-        :type month: int
         :return: List of shows for the requested year and month, and
             corresponding details. If show information could not be
             retrieved, an empty list will be returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
@@ -536,7 +501,7 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_id(show_ids)
+        shows = self.info.retrieve_core_info_by_ids(show_ids)
 
         if not shows:
             return []
@@ -556,10 +521,8 @@ class Show:
         year, sorted by month.
 
         :param year: Four-digit year
-        :type year: int
         :return: List of available show months. If show information
             could not be retrieved, an empty list will be returned.
-        :rtype: List[int]
         """
         try:
             _ = date_parser.parse(f"{year:04d}")
@@ -582,21 +545,19 @@ class Show:
 
     @lru_cache(typed=True)
     def retrieve_recent(self,
-                        include_days_ahead: int = 7,
-                        include_days_back: int = 32) -> List[Dict[str, Any]]:
+                        include_days_ahead: Optional[int] = 7,
+                        include_days_back: Optional[int] = 32
+                        ) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing show ID,
         show date, Best Of and Repeat Show information for recent shows.
 
         :param include_days_ahead: Number of days in the future to
             include, defaults to 7
-        :type include_days_ahead: int, optional
         :param include_days_back: Number of days in the past to
             include, defaults to 32
-        :type include_days_back: int, optional
         :return: List of recent shows and corresponding information. If
             show information could not be retrieved, an empty list will
             be returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             past_days = int(include_days_back)
@@ -626,8 +587,8 @@ class Show:
 
     @lru_cache(typed=True)
     def retrieve_recent_details(self,
-                                include_days_ahead: int = 7,
-                                include_days_back: int = 32
+                                include_days_ahead: Optional[int] = 7,
+                                include_days_back: Optional[int] = 32
                                 ) -> List[Dict[str, Any]]:
         """Returns a list of dictionary objects containing show ID,
         show date, host, scorekeeper, panelist and guest information
@@ -635,14 +596,11 @@ class Show:
 
         :param include_days_ahead: Number of days in the future to
             include, defaults to 7
-        :type include_days_ahead: int, optional
         :param include_days_back: Number of days in the past to
             include, defaults to 32
-        :type include_days_back: int, optional
         :return: List of recent shows and corresponding details. If show
             information could not be retrieved, an empty list will be
             returned.
-        :rtype: List[Dict[str, Any]]
         """
         try:
             past_days = int(include_days_back)
@@ -669,7 +627,7 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_id(show_ids)
+        shows = self.info.retrieve_core_info_by_ids(show_ids)
 
         if not shows:
             return []
@@ -688,11 +646,9 @@ class Show:
         shows in the requested year, sorted by show date.
 
         :param year: Four-digit year
-        :type year: int
         :return: List of tuples each containing show date and panelist
             scores. If show scores could not be retrieved, an empty list
             will be returned.
-        :rtype: List[Tuple[str, int, int, int]]
         """
         try:
             _ = date_parser.parse(f"{year:04d}")
@@ -734,7 +690,6 @@ class Show:
 
         :return: List of available show years. If show dates could not
             be retrieved, an empty list will be returned.
-        :rtype: List[int]
         """
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT YEAR(showdate) "

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -93,7 +93,7 @@ class Show:
             will be returned.
         :rtype: List[Dict[str, Any]]
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT showid AS id FROM ww_shows "
                  "ORDER BY showdate ASC;")
         cursor.execute(query)
@@ -103,15 +103,17 @@ class Show:
         if not results:
             return []
 
-        shows = []
-        for row in results:
-            info = self.info.retrieve_core_info_by_id(row.id)
-            if info:
-                info["panelists"] = self.info.retrieve_panelist_info_by_id(row.id)
-                info["bluff"] = self.info.retrieve_bluff_info_by_id(row.id)
-                info["guests"] = self.info.retrieve_guest_info_by_id(row.id)
+        show_ids = [v[0] for v in results]
+        shows = self.info.retrieve_core_info_by_id(show_ids)
 
-            shows.append(info)
+        if not shows:
+            return []
+
+        for show in shows:
+            if show:
+                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
+                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
+                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
 
         return shows
 
@@ -133,7 +135,7 @@ class Show:
         if not results:
             return []
 
-        return [[v[0] for v in results]]
+        return [v[0] for v in results]
 
     def retrieve_all_dates(self) -> List[str]:
         """Returns a list of all show dates from the database, sorted
@@ -153,7 +155,7 @@ class Show:
         if not results:
             return []
 
-        return [[v[0].isoformat() for v in results]]
+        return [v[0].isoformat() for v in results]
 
     def retrieve_all_dates_tuple(self) -> List[Tuple[int, int, int]]:
         """Returns a list of all show dates as a tuple of year, month,
@@ -445,15 +447,15 @@ class Show:
         if not valid_int_id(show_id):
             return {}
 
-        info = self.info.retrieve_core_info_by_id(show_id)
+        info = self.info.retrieve_core_info_by_id([show_id])
         if not info:
             return {}
 
-        info["panelists"] = self.info.retrieve_panelist_info_by_id(show_id)
-        info["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
-        info["guests"] = self.info.retrieve_guest_info_by_id(show_id)
+        info[0]["panelists"] = self.info.retrieve_panelist_info_by_id(show_id)
+        info[0]["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
+        info[0]["guests"] = self.info.retrieve_guest_info_by_id(show_id)
 
-        return info
+        return info[0]
 
     @lru_cache(typed=True)
     def retrieve_details_by_year(self, year: int) -> List[Dict[str, Any]]:
@@ -484,7 +486,19 @@ class Show:
         if not results:
             return []
 
-        return [self.retrieve_details_by_id(v[0]) for v in results]
+        show_ids = [v[0] for v in results]
+        shows = self.info.retrieve_core_info_by_id(show_ids)
+
+        if not shows:
+            return []
+
+        for show in shows:
+            if show:
+                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
+                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
+                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+
+        return shows
 
     @lru_cache(typed=True)
     def retrieve_details_by_year_month(self,
@@ -521,7 +535,19 @@ class Show:
         if not results:
             return []
 
-        return [self.retrieve_details_by_id(v[0]) for v in results]
+        show_ids = [v[0] for v in results]
+        shows = self.info.retrieve_core_info_by_id(show_ids)
+
+        if not shows:
+            return []
+
+        for show in shows:
+            if show:
+                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
+                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
+                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+
+        return shows
 
     @lru_cache(typed=True)
     def retrieve_months_by_year(self,
@@ -642,7 +668,19 @@ class Show:
         if not results:
             return []
 
-        return [self.retrieve_details_by_id(v[0]) for v in results]
+        show_ids = [v[0] for v in results]
+        shows = self.info.retrieve_core_info_by_id(show_ids)
+
+        if not shows:
+            return []
+
+        for show in shows:
+            if show:
+                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
+                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
+                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+
+        return shows
 
     @lru_cache(typed=True)
     def retrieve_scores_by_year(self, year: int) -> List[Tuple]:

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -20,10 +20,8 @@ class ShowUtility:
 
     :param connect_dict: Dictionary containing database connection
         settings as required by mysql.connector.connect
-    :type connect_dict: Dict[str, Any], optional
     :param database_connection: mysql.connector.connect database
         connection
-    :type database_connection: mysql.connector.connect, optional
     """
 
     def __init__(self,
@@ -48,13 +46,9 @@ class ShowUtility:
         """Converts a show date to the matching show ID value.
 
         :param year: Year portion of a show date
-        :type year: int
         :param month: Month portion of a show date
-        :type month: int
         :param day: Day portion of a show date
-        :type day: int
         :return: Show ID, if a match is found
-        :rtype: int
         """
         try:
             show_date = datetime.datetime(year, month, day)
@@ -79,9 +73,7 @@ class ShowUtility:
         """Converts a show's ID to the matching show date.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: Show date, if a match is found
-        :rtype: str
         """
         if not valid_int_id(show_id):
             return None
@@ -107,13 +99,9 @@ class ShowUtility:
         """Checks to see if a show date exists.
 
         :param year: Year portion of a show date
-        :type year: int
         :param month: Month portion of a show date
-        :type month: int
         :param day: Day portion of a show date
-        :type day: int
         :return: True or False, based on whether the show date exists
-        :rtype: bool
         """
         try:
             show_date = datetime.datetime(year, month, day)
@@ -135,9 +123,7 @@ class ShowUtility:
         """Checks to see if a show ID exists.
 
         :param show_id: Show ID
-        :type show_id: int
         :return: True or False, based on whether the show ID exists
-        :rtype: bool
         """
         if not valid_int_id(show_id):
             return False

--- a/wwdtm/validation.py
+++ b/wwdtm/validation.py
@@ -11,10 +11,8 @@ def valid_int_id(int_id: int) -> bool:
     in ID fields in MySQL tables.
 
     :param int_id: ID number to validate
-    :type int_id: int
     :return: True or False, based on if the integer falls inclusively
         between 0 and 2147483647
-    :rtype: bool
     """
     try:
         if not int_id:


### PR DESCRIPTION
Rework how data is queried from the database and processed to be more optimal in terms of performance and, in some places, memory usage. This includes changing from using dictionaries as return objects for MySQL Connect cursors to using  NamedTuples. Changes also include:

- Making use of list/dictionary comprehensions, where it makes sense
- Returning objects directly instead of assigning to a variable where feasible

Update docstrings to no longer explicitly list parameter and return types. Instead, both are now autogenerated as part of Sphinx extensions: `sphinx_toolbox.more_autodoc.typehints` and `sphinx_autodoc_typehints`. These changes were also made to all of the test modules.

Lastly, add a new performance testing script to get a gauge on how key modules and methods perform on different systems and as changes are made to optimize code, operating system configuration changes, etc.