### PR TITLE
Update Development Status in setup.cfg to be Production/Stable

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,7 @@ description = Library used to query data from copy of Wait Wait Stats Database.
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 classifiers =
-    Development Status :: 1 - Planning
+    Development Status :: 5 - Production/Stable
     Intended Audience :: Developers
     License :: OSI Approved :: Apache Software License
     Programming Language :: Python :: 3

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.3"
+VERSION = "2.0.3.1"


### PR DESCRIPTION
Now that `wwdtm` is stable, update the `Development Status` in `setup.cfg` to reflect that the library is now stable.