### PR TITLE
Bump required package versions for NumPy and pytz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,3 @@
-flake8>=4.0.1
-pycodestyle>=2.8.0
-pytest>=6.2.5
-black==22.1.0
-
 mysql-connector-python==8.0.28
 numpy==1.22.3
 python-dateutil==2.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ include_package_data = true
 python_requires = >= 3.8
 install_requires =
     mysql-connector-python==8.0.28
-    numpy==1.22.1
+    numpy==1.22.3
     python-dateutil==2.8.2
     python-slugify==5.0.2
-    pytz==2021.3
+    pytz==2022.1
 
 [options.packages.find]
 where=.

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.3.1"
+VERSION = "2.0.4"


### PR DESCRIPTION
Bump required version of NumPy from 1.22.1 to 1.22.3 and pytz from 2021.3 to 2022.1