### PR TITLE
Update required component versions for preliminary support for Python 3.11

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,23 +5,23 @@ Changes
 2.0.8
 =====
 
-Upgrade components and development tools to newer versions to include preliminary
-support for Python 3.11.
+Update required components and development tools to newer versions to include
+preliminary support for Python 3.11.
 
 Component Changes
 -----------------
 
 * Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
-* Upgrade NumPy from 1.23.2 to 1.23.3
+* Upgrade NumPy from 1.23.2 to 1.23.4
 * Upgrade python-slugify from 5.0.2 to 6.1.2
-* Upgrade pytz from 2022.2.1 to 2022.4
+* Upgrade pytz from 2022.2.1 to 2022.6
 
 Development Changes
 -------------------
 
 * Upgrade flake8 from 4.0.1 to 5.0.4
 * Upgrade pycodestyle from 2.8.0 to 2.9.1
-* Upgrade pytest from 7.1.2 to 7.1.3
+* Upgrade pytest from 7.1.2 to 7.2.0
 * Upgrade Black from 22.6.0 to 22.10.0
 
 Documentation Changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,38 @@
 Changes
 *******
 
+2.0.8
+=====
+
+Upgrade components and development tools to newer versions to include preliminary
+support for Python 3.11.
+
+Component Changes
+-----------------
+
+* Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
+* Upgrade NumPy from 1.23.2 to 1.23.3
+* Upgrade python-slugify from 5.0.2 to 6.1.2
+* Upgrade pytz from 2022.2.1 to 2022.4
+
+Development Changes
+-------------------
+
+* Upgrade flake8 from 4.0.1 to 5.0.4
+* Upgrade pycodestyle from 2.8.0 to 2.9.1
+* Upgrade pytest from 7.1.2 to 7.1.3
+* Upgrade Black from 22.6.0 to 22.10.0
+
+Documentation Changes
+---------------------
+
+In addition to the aforementioned component updates listed in the above sections,
+the following lists the components updated related to documentation building.
+
+* Upgrade Sphinx from 5.1.1 to 5.2.3
+* Upgrade sphinx-autodoc-typehints from 1.19.1 to 1.19.4
+* Upgrade sphinx-toolbox from 3.1.2 to 3.2.0
+
 2.0.7
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,8 +30,8 @@ Documentation Changes
 In addition to the aforementioned component updates listed in the above sections,
 the following lists the components updated related to documentation building.
 
-* Upgrade Sphinx from 5.1.1 to 5.2.3
-* Upgrade sphinx-autodoc-typehints from 1.19.1 to 1.19.4
+* Upgrade Sphinx from 5.1.1 to 5.3.0
+* Upgrade sphinx-autodoc-typehints from 1.19.1 to 1.19.5
 * Upgrade sphinx-toolbox from 3.1.2 to 3.2.0
 
 2.0.7

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,8 @@ library is available at `PyPI`_.
 Requirements
 ============
 
-This version of the library is developed to use features that are included
-in Python 3.8; and, thus, is the minimum version of Python supported.
+This version of the library requires a minimum Python version of 3.8 and
+has been tested thoroughly with Python 3.8 and 3.10.
 
 In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,9 +2,9 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - Sphinx==5.1.1
+  - Sphinx==5.3.0
   - sphinx-autobuild==2021.3.14
-  - sphinx-autodoc-typehints==1.19.1
+  - sphinx-autodoc-typehints==1.19.5
   - sphinx-copybutton==0.5.0
   - sphinx-toolbox==3.1.2
   - Pallets-Sphinx-Themes==2.0.2

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -22,11 +22,11 @@ modules:
 Python Version
 ==============
 
-Python 3.8 or higher is now required for ``wwdtm``. This is due to the latest
-stable version of NumPy dropping support for Python 3.7.
+Python 3.8 or higher is now required for ``wwdtm`` due to dependent packages
+requiring Python 3.8 as the minimum version.
 
-The development and testing of ``wwdtm`` version 2 has been done primarily
-using both Python 3.8 and 3.9, with preliminary testing done on 3.10.
+Development and testing of ``wwdtm`` version 2 is done using Python 3.8 and
+3.10, with preliminary testing done on 3.11.
 
 Handling Database Connections
 =============================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,13 +1,13 @@
 flake8==5.0.4
 pycodestyle==2.9.1
-pytest==7.1.3
+pytest==7.2.0
 black==22.10.0
 
 mysql-connector-python==8.0.31
-numpy==1.23.3
+numpy==1.23.4
 python-dateutil==2.8.2
 python-slugify==6.1.2
-pytz==2022.4
+pytz==2022.6
 
 Sphinx==5.2.3
 sphinx-autobuild==2021.3.14

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -9,9 +9,9 @@ python-dateutil==2.8.2
 python-slugify==6.1.2
 pytz==2022.6
 
-Sphinx==5.2.3
+Sphinx==5.3.0
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.19.4
+sphinx-autodoc-typehints==1.19.5
 sphinx-copybutton==0.5.0
 sphinx-toolbox==3.2.0
 Pallets-Sphinx-Themes==2.0.2

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,17 +1,17 @@
-flake8==4.0.1
-pycodestyle==2.8.0
-pytest==7.1.2
-black==22.6.0
+flake8==5.0.4
+pycodestyle==2.9.1
+pytest==7.1.3
+black==22.10.0
 
-mysql-connector-python==8.0.30
-numpy==1.23.2
+mysql-connector-python==8.0.31
+numpy==1.23.3
 python-dateutil==2.8.2
-python-slugify==5.0.2
-pytz==2022.2.1
+python-slugify==6.1.2
+pytz==2022.4
 
-Sphinx==5.1.1
+Sphinx==5.2.3
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.19.1
+sphinx-autodoc-typehints==1.19.4
 sphinx-copybutton==0.5.0
-sphinx-toolbox==3.1.2
+sphinx-toolbox==3.2.0
 Pallets-Sphinx-Themes==2.0.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ build-backend = "setuptools.build_meta"
 
 [tool.black]
 required-version = "22.10.0"
-target-version = ["py38", "py39", "py310"]
+target-version = ["py38", "py39", "py310", "py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "22.6.0"
+required-version = "22.10.0"
 target-version = ["py38", "py39", "py310"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 flake8==5.0.4
 pycodestyle==2.9.1
-pytest==7.1.3
+pytest==7.2.0
 black==22.10.0
 
 mysql-connector-python==8.0.31
-numpy==1.23.3
+numpy==1.23.4
 python-dateutil==2.8.2
 python-slugify==6.1.2
-pytz==2022.4
+pytz==2022.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-flake8==4.0.1
-pycodestyle==2.8.0
-pytest==7.1.2
-black==22.6.0
+flake8==5.0.4
+pycodestyle==2.9.1
+pytest==7.1.3
+black==22.10.0
 
-mysql-connector-python==8.0.30
-numpy==1.23.2
+mysql-connector-python==8.0.31
+numpy==1.23.3
 python-dateutil==2.8.2
-python-slugify==5.0.2
-pytz==2022.2.1
+python-slugify==6.1.2
+pytz==2022.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mysql-connector-python==8.0.31
-numpy==1.23.3
+numpy==1.23.4
 python-dateutil==2.8.2
 python-slugify==6.1.2
-pytz==2022.4
+pytz==2022.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mysql-connector-python==8.0.30
-numpy==1.23.2
+mysql-connector-python==8.0.31
+numpy==1.23.3
 python-dateutil==2.8.2
-python-slugify==5.0.2
-pytz==2022.2.1
+python-slugify==6.1.2
+pytz==2022.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,11 @@ packages=find:
 include_package_data = true
 python_requires = >= 3.8
 install_requires =
-    mysql-connector-python==8.0.30
-    numpy==1.23.2
+    mysql-connector-python==8.0.31
+    numpy==1.23.3
     python-dateutil==2.8.2
-    python-slugify==5.0.2
-    pytz==2022.2.1
+    python-slugify==6.1.2
+    pytz==2022.4
 
 [options.packages.find]
 where=.

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,10 +28,10 @@ include_package_data = true
 python_requires = >= 3.8
 install_requires =
     mysql-connector-python==8.0.31
-    numpy==1.23.3
+    numpy==1.23.5
     python-dateutil==2.8.2
     python-slugify==6.1.2
-    pytz==2022.4
+    pytz==2022.6
 
 [options.packages.find]
 where=.

--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,9 @@ setup(
     name="wwdtm",
     install_requires=[
         "mysql-connector-python==8.0.31",
-        "numpy==1.23.3",
+        "numpy==1.23.4",
         "python-dateutil==2.8.2",
         "python-slugify==6.1.2",
-        "pytz==2022.4",
+        "pytz==2022.6",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,10 @@ from setuptools import setup
 setup(
     name="wwdtm",
     install_requires=[
-        "mysql-connector-python==8.0.30",
-        "numpy==1.23.2",
+        "mysql-connector-python==8.0.31",
+        "numpy==1.23.3",
         "python-dateutil==2.8.2",
-        "python-slugify==5.0.2",
-        "pytz==2022.2.1",
+        "python-slugify==6.1.2",
+        "pytz==2022.4",
     ],
 )

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.7"
+VERSION = "2.0.8"


### PR DESCRIPTION
## 2.0.8

Update required components and development tools to newer versions to include preliminary support for Python 3.11.

### Component Changes

* Upgrade MySQL Connector/Python from 8.0.30 to 8.0.31
* Upgrade NumPy from 1.23.2 to 1.23.4
* Upgrade python-slugify from 5.0.2 to 6.1.2
* Upgrade pytz from 2022.2.1 to 2022.6

### Development Changes

* Upgrade flake8 from 4.0.1 to 5.0.4
* Upgrade pycodestyle from 2.8.0 to 2.9.1
* Upgrade pytest from 7.1.2 to 7.2.0
* Upgrade Black from 22.6.0 to 22.10.0

### Documentation Changes

In addition to the aforementioned component updates listed in the above sections, the following lists the components updated related to documentation building.

* Upgrade Sphinx from 5.1.1 to 5.3.0
* Upgrade sphinx-autodoc-typehints from 1.19.1 to 1.19.5
* Upgrade sphinx-toolbox from 3.1.2 to 3.2.0