### PR TITLE
Update Sphinx Version to 5.1.1 for Documentation

### DIFF
--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,9 +2,9 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - sphinx==4.4.0
+  - Sphinx==5.1.1
   - sphinx-autobuild==2021.3.14
-  - sphinx-autodoc-typehints==1.14.1
-  - sphinx-copybutton==0.4.0
-  - sphinx-toolbox=2.16.1
+  - sphinx-autodoc-typehints==1.19.1
+  - sphinx-copybutton==0.5.0
+  - sphinx-toolbox==3.1.2
   - Pallets-Sphinx-Themes==2.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,9 +9,9 @@ python-dateutil==2.8.2
 python-slugify==5.0.2
 pytz==2021.3
 
-Sphinx==4.4.0
+Sphinx==5.1.1
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.14.1
-sphinx-copybutton==0.4.0
-sphinx-toolbox==2.16.1
+sphinx-autodoc-typehints==1.19.1
+sphinx-copybutton==0.5.0
+sphinx-toolbox==3.1.2
 Pallets-Sphinx-Themes==2.0.2


### PR DESCRIPTION
Update the `docs/requirements.txt` file to use Sphinx 5.1.1 for building docs and `docs/environment.yaml` for readthedocs build.