### PR TITLE
Optimizing Performance for wwdtm.show

### DIFF
--- a/docs/migrating/show.rst
+++ b/docs/migrating/show.rst
@@ -16,10 +16,6 @@ changed to become methods under :py:class:`wwdtm.show.ShowInfo`:
 
 * :py:func:`retrieve_bluff_info_by_id`
 * :py:func:`retrieve_core_info_by_id`
-
-  * Renamed to :py:meth:`retrieve_core_info_by_ids`
-  * Changed the ``show_id`` (:py:class:`int`) parameter to ``show_ids``
-    (:py:class:`list` [:py:class:`int`])
 * :py:func:`retrieve_guest_info_by_id`
 * :py:func:`retrieve_panelist_info_by_id`
 

--- a/docs/tests/show.rst
+++ b/docs/tests/show.rst
@@ -8,12 +8,20 @@ the following objects:
 
 - :py:class:`wwdtm.show.Show`
 - :py:class:`wwdtm.show.ShowInfo`
+- :py:class:`wwdtm.show.ShowInfoMultiple`
 - :py:class:`wwdtm.show.ShowUtility`
 
 test_show_info
 ==============
 
 .. automodule:: tests.show.test_show_info
+    :members:
+    :undoc-members:
+
+test_show_info_multiple
+=======================
+
+.. automodule:: tests.show.test_show_info_multiple
     :members:
     :undoc-members:
 

--- a/docs/wwdtm/show.rst
+++ b/docs/wwdtm/show.rst
@@ -21,6 +21,13 @@ ShowInfo
     :members:
     :inherited-members:
 
+ShowInfoMultiple
+================
+
+.. autoclass:: wwdtm.show.ShowInfoMultiple
+    :members:
+    :inherited-members:
+
 ShowUtility
 ===========
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License 2.0
     Programming Language :: Python :: 3
+    Programming Language :: Python :: 3.8
     Topic :: Software Development :: Libraries
 
 [options]

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -42,16 +42,15 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
 
 
 @pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_core_info_by_ids(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_ids`
+def test_show_info_retrieve_core_info_by_id(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
 
     :param show_id: Show ID to test retrieving show core information
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    core = info.retrieve_core_info_by_ids([show_id])
+    show = info.retrieve_core_info_by_id(show_id)
 
-    assert core, f"Core information for show ID {show_id} could not be retrieved"
-    show = core[0]
+    assert show, f"Core information for show ID {show_id} could not be retrieved"
 
     assert "id" in show, (f"'id' was not returned with core information for "
                           f"show ID {show_id}")
@@ -69,10 +68,10 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
     guests = info.retrieve_guest_info_by_id(show_id)
 
     assert guests, f"Guest information for show ID {show_id} could not be retrieved"
-    assert "id" in guests[0], (f"'id' was not returned for the first list item "
-                               f"for show ID {show_id}")
-    assert "score" in guests[0], (f"'score' was not returned for the first list "
-                                  f"item for show ID {show_id}")
+    assert "id" in guests[0], (f"'id' was not returned for the first guest for "
+                               f"show ID {show_id}")
+    assert "score" in guests[0], (f"'score' was not returned for the first "
+                                  f"guest for show ID {show_id}")
 
 
 @pytest.mark.parametrize("show_id", [1162])
@@ -84,8 +83,9 @@ def test_show_info_retrieve_panelist_info_by_id(show_id: int):
     info = ShowInfo(connect_dict=get_connect_dict())
     panelists = info.retrieve_panelist_info_by_id(show_id)
 
-    assert panelists, f"Guest information for show ID {show_id} could not be retrieved"
-    assert "id" in panelists[0], (f"'id' was not returned for the first list "
-                                  f"item for show ID {show_id}")
+    assert panelists, (f"Panelist information for show ID {show_id} could not "
+                       "be retrieved")
+    assert "id" in panelists[0], (f"'id' was not returned for the first panelist "
+                                  f"for show ID {show_id}")
     assert "score" in panelists[0], (f"'score' was not returned for the first "
-                                     f"list item for show ID {show_id}")
+                                     f"panelist for show ID {show_id}")

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2021 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+"""Testing for object :py:class:`wwdtm.show.ShowInfo`
+"""
+import json
+from typing import Any, Dict, List
+
+import pytest
+from wwdtm.show import ShowInfoMultiple
+
+
+@pytest.mark.skip
+def get_connect_dict() -> Dict[str, Any]:
+    """Read in database connection settings and return values as a
+    dictionary.
+    """
+    with open("config.json", "r") as config_file:
+        config_dict = json.load(config_file)
+        if "database" in config_dict:
+            return config_dict["database"]
+
+
+@pytest.mark.parametrize("show_id", [1083])
+def test_show_info_retrieve_bluff_info_all(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`
+
+    :param show_id: Show ID to test retrieving show Bluff the Listener
+        information from all shows retrieved
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    bluffs = info.retrieve_bluff_info_all()
+
+    assert bluffs, ("Bluff the Listener information for all shows could not "
+                    "be retrieved")
+    assert show_id in bluffs, ("Bluff the Listener information was not "
+                               f"returned for show ID {show_id}")
+
+    bluff = bluffs[show_id]
+    assert "chosen_panelist" in bluff, ("'chosen_panelist' was not returned with "
+                                        f"panelist information for show ID {show_id}")
+    assert "correct_panelist" in bluff, ("'correct_panelist' was not returned with "
+                                         f"panelist information for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_ids", [[1083, 1162]])
+def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_by_ids`
+
+    :param show_ids: List of show IDs to test retrieving show Bluff the
+        Listener information
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    bluffs = info.retrieve_bluff_info_by_ids(show_ids)
+
+    assert bluffs, (f"Bluff the Listener information for the show IDs {show_ids} "
+                    f"could not be retrieved")
+
+    for show_id in show_ids:
+        assert show_id in bluffs, ("Bluff the Listener information was not "
+                                   f"returned for show ID {show_id}")
+        assert "chosen_panelist" in bluffs[show_id], ("'chosen_panelist' was not "
+                                                      "returned with panelist "
+                                                      "information for show ID "
+                                                      f"{show_id}")
+        assert "correct_panelist" in bluffs[show_id], ("'correct_panelist' was not "
+                                                       "returned with panelist "
+                                                       "information for show ID "
+                                                       f"{show_id}")
+
+
+@pytest.mark.parametrize("show_id", [1162])
+def test_show_info_retrieve_core_info_all(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_all`
+
+    :param show_id: Show ID to test retrieving show core information
+        from all shows retrieved
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows = info.retrieve_core_info_all()
+
+    assert shows, "Core information for all shows could not be retrieved"
+    assert show_id in shows, (f"Core information for show ID {show_id} "
+                              f"could not be retrieved")
+
+    show = shows[show_id]
+    assert "id" in show, ("'id' was not returned with core information for "
+                          f"show ID {show_id}")
+    assert "description" in show, ("'description' was not returned with show "
+                                   f"information for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_ids", [[1082, 1162]])
+def test_show_info_retrieve_core_info_by_ids(show_ids: List[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_by_ids`
+
+    :param show_id: Show ID to test retrieving show core information
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows = info.retrieve_core_info_by_ids(show_ids)
+
+    assert shows, "Core information all shows could not be retrieved"
+
+    for show_id in show_ids:
+        assert show_id in shows, ("Core information could not be retrieved for "
+                                  f"show ID {show_id}")
+        assert "id" in shows[show_id], ("'id' was not returned with core information "
+                                        f"for show ID {show_id}")
+        assert "description" in shows[show_id], ("'description' was not returned with "
+                                                 f"show information for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_id", [1082])
+def test_show_info_retrieve_guest_info_all(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_all`
+
+    :param show_id: Show ID to test retrieving show guest information
+        for all shows retrieved
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows_guests = info.retrieve_guest_info_all()
+
+    assert shows_guests, "Guest information all shows could not be retrieved"
+    assert show_id in shows_guests, ("Guest information could not be retrieved for "
+                                     f"show ID {show_id}")
+
+    guests = shows_guests[show_id]
+    if guests:
+        assert "id" in guests[0], ("'id' was not returned for the first guest "
+                                   f"for show ID {show_id}")
+        assert "score" in guests[0], ("'score' was not returned for the first "
+                                      f"guest for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_ids", [[1082, 1162]])
+def test_show_info_retrieve_guest_info_by_ids(show_ids: List[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_by_ids`
+
+    :param show_ids: List of show IDs to test retrieving show guest
+        information
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows_guests = info.retrieve_guest_info_by_ids(show_ids)
+
+    assert shows_guests, (f"Guest information for show IDs {show_ids} could not "
+                          "be retrieved")
+
+    for show_id in show_ids:
+        assert show_id in shows_guests, (f"Guest information for show ID {show_id} "
+                                         "could not be retrieved")
+
+        guests = shows_guests[show_id]
+        if guests:
+            assert "id" in guests[0], ("'id' was not returned for the first guest "
+                                       f"for show ID {show_id}")
+            assert "score" in guests[0], ("'score' was not returned for the first "
+                                          f"guest for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_id", [1082])
+def test_show_info_retrieve_panelist_info_all(show_id: int):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
+
+    :param show_id: Show ID to test retrieving show panelist information
+        for all shows retrieved
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows_panelists = info.retrieve_panelist_info_all()
+
+    assert shows_panelists, f"Panelist information for all shows could not be retrieved"
+    assert show_id in shows_panelists, ("Panelist information could not be retrieved "
+                                        f"for show ID {show_id}")
+
+    panelists = shows_panelists[show_id]
+    assert "id" in panelists[0], (f"'id' was not returned for the first panelist "
+                                  f"for show ID {show_id}")
+    assert "score" in panelists[0], (f"'score' was not returned for the first "
+                                     f"panelist for show ID {show_id}")
+
+
+@pytest.mark.parametrize("show_ids", [[1082, 1162]])
+def test_show_info_retrieve_panelist_info_by_ids(show_ids: List[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
+
+    :param show_ids: List of show IDs to test retrieving show panelist
+        information
+    """
+    info = ShowInfoMultiple(connect_dict=get_connect_dict())
+    shows_panelists = info.retrieve_panelist_info_by_ids(show_ids)
+
+    assert shows_panelists, (f"Panelist information for show IDs {show_ids} could not "
+                             "be retrieved")
+
+    for show_id in shows_panelists:
+        assert show_id in shows_panelists, ("Panelist information could not be "
+                                            f"retrieved for show ID {show_id}")
+        panelists = shows_panelists[show_id]
+        if panelists:
+            assert "id" in panelists[0], (f"'id' was not returned for the first panelist "
+                                          f"for show ID {show_id}")
+            assert "score" in panelists[0], (f"'score' was not returned for the first "
+                                             f"panelist for show ID {show_id}")

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -24,5 +24,10 @@ from wwdtm.panelist import (Panelist,
 from wwdtm.scorekeeper import (Scorekeeper,
                                ScorekeeperAppearances,
                                ScorekeeperUtility)
+from wwdtm.show import (Show,
+                        ShowInfo,
+                        ShowInfoMultiple,
+                        ShowUtility)
 
-VERSION = "2.0.0-beta.1"
+
+VERSION = "2.0.0-beta.2"

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -5,5 +5,6 @@
 # wwdtm is released under the terms of the Apache License 2.0
 """Wait Wait Stats: Show module"""
 from wwdtm.show.info import ShowInfo
+from wwdtm.show.info_multiple import ShowInfoMultiple
 from wwdtm.show.show import Show
 from wwdtm.show.utility import ShowUtility

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -101,7 +101,7 @@ class ShowInfo:
             "correct_panelist": correct_bluff_info,
         }
 
-    def retrieve_core_info_by_ids(self, show_ids: List[int]) -> Dict[str, Any]:
+    def retrieve_core_info_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a dictionary with core information for the requested
         show ID.
 
@@ -110,9 +110,8 @@ class ShowInfo:
             description and notes. If show core information could not be
             retrieved, an empty dictionary will be returned.
         """
-        for show_id in show_ids:
-            if not valid_int_id(show_id):
-                return {}
+        if not valid_int_id(show_id):
+            return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
         query = ("SELECT s.showid AS show_id, s.showdate AS date, "
@@ -136,82 +135,78 @@ class ShowInfo:
                  "sk.scorekeeperid = skm.scorekeeperid "
                  "JOIN ww_showdescriptions sd ON sd.showid = s.showid "
                  "JOIN ww_shownotes sn ON sn.showid = s.showid "
-                 "WHERE s.showid IN ({ids}) "
-                 "ORDER BY s.showdate ASC;".format(ids=", ".join(str(v) for v in show_ids)))
-        cursor.execute(query)
-        result = cursor.fetchall()
+                 "WHERE s.showid = %s "
+                 "ORDER BY s.showdate ASC;")
+        cursor.execute(query, (show_id, ))
+        result = cursor.fetchone()
         cursor.close()
 
         if not result:
             return {}
 
-        shows = []
-        for show in result:
-            location_info = {
-                "id": show.location_id,
-                "slug": show.location_slug,
-                "city": show.city,
-                "state": show.state,
-                "venue": show.venue,
-            }
+        location_info = {
+            "id": result.location_id,
+            "slug": result.location_slug,
+            "city": result.city,
+            "state": result.state,
+            "venue": result.venue,
+        }
 
-            if not show.location_slug:
-                location_info["slug"] = self.loc_util.slugify_location(location_id=show.location_id,
-                                                                       venue=show.venue,
-                                                                       city=show.city,
-                                                                       state=show.state)
+        if not result.location_slug:
+            location_info["slug"] = self.loc_util.slugify_location(location_id=result.location_id,
+                                                                   venue=result.venue,
+                                                                   city=result.city,
+                                                                   state=result.state)
 
-            host_info = {
-                "id": show.host_id,
-                "name": show.host,
-                "slug": show.host_slug if show.host_slug else slugify(show.host),
-                "guest": bool(show.host_guest),
-            }
+        host_info = {
+            "id": result.host_id,
+            "name": result.host,
+            "slug": result.host_slug if result.host_slug else slugify(result.host),
+            "guest": bool(result.host_guest),
+        }
 
-            scorekeeper_info = {
-                "id": show.scorekeeper_id,
-                "name": show.scorekeeper,
-                "slug": show.scorekeeper_slug if show.scorekeeper_slug else slugify(show.scorekeeper),
-                "guest": bool(show.scorekeeper_guest),
-                "description": show.scorekeeper_description if show.scorekeeper_description else None,
-            }
+        scorekeeper_info = {
+            "id": result.scorekeeper_id,
+            "name": result.scorekeeper,
+            "slug": result.scorekeeper_slug if result.scorekeeper_slug else slugify(result.scorekeeper),
+            "guest": bool(result.scorekeeper_guest),
+            "description": result.scorekeeper_description if result.scorekeeper_description else None,
+        }
 
-            if show.show_description:
-                description = str(show.show_description).strip()
-            else:
-                description = None
+        if result.show_description:
+            description = str(result.show_description).strip()
+        else:
+            description = None
 
-            if show.show_notes:
-                notes = str(show.show_notes).strip()
-            else:
-                notes = None
+        if result.show_notes:
+            notes = str(result.show_notes).strip()
+        else:
+            notes = None
 
-            show_info = {
-                "id": show.show_id,
-                "date": show.date.isoformat(),
-                "best_of": bool(show.best_of),
-                "repeat_show": bool(show.repeat_show_id),
-                "original_show_id": None,
-                "original_show_date": None,
-                "description": description,
-                "notes": notes,
-                "location": location_info,
-                "host": host_info,
-                "scorekeeper": scorekeeper_info,
-            }
+        show_info = {
+            "id": result.show_id,
+            "date": result.date.isoformat(),
+            "best_of": bool(result.best_of),
+            "repeat_show": bool(result.repeat_show_id),
+            "original_show_id": None,
+            "original_show_date": None,
+            "description": description,
+            "notes": notes,
+            "location": location_info,
+            "host": host_info,
+            "scorekeeper": scorekeeper_info,
+        }
 
-            repeat_show_id = show.repeat_show_id
-            if repeat_show_id:
-                original_date = self.utility.convert_id_to_date(repeat_show_id)
-                show_info["original_show_id"] = repeat_show_id
-                show_info["original_show_date"] = original_date
-            else:
-                show_info.pop("original_show_id", None)
-                show_info.pop("original_show_date", None)
+        repeat_show_id = result.repeat_show_id
+        if repeat_show_id:
+            original_date = self.utility.convert_id_to_date(repeat_show_id)
+            show_info["original_show_id"] = repeat_show_id
+            show_info["original_show_date"] = original_date
+        else:
+            show_info.pop("original_show_id", None)
+            show_info.pop("original_show_date", None)
 
-            shows.append(show_info)
-
-        return(shows)
+        return show_info
 
     @lru_cache(typed=True)
     def retrieve_guest_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -1,0 +1,560 @@
+# -*- coding: utf-8 -*-
+# vim: set noai syntax=python ts=4 sw=4:
+#
+# Copyright (c) 2018-2021 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+"""Wait Wait Don't Tell Me! Stats Supplemental Show Information
+Retrieval Functions for Multiple Shows
+"""
+from functools import lru_cache
+from typing import Any, Dict, List, Optional
+
+from mysql.connector import connect
+from slugify import slugify
+from wwdtm.show.utility import ShowUtility
+from wwdtm.location.location import LocationUtility
+from wwdtm.validation import valid_int_id
+
+
+class ShowInfoMultiple:
+    """This class contains functions that retrieve show supplemental
+    show information, including panelist, guest and Bluff the Listener
+    information for multiple shows from a copy of the Wait Wait Stats
+    database
+
+    :param connect_dict: Dictionary containing database connection
+        settings as required by mysql.connector.connect
+    :param database_connection: mysql.connector.connect database
+        connection
+    """
+
+    def __init__(self,
+                 connect_dict: Optional[Dict[str, Any]] = None,
+                 database_connection: Optional[connect] = None):
+        """Class initialization method.
+        """
+        if connect_dict:
+            self.connect_dict = connect_dict
+            self.database_connection = connect(**connect_dict)
+        elif database_connection:
+            if not database_connection.is_connected():
+                database_connection.reconnect()
+
+            self.database_connection = database_connection
+
+        self.utility = ShowUtility(database_connection=self.database_connection)
+        self.loc_util = LocationUtility(database_connection=self.database_connection)
+
+    def retrieve_bluff_info_all(self) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a dictionary containing Bluff the Listener information
+        for all shows.
+
+        :return: Dictionary containing correct and chosen Bluff the
+            Listener information.
+        """
+
+        bluff_info = {}
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, "
+                 "blm.chosenbluffpnlid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug "
+                 "FROM ww_showbluffmap blm "
+                 "JOIN ww_shows s ON s.showid = blm.showid "
+                 "JOIN ww_panelists p ON "
+                 "p.panelistid = blm.chosenbluffpnlid;")
+        cursor.execute(query)
+        chosen_results = cursor.fetchall()
+
+        query = ("SELECT s.showid AS show_id, "
+                 "blm.correctbluffpnlid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug "
+                 "FROM ww_showbluffmap blm "
+                 "JOIN ww_shows s ON s.showid = blm.showid "
+                 "JOIN ww_panelists p ON "
+                 "p.panelistid = blm.correctbluffpnlid;")
+        cursor.execute(query)
+        correct_results = cursor.fetchall()
+        cursor.close()
+
+        if not chosen_results or not correct_results:
+            return {}
+
+        for show in chosen_results:
+            if show.show_id not in bluff_info:
+                bluff_info[show.show_id] = {}
+
+            bluff_info[show.show_id]["chosen_panelist"] = {
+                "id": show.panelist_id,
+                "name": show.name,
+                "slug": show.slug if show.slug else slugify(show.name),
+            }
+
+        for show in correct_results:
+            if show.show_id not in bluff_info:
+                bluff_info[show.show_id] = {}
+
+            bluff_info[show.show_id]["correct_panelist"] = {
+                "id": show.panelist_id,
+                "name": show.name,
+                "slug": show.slug if show.slug else slugify(show.name),
+            }
+
+        return bluff_info
+
+    def retrieve_bluff_info_by_ids(self, show_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a dictionary containing Bluff the Listener information
+        for the requested show IDs.
+
+        :param show_ids: List of show IDs
+        :return: Dictionary containing correct and chosen Bluff the
+            Listener information.
+        """
+        for show_id in show_ids:
+            if not valid_int_id(show_id):
+                return {}
+
+        bluff_info = {}
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, "
+                 "blm.chosenbluffpnlid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug "
+                 "FROM ww_showbluffmap blm "
+                 "JOIN ww_shows s ON s.showid = blm.showid "
+                 "JOIN ww_panelists p ON "
+                 "p.panelistid = blm.chosenbluffpnlid "
+                 "WHERE s.showid IN ({ids});".format(ids=", ".join(str(v) for v in show_ids)))
+        cursor.execute(query)
+        chosen_results = cursor.fetchall()
+
+        query = ("SELECT s.showid AS show_id, "
+                 "blm.correctbluffpnlid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug "
+                 "FROM ww_showbluffmap blm "
+                 "JOIN ww_shows s ON s.showid = blm.showid "
+                 "JOIN ww_panelists p ON "
+                 "p.panelistid = blm.correctbluffpnlid "
+                 "WHERE s.showid IN ({ids});".format(ids=", ".join(str(v) for v in show_ids)))
+        cursor.execute(query)
+        correct_results = cursor.fetchall()
+        cursor.close()
+
+        if not chosen_results or not correct_results:
+            return {}
+
+        for show in chosen_results:
+            if show.show_id not in bluff_info:
+                bluff_info[show.show_id] = {}
+
+            bluff_info[show.show_id]["chosen_panelist"] = {
+                "id": show.panelist_id,
+                "name": show.name,
+                "slug": show.slug if show.slug else slugify(show.name),
+            }
+
+        for show in correct_results:
+            if show.show_id not in bluff_info:
+                bluff_info[show.show_id] = {}
+
+            bluff_info[show.show_id]["correct_panelist"] = {
+                "id": show.panelist_id,
+                "name": show.name,
+                "slug": show.slug if show.slug else slugify(show.name),
+            }
+
+        return bluff_info
+
+    def retrieve_core_info_all(self) -> Dict[int, Dict[str, Any]]:
+        """Returns a dictionary with core information for all shows.
+
+        :return: Dictionary containing host, scorekeeper, location,
+            description and notes. If show core information could not be
+            retrieved, an empty dictionary will be returned.
+        """
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, s.showdate AS date, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
+                 "l.locationid AS location_id, l.city, l.state, "
+                 "l.venue, l.locationslug AS location_slug, h.hostid AS host_id, "
+                 "h.host, h.hostslug AS host_slug, hm.guest as host_guest, "
+                 "sk.scorekeeperid AS scorekeeper_id, sk.scorekeeper, "
+                 "sk.scorekeeperslug AS scorekeeper_slug, "
+                 "skm.guest AS scorekeeper_guest, "
+                 "skm.description AS scorekeeper_description, "
+                 "sd.showdescription AS show_description, "
+                 "sn.shownotes AS show_notes "
+                 "FROM ww_shows s "
+                 "JOIN ww_showlocationmap lm ON lm.showid = s.showid "
+                 "JOIN ww_locations l ON l.locationid = lm.locationid "
+                 "JOIN ww_showhostmap hm ON hm.showid = s.showid "
+                 "JOIN ww_hosts h ON h.hostid = hm.hostid "
+                 "JOIN ww_showskmap skm ON skm.showid = s.showid "
+                 "JOIN ww_scorekeepers sk ON "
+                 "sk.scorekeeperid = skm.scorekeeperid "
+                 "JOIN ww_showdescriptions sd ON sd.showid = s.showid "
+                 "JOIN ww_shownotes sn ON sn.showid = s.showid "
+                 "ORDER BY s.showdate ASC;")
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        shows = {}
+        for show in results:
+            location_info = {
+                "id": show.location_id,
+                "slug": show.location_slug,
+                "city": show.city,
+                "state": show.state,
+                "venue": show.venue,
+            }
+
+            if not show.location_slug:
+                location_info["slug"] = self.loc_util.slugify_location(location_id=show.location_id,
+                                                                       venue=show.venue,
+                                                                       city=show.city,
+                                                                       state=show.state)
+
+            host_info = {
+                "id": show.host_id,
+                "name": show.host,
+                "slug": show.host_slug if show.host_slug else slugify(show.host),
+                "guest": bool(show.host_guest),
+            }
+
+            scorekeeper_info = {
+                "id": show.scorekeeper_id,
+                "name": show.scorekeeper,
+                "slug": show.scorekeeper_slug if show.scorekeeper_slug else slugify(show.scorekeeper),
+                "guest": bool(show.scorekeeper_guest),
+                "description": show.scorekeeper_description if show.scorekeeper_description else None,
+            }
+
+            if show.show_description:
+                description = str(show.show_description).strip()
+            else:
+                description = None
+
+            if show.show_notes:
+                notes = str(show.show_notes).strip()
+            else:
+                notes = None
+
+            show_info = {
+                "id": show.show_id,
+                "date": show.date.isoformat(),
+                "best_of": bool(show.best_of),
+                "repeat_show": bool(show.repeat_show_id),
+                "original_show_id": None,
+                "original_show_date": None,
+                "description": description,
+                "notes": notes,
+                "location": location_info,
+                "host": host_info,
+                "scorekeeper": scorekeeper_info,
+            }
+
+            repeat_show_id = show.repeat_show_id
+            if repeat_show_id:
+                original_date = self.utility.convert_id_to_date(repeat_show_id)
+                show_info["original_show_id"] = repeat_show_id
+                show_info["original_show_date"] = original_date
+            else:
+                show_info.pop("original_show_id", None)
+                show_info.pop("original_show_date", None)
+
+            shows[show.show_id] = show_info
+
+        return(shows)
+
+    def retrieve_core_info_by_ids(self, show_ids: List[int]) -> Dict[int, Dict[str, Any]]:
+        """Returns a dictionary with core information for the requested
+        show IDs.
+
+        :param show_ids: List of show IDs
+        :return: Dictionary containing host, scorekeeper, location,
+            description and notes. If show core information could not be
+            retrieved, an empty dictionary will be returned.
+        """
+        for show_id in show_ids:
+            if not valid_int_id(show_id):
+                return {}
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, s.showdate AS date, "
+                 "s.bestof AS best_of, s.repeatshowid AS repeat_show_id, "
+                 "l.locationid AS location_id, l.city, l.state, "
+                 "l.venue, l.locationslug AS location_slug, h.hostid AS host_id, "
+                 "h.host, h.hostslug AS host_slug, hm.guest as host_guest, "
+                 "sk.scorekeeperid AS scorekeeper_id, sk.scorekeeper, "
+                 "sk.scorekeeperslug AS scorekeeper_slug, "
+                 "skm.guest AS scorekeeper_guest, "
+                 "skm.description AS scorekeeper_description, "
+                 "sd.showdescription AS show_description, "
+                 "sn.shownotes AS show_notes "
+                 "FROM ww_shows s "
+                 "JOIN ww_showlocationmap lm ON lm.showid = s.showid "
+                 "JOIN ww_locations l ON l.locationid = lm.locationid "
+                 "JOIN ww_showhostmap hm ON hm.showid = s.showid "
+                 "JOIN ww_hosts h ON h.hostid = hm.hostid "
+                 "JOIN ww_showskmap skm ON skm.showid = s.showid "
+                 "JOIN ww_scorekeepers sk ON "
+                 "sk.scorekeeperid = skm.scorekeeperid "
+                 "JOIN ww_showdescriptions sd ON sd.showid = s.showid "
+                 "JOIN ww_shownotes sn ON sn.showid = s.showid "
+                 "WHERE s.showid IN ({ids}) "
+                 "ORDER BY s.showdate ASC;".format(ids=", ".join(str(v) for v in show_ids)))
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        shows = {}
+        for show in results:
+            location_info = {
+                "id": show.location_id,
+                "slug": show.location_slug,
+                "city": show.city,
+                "state": show.state,
+                "venue": show.venue,
+            }
+
+            if not show.location_slug:
+                location_info["slug"] = self.loc_util.slugify_location(location_id=show.location_id,
+                                                                       venue=show.venue,
+                                                                       city=show.city,
+                                                                       state=show.state)
+
+            host_info = {
+                "id": show.host_id,
+                "name": show.host,
+                "slug": show.host_slug if show.host_slug else slugify(show.host),
+                "guest": bool(show.host_guest),
+            }
+
+            scorekeeper_info = {
+                "id": show.scorekeeper_id,
+                "name": show.scorekeeper,
+                "slug": show.scorekeeper_slug if show.scorekeeper_slug else slugify(show.scorekeeper),
+                "guest": bool(show.scorekeeper_guest),
+                "description": show.scorekeeper_description if show.scorekeeper_description else None,
+            }
+
+            if show.show_description:
+                description = str(show.show_description).strip()
+            else:
+                description = None
+
+            if show.show_notes:
+                notes = str(show.show_notes).strip()
+            else:
+                notes = None
+
+            show_info = {
+                "id": show.show_id,
+                "date": show.date.isoformat(),
+                "best_of": bool(show.best_of),
+                "repeat_show": bool(show.repeat_show_id),
+                "original_show_id": None,
+                "original_show_date": None,
+                "description": description,
+                "notes": notes,
+                "location": location_info,
+                "host": host_info,
+                "scorekeeper": scorekeeper_info,
+            }
+
+            repeat_show_id = show.repeat_show_id
+            if repeat_show_id:
+                original_date = self.utility.convert_id_to_date(repeat_show_id)
+                show_info["original_show_id"] = repeat_show_id
+                show_info["original_show_date"] = original_date
+            else:
+                show_info.pop("original_show_id", None)
+                show_info.pop("original_show_date", None)
+
+            shows[show.show_id] = show_info
+
+        return(shows)
+
+    def retrieve_guest_info_all(self) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a list of dictionary objects containing Not My Job
+        guest information for all shows.
+
+        :return: Dictionary containing Not My Job guest information. If
+            Not My Job information could not be retrieved, an empty list
+            will be returned.
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, gm.guestid AS guest_id, "
+                 "g.guest AS name, g.guestslug AS slug, "
+                 "gm.guestscore AS score, gm.exception AS score_exception "
+                 "FROM ww_showguestmap gm "
+                 "JOIN ww_guests g ON g.guestid = gm.guestid "
+                 "JOIN ww_shows s ON s.showid = gm.showid "
+                 "ORDER BY s.showdate ASC, gm.showguestmapid ASC;")
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        shows = {}
+        for guest in results:
+            if guest.show_id not in shows:
+                shows[guest.show_id] = []
+
+            shows[guest.show_id].append({
+                "id": guest.guest_id,
+                "name": guest.name,
+                "slug": guest.slug if guest.slug else slugify(guest.name),
+                "score": guest.score if guest.score else None,
+                "score_exception": bool(guest.score_exception),
+            })
+
+        return shows
+
+    def retrieve_guest_info_by_ids(self, show_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a list of dictionary objects containing Not My Job
+        guest information for the requested show IDs.
+
+        :param show_ids: List of show IDs
+        :return: Dictionary containing Not My Job guest information. If
+            Not My Job information could not be retrieved, an empty list
+            will be returned.
+        """
+        for show_id in show_ids:
+            if not valid_int_id(show_id):
+                return {}
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, gm.guestid AS guest_id, "
+                 "g.guest AS name, g.guestslug AS slug, "
+                 "gm.guestscore AS score, gm.exception AS score_exception "
+                 "FROM ww_showguestmap gm "
+                 "JOIN ww_guests g ON g.guestid = gm.guestid "
+                 "JOIN ww_shows s ON s.showid = gm.showid "
+                 "WHERE gm.showid IN ({ids}) "
+                 "ORDER BY s.showdate ASC, "
+                 "gm.showguestmapid ASC;".format(ids=", ".join(str(v) for v in show_ids)))
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        shows = {}
+        for guest in results:
+            if guest.show_id not in shows:
+                shows[guest.show_id] = []
+
+            shows[guest.show_id].append({
+                "id": guest.guest_id,
+                "name": guest.name,
+                "slug": guest.slug if guest.slug else slugify(guest.name),
+                "score": guest.score if guest.score else None,
+                "score_exception": bool(guest.score_exception),
+            })
+
+        return shows
+
+    def retrieve_panelist_info_all(self) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a list of dictionary objects containing panelist
+        information for all shows.
+
+        :return: List of panelists with corresponding scores and
+            ranking information. If panelist information could not be
+            retrieved, an empty list will be returned.
+        """
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, pm.panelistid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug, "
+                 "pm.panelistlrndstart AS start, "
+                 "pm.panelistlrndcorrect AS correct, "
+                 "pm.panelistscore AS score, pm.showpnlrank AS rank "
+                 "FROM ww_showpnlmap pm "
+                 "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+                 "JOIN ww_shows s ON s.showid = pm.showid "
+                 "ORDER by s.showdate ASC, pm.panelistscore DESC, "
+                 "pm.showpnlmapid ASC;")
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        panelists = {}
+        for panelist in results:
+            if panelist.show_id not in panelists:
+                panelists[panelist.show_id] = []
+
+            panelists[panelist.show_id].append({
+                "id": panelist.panelist_id,
+                "name": panelist.name,
+                "slug": panelist.slug if panelist.slug else slugify(panelist.name),
+                "lightning_round_start": panelist.start if panelist.start else None,
+                "lightning_round_correct": panelist.correct if panelist.correct else None,
+                "score": panelist.score if panelist.score else None,
+                "rank": panelist.rank if panelist.rank else None,
+            })
+
+        return panelists
+
+    def retrieve_panelist_info_by_ids(self, show_ids: List[int]) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a list of dictionary objects containing panelist
+        information for the requested show IDs.
+
+        :param show_ids: List of show IDs
+        :return: List of panelists with corresponding scores and
+            ranking information. If panelist information could not be
+            retrieved, an empty list will be returned.
+        """
+        for show_id in show_ids:
+            if not valid_int_id(show_id):
+                return {}
+
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = ("SELECT s.showid AS show_id, pm.panelistid AS panelist_id, "
+                 "p.panelist AS name, p.panelistslug AS slug, "
+                 "pm.panelistlrndstart AS start, "
+                 "pm.panelistlrndcorrect AS correct, "
+                 "pm.panelistscore AS score, pm.showpnlrank AS rank "
+                 "FROM ww_showpnlmap pm "
+                 "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
+                 "JOIN ww_shows s ON s.showid = pm.showid "
+                 "WHERE pm.showid IN ({ids}) "
+                 "ORDER by s.showdate ASC, pm.panelistscore DESC, "
+                 "pm.showpnlmapid ASC;".format(ids=", ".join(str(v) for v in show_ids)))
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        panelists = {}
+        for panelist in results:
+            if panelist.show_id not in panelists:
+                panelists[panelist.show_id] = []
+
+            panelists[panelist.show_id].append({
+                "id": panelist.panelist_id,
+                "name": panelist.name,
+                "slug": panelist.slug if panelist.slug else slugify(panelist.name),
+                "lightning_round_start": panelist.start if panelist.start else None,
+                "lightning_round_correct": panelist.correct if panelist.correct else None,
+                "score": panelist.score if panelist.score else None,
+                "rank": panelist.rank if panelist.rank else None,
+            })
+
+        return panelists

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -678,6 +678,7 @@ class Show:
                  "ORDER BY s.showdate ASC, pm.panelistscore ASC;")
         cursor.execute(query, (year, ))
         results = cursor.fetchall()
+        cursor.close()
 
         if not results:
             return []

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from mysql.connector import connect
 from wwdtm.show.info import ShowInfo
+from wwdtm.show.info_multiple import ShowInfoMultiple
 from wwdtm.show.utility import ShowUtility
 from wwdtm.validation import valid_int_id
 
@@ -41,6 +42,7 @@ class Show:
             self.database_connection = database_connection
 
         self.info = ShowInfo(database_connection=self.database_connection)
+        self.info_multiple = ShowInfoMultiple(database_connection=self.database_connection)
         self.utility = ShowUtility(database_connection=self.database_connection)
 
     def retrieve_all(self) -> List[Dict[str, Any]]:
@@ -89,27 +91,33 @@ class Show:
             If show information could not be retrieved, an empty list
             will be returned.
         """
-        cursor = self.database_connection.cursor(dictionary=False)
-        query = ("SELECT showid AS id FROM ww_shows "
-                 "ORDER BY showdate ASC;")
-        cursor.execute(query)
-        results = cursor.fetchall()
-        cursor.close()
+        info = self.info_multiple.retrieve_core_info_all()
 
-        if not results:
+        if not info:
             return []
 
-        show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_ids(show_ids)
+        panelists = self.info_multiple.retrieve_panelist_info_all()
+        bluffs = self.info_multiple.retrieve_bluff_info_all()
+        guests = self.info_multiple.retrieve_guest_info_all()
 
-        if not shows:
-            return []
+        shows = []
+        for show in info:
+            if info[show]["id"] in panelists:
+                info[show]["panelists"] = panelists[info[show]["id"]]
+            else:
+                info[show]["panelists"] = []
 
-        for show in shows:
-            if show:
-                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
-                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
-                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+            if info[show]["id"] in bluffs:
+                info[show]["bluff"] = bluffs[info[show]["id"]]
+            else:
+                info[show]["bluff"] = []
+
+            if info[show]["id"] in guests:
+                info[show]["guests"] = guests[info[show]["id"]]
+            else:
+                info[show]["guests"] = []
+
+            shows.append(info[show])
 
         return shows
 
@@ -417,15 +425,15 @@ class Show:
         if not valid_int_id(show_id):
             return {}
 
-        info = self.info.retrieve_core_info_by_ids([show_id])
+        info = self.info.retrieve_core_info_by_id(show_id)
         if not info:
             return {}
 
-        info[0]["panelists"] = self.info.retrieve_panelist_info_by_id(show_id)
-        info[0]["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
-        info[0]["guests"] = self.info.retrieve_guest_info_by_id(show_id)
+        info["panelists"] = self.info.retrieve_panelist_info_by_id(show_id)
+        info["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
+        info["guests"] = self.info.retrieve_guest_info_by_id(show_id)
 
-        return info[0]
+        return info
 
     @lru_cache(typed=True)
     def retrieve_details_by_year(self, year: int) -> List[Dict[str, Any]]:
@@ -455,16 +463,18 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_ids(show_ids)
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
 
-        if not shows:
+        if not info:
             return []
 
-        for show in shows:
-            if show:
-                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
-                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
-                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+        shows = []
+        for show in info:
+            if info[show]:
+                info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(info[show]["id"])
+                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(info[show]["id"])
+                info[show]["guests"] = self.info.retrieve_guest_info_by_id(info[show]["id"])
+                shows.append(info[show])
 
         return shows
 
@@ -501,16 +511,18 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_ids(show_ids)
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
 
-        if not shows:
+        if not info:
             return []
 
-        for show in shows:
-            if show:
-                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
-                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
-                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+        shows = []
+        for show in info:
+            if info[show]:
+                info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(info[show]["id"])
+                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(info[show]["id"])
+                info[show]["guests"] = self.info.retrieve_guest_info_by_id(info[show]["id"])
+                shows.append(info[show])
 
         return shows
 
@@ -627,16 +639,17 @@ class Show:
             return []
 
         show_ids = [v[0] for v in results]
-        shows = self.info.retrieve_core_info_by_ids(show_ids)
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
 
-        if not shows:
+        if not info:
             return []
 
-        for show in shows:
-            if show:
-                show["panelists"] = self.info.retrieve_panelist_info_by_id(show["id"])
-                show["bluff"] = self.info.retrieve_bluff_info_by_id(show["id"])
-                show["guests"] = self.info.retrieve_guest_info_by_id(show["id"])
+        shows = []
+        for show in info:
+            info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(show)
+            info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(show)
+            info[show]["guests"] = self.info.retrieve_guest_info_by_id(show)
+            shows.append(info[show])
 
         return shows
 


### PR DESCRIPTION
Re-work the wwdtm.show code to reduce the number of calls made to the database when requesting details for multiple shows. Instead of calling each of the ShowInfo methods multiple ones when requesting a batch of shows, create new versions of the methods that are meant to pull information for all shows or based on a list of show IDs.