### PR TITLE
Fix SQL errors that occur with MySQL 8.x

### DIFF
--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -30,4 +30,4 @@ from wwdtm.show import (Show,
                         ShowUtility)
 
 
-VERSION = "2.0.0-rc.1"
+VERSION = "2.0.0-rc.2"

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -122,7 +122,7 @@ class PanelistAppearances:
                  "pm.panelistlrndstart AS start, "
                  "pm.panelistlrndcorrect AS correct, "
                  "pm.panelistscore AS score, "
-                 "pm.showpnlrank AS rank FROM ww_showpnlmap pm "
+                 "pm.showpnlrank AS pnl_rank FROM ww_showpnlmap pm "
                  "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
                  "JOIN ww_shows s ON s.showid = pm.showid "
                  "WHERE pm.panelistid = %s "
@@ -142,7 +142,7 @@ class PanelistAppearances:
                     "lightning_round_start": appearance.start if appearance.start else None,
                     "lightning_round_correct": appearance.correct if appearance.correct else None,
                     "score": appearance.score if appearance.score else None,
-                    "rank": appearance.rank if appearance.rank else None,
+                    "rank": appearance.pnl_rank if appearance.pnl_rank else None,
                 }
                 appearances.append(info)
 

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -267,7 +267,7 @@ class ShowInfo:
                  "p.panelistslug AS slug, "
                  "pm.panelistlrndstart AS start, "
                  "pm.panelistlrndcorrect AS correct, "
-                 "pm.panelistscore AS score, pm.showpnlrank AS rank "
+                 "pm.panelistscore AS score, pm.showpnlrank AS pnl_rank "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_panelists p on p.panelistid = pm.panelistid "
                  "WHERE pm.showid = %s "
@@ -288,7 +288,7 @@ class ShowInfo:
                 "lightning_round_start": row.start,
                 "lightning_round_correct": row.correct,
                 "score": row.score if row.score else None,
-                "rank": row.rank if row.rank else None,
+                "rank": row.pnl_rank if row.pnl_rank else None,
             })
 
         return panelists

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -480,7 +480,7 @@ class ShowInfoMultiple:
                  "p.panelist AS name, p.panelistslug AS slug, "
                  "pm.panelistlrndstart AS start, "
                  "pm.panelistlrndcorrect AS correct, "
-                 "pm.panelistscore AS score, pm.showpnlrank AS rank "
+                 "pm.panelistscore AS score, pm.showpnlrank AS pnl_rank "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
                  "JOIN ww_shows s ON s.showid = pm.showid "
@@ -505,7 +505,7 @@ class ShowInfoMultiple:
                 "lightning_round_start": panelist.start,
                 "lightning_round_correct": panelist.correct,
                 "score": panelist.score if panelist.score else None,
-                "rank": panelist.rank if panelist.rank else None,
+                "rank": panelist.pnl_rank if panelist.pnl_rank else None,
             })
 
         return panelists
@@ -528,7 +528,7 @@ class ShowInfoMultiple:
                  "p.panelist AS name, p.panelistslug AS slug, "
                  "pm.panelistlrndstart AS start, "
                  "pm.panelistlrndcorrect AS correct, "
-                 "pm.panelistscore AS score, pm.showpnlrank AS rank "
+                 "pm.panelistscore AS score, pm.showpnlrank AS pnl_rank "
                  "FROM ww_showpnlmap pm "
                  "JOIN ww_panelists p ON p.panelistid = pm.panelistid "
                  "JOIN ww_shows s ON s.showid = pm.showid "
@@ -554,7 +554,7 @@ class ShowInfoMultiple:
                 "lightning_round_start": panelist.start if panelist.start else None,
                 "lightning_round_correct": panelist.correct if panelist.correct else None,
                 "score": panelist.score if panelist.score else None,
-                "rank": panelist.rank if panelist.rank else None,
+                "rank": panelist.pnl_rank if panelist.pnl_rank else None,
             })
 
         return panelists

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -170,7 +170,8 @@ class Show:
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT YEAR(showdate), MONTH(showdate), DAY(showdate) "
                  "FROM ww_shows "
-                 "ORDER BY showdate ASC;")
+                 "ORDER BY YEAR(showdate) ASC, MONTH(showdate) ASC, "
+                 "DAY(showdate) ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -191,7 +192,7 @@ class Show:
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT YEAR(showdate), MONTH(showdate) "
                  "FROM ww_shows "
-                 "ORDER BY showdate ASC;")
+                 "ORDER BY YEAR(showdate) ASC, MONTH(showdate) ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -212,7 +213,7 @@ class Show:
         cursor = self.database_connection.cursor(dictionary=False)
         query = ("SELECT DISTINCT YEAR(showdate), MONTH(showdate) "
                  "FROM ww_shows "
-                 "ORDER BY showdate ASC;")
+                 "ORDER BY YEAR(showdate) ASC, MONTH(showdate) ASC;")
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()


### PR DESCRIPTION
Initial testing was done against MariaDB 10.5 and threw no errors or exceptions to SQL syntax. When testing against MySQL 8.x, some queries needed to be updated to meet the new syntax changes/requirements.