### PR TITLE
Correct Panelist and Guest Appearance Score Values

### DIFF
--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -26,7 +26,7 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("panelist_id", [14])
+@pytest.mark.parametrize("panelist_id", [14, 73])
 def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
 
@@ -40,7 +40,7 @@ def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
     assert "shows" in appearance, f"'shows' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank", "maeve-higgins"])
 def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
 
@@ -54,7 +54,7 @@ def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
     assert "shows" in appearance, f"'shows' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("panelist_id", [14])
+@pytest.mark.parametrize("panelist_id", [14, 73])
 def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_id`
 
@@ -67,7 +67,7 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int
     assert breakdown, f"No appearance information returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank", "maeve-higgins"])
 def test_panelist_appearances_retrieve_yearly_appearances_by_slug(panelist_slug: str):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_slug`
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.1"
+VERSION = "2.0.2"

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -107,7 +107,7 @@ class GuestAppearances:
                     "date": appearance.date.isoformat(),
                     "best_of": bool(appearance.best_of),
                     "repeat_show": bool(appearance.repeat_show_id),
-                    "score": appearance.score if appearance.score else None,
+                    "score": appearance.score,
                     "score_exception": bool(appearance.score_exception),
                 }
                 appearances.append(info)

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -153,14 +153,12 @@ class PanelistAppearances:
                     "date": appearance.date.isoformat(),
                     "best_of": bool(appearance.best_of),
                     "repeat_show": bool(appearance.repeat_show_id),
-                    "lightning_round_start": appearance.start
-                    if appearance.start
+                    "lightning_round_start": appearance.start,
+                    "lightning_round_correct": appearance.correct,
+                    "score": appearance.score if appearance.score is not None else None,
+                    "rank": appearance.pnl_rank
+                    if appearance.pnl_rank is not None
                     else None,
-                    "lightning_round_correct": appearance.correct
-                    if appearance.correct
-                    else None,
-                    "score": appearance.score if appearance.score else None,
-                    "rank": appearance.pnl_rank if appearance.pnl_rank else None,
                 }
                 appearances.append(info)
 


### PR DESCRIPTION
Instead of doing tests to see if panelist or guest appearance score is `NULL`, just return the value directly. By storing `None` in the dictionary key value, this breaks current functionality in Stats, Reports and Graphs.