### PR TITLE
Correct dependency versions in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(
     name="wwdtm",
     install_requires=[
         "mysql-connector-python==8.0.28",
-        "numpy==1.22.1",
+        "numpy==1.22.3",
         "python-dateutil==2.8.2",
         "python-slugify==5.0.2",
-        "pytz==2021.3",
+        "pytz==2022.1",
     ],
 )

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.4"
+VERSION = "2.0.5"


### PR DESCRIPTION
Forgot to update versions for NumPy and pytz in `setup.py`