### PR TITLE
Adding .readthedocs.yaml to set Ubuntu and Python version

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+version: 2
+
+build:
+  os: "ubuntu-20.04"
+  tools:
+    python: "3.8"


### PR DESCRIPTION
Setting Ubuntu version to 20.04 and Python version to 3.8 to test building of docs using Read the Docs