### PR TITLE
Revert Panelist Lightning-Fill-in-the-Blank Start/Correct Value Behavior

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ long_description_content_type = text/x-rst
 classifiers =
     Development Status :: 1 - Planning
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License 2.0
+    License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.8
     Topic :: Software Development :: Libraries

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -30,4 +30,4 @@ from wwdtm.show import (Show,
                         ShowUtility)
 
 
-VERSION = "2.0.0-beta.3"
+VERSION = "2.0.0-beta.4"

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -285,8 +285,8 @@ class ShowInfo:
                 "id": row.id,
                 "name": row.name,
                 "slug": row.slug if row.slug else slugify(row.name),
-                "lightning_round_start": row.start if row.start else None,
-                "lightning_round_correct": row.correct if row.correct else None,
+                "lightning_round_start": row.start,
+                "lightning_round_correct": row.correct,
                 "score": row.score if row.score else None,
                 "rank": row.rank if row.rank else None,
             })

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -502,8 +502,8 @@ class ShowInfoMultiple:
                 "id": panelist.panelist_id,
                 "name": panelist.name,
                 "slug": panelist.slug if panelist.slug else slugify(panelist.name),
-                "lightning_round_start": panelist.start if panelist.start else None,
-                "lightning_round_correct": panelist.correct if panelist.correct else None,
+                "lightning_round_start": panelist.start,
+                "lightning_round_correct": panelist.correct,
                 "score": panelist.score if panelist.score else None,
                 "rank": panelist.rank if panelist.rank else None,
             })


### PR DESCRIPTION
Revert the logic for panelist Lightning Fill-in-the-Blank round start and correct values back to `libwwdtm` behavior (which is to return the values as-is from the database instead of returning `None`