### PR TITLE
Adding Shows by Month/Day

### DIFF
--- a/docs/tests/index.rst
+++ b/docs/tests/index.rst
@@ -3,11 +3,8 @@
 Testing Modules
 ---------------
 
-The ``wwdtm`` library provides corresponding modules to retrieve data for
-guests, hosts, locations, panelists, scorekeepers, and shows from a copy
-of the Wait Wait Don't Tell Me! Stats database.
-
-The following is a list of modules provided in the library:
+This section of the documentation covers the ``pytest`` testing modules for
+each of the ``wwdtm`` library modules:
 
 .. toctree::
     :maxdepth: 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ long_description_content_type = text/x-rst
 classifiers =
     Development Status :: 1 - Planning
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License 2.0
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Topic :: Software Development :: Libraries

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -141,7 +141,8 @@ def test_show_retrieve_by_id(show_id: int):
 def test_show_retrieve_by_month_day(month: int, day: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_month_day`
 
-    :param year: Four digit year to test retrieving show information
+    :param month: One or two digit month to test retrieving show details
+    :param day: One or two digit day to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_by_month_day(month, day)
@@ -234,7 +235,8 @@ def test_show_retrieve_details_by_id(show_id: int):
 def test_show_retrieve_details_by_month_day(month: int, day: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
 
-    :param year: Four digit year to test retrieving show information
+    :param month: One or two digit month to test retrieving show details
+    :param day: One or two digit day to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_details_by_month_day(month, day)

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -137,6 +137,21 @@ def test_show_retrieve_by_id(show_id: int):
     assert "date" in info, f"'date' was not returned for ID {show_id}"
 
 
+@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
+def test_show_retrieve_by_month_day(month: int, day: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_month_day`
+
+    :param year: Four digit year to test retrieving show information
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_by_month_day(month, day)
+
+    assert shows, (f"No shows could be retrieved for month {month:02d} "
+                   "and day {day:02d}")
+    assert "id" in shows[0], (f"'id' was not returned for the first list item "
+                              f"for month {month:02d} and day {day:02d}")
+
+
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_by_year(year: int):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year`
@@ -213,6 +228,21 @@ def test_show_retrieve_details_by_id(show_id: int):
     assert info, f"Show ID {show_id} not found"
     assert "date" in info, f"'date' was not returned for ID {show_id}"
     assert "host" in info, f"'host' was not returned for ID {show_id}"
+
+
+@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
+def test_show_retrieve_details_by_month_day(month: int, day: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
+
+    :param year: Four digit year to test retrieving show information
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_details_by_month_day(month, day)
+
+    assert shows, (f"No shows could be retrieved for month {month:02d} "
+                   "and day {day:02d}")
+    assert "id" in shows[0], (f"'id' was not returned for the first list item "
+                              f"for month {month:02d} and day {day:02d}")
 
 
 @pytest.mark.parametrize("year", [2021])

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -30,4 +30,4 @@ from wwdtm.show import (Show,
                         ShowUtility)
 
 
-VERSION = "2.0.0-beta.2"
+VERSION = "2.0.0-beta.3"


### PR DESCRIPTION
Add methods, along with tests and documentation, to query for show information and details based on requested month and day. This enables the ability to support "On This Day" type of reports or queries.