### PR TITLE
Update package version requirements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -20,6 +20,39 @@ large number of API changes from ``wwdtm`` version 1.x to the current version.
 This section of the documentation will provide a summary of changes and
 changes to function/method locations.
 
+Known Issues
+============
+
+Earlier pre-release versions of wwdtm 2.0 had some incompatibilities if the
+database it is pulling from runs MySQL 5.7 or newer due to a violation of
+``sql_mode`` flag ``ONLY_FULL_GROUP_BY``. The scripts have caused the
+violations have been updated and the issue should be resolved starting with
+the pre-release version 2.0.0-rc.3.
+
+To remove the ``ONLY_FULL_GROUP_BY`` flag from the global ``sql_mode``
+variable, you will first need to query the current value of ``sql_mode`` by
+running:
+
+.. code-block:: mysql
+
+    select @@sql_mode;
+
+Copy the result and remove the ``ONLY_FULL_GROUP_BY`` flag from the list and
+run the following command to unset the flag globally:
+
+.. code-block:: mysql
+
+    set global sql_mode='<flags>';
+
+Although a restart of the MySQL database service is not required, the existing
+connection does need to be closed and re-opened for the change to take effect
+from the MySQL tool of choice.
+
+A way to validate that the variable change is working as expected, if you
+have a working copy of the Git repository, is to run ``pytest`` to check for
+errors and messages pertaining to the ``ONLY_FULL_GROUP_BY`` flag.
+
+
 Table of Contents
 =================
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@ flake8>=4.0.1
 pycodestyle>=2.8.0
 pytest>=6.2.5
 
-mysql-connector-python==8.0.27
-numpy==1.21.5
+mysql-connector-python==8.0.28
+numpy==1.22.1
 python-dateutil==2.8.2
 python-slugify==5.0.2
 pytz==2021.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,8 +27,8 @@ packages=find:
 include_package_data = true
 python_requires = >= 3.8
 install_requires =
-    mysql-connector-python==8.0.27
-    numpy==1.21.5
+    mysql-connector-python==8.0.28
+    numpy==1.22.1
     python-dateutil==2.8.2
     python-slugify==5.0.2
     pytz==2021.3

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,8 @@ from setuptools import setup
 
 setup(name="wwdtm",
       install_requires=[
-          "mysql-connector-python==8.0.27",
-          "numpy==1.21.5",
+          "mysql-connector-python==8.0.28",
+          "numpy==1.22.1",
           "python-dateutil==2.8.2",
           "python-slugify==5.0.2",
           "pytz==2021.3",

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -30,4 +30,4 @@ from wwdtm.show import (Show,
                         ShowUtility)
 
 
-VERSION = "2.0.0-rc.2"
+VERSION = "2.0.0-rc.3"


### PR DESCRIPTION
Bump version of numpy from 1.21.5 to 1.22.1 and mysql-connector-python from 8.0.27 to 8.0.28.

Also, provide a Known Issues section in the docs that reference issues with possible issues with using pre-release versions of the library with newer versions of MySQL.