### PR TITLE
Update Pallets-Sphinx-Themes to 2.0.3

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: "ubuntu-20.04"
+  os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.10"
 
 formats:
   - pdf

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ the ``Pallets-Sphinx-Themes`` package.
 
 * Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3
 
+Also, update the build environment from ``ubuntu-20.04`` and Python 3.8 to
+``ubuntu-22.04`` and Python 3.10.
+
 2.0.8
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@
 Changes
 *******
 
+2.0.9
+=====
+
+Documentation Changes
+---------------------
+
+Fixed an issue with Read the Docs build issue related to the build pipeline
+using a newer version of the ``packaging`` package and the previous version of
+the ``Pallets-Sphinx-Themes`` package.
+
+* Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3
+
 2.0.8
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,8 +14,8 @@ the ``Pallets-Sphinx-Themes`` package.
 
 * Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3
 
-Also, update the build environment from ``ubuntu-20.04`` and Python 3.8 to
-``ubuntu-22.04`` and Python 3.10.
+Also, update the Read the Docs build environment from ``ubuntu-20.04`` and
+Python 3.8 to ``ubuntu-22.04`` and Python 3.10.
 
 2.0.8
 =====

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -7,4 +7,4 @@ dependencies:
   - sphinx-autodoc-typehints==1.19.5
   - sphinx-copybutton==0.5.0
   - sphinx-toolbox==3.1.2
-  - Pallets-Sphinx-Themes==2.0.2
+  - Pallets-Sphinx-Themes==2.0.3

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -14,4 +14,4 @@ sphinx-autobuild==2021.3.14
 sphinx-autodoc-typehints==1.19.5
 sphinx-copybutton==0.5.0
 sphinx-toolbox==3.2.0
-Pallets-Sphinx-Themes==2.0.2
+Pallets-Sphinx-Themes==2.0.3

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -21,4 +21,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.0.8"
+VERSION = "2.0.9"


### PR DESCRIPTION
## Documentation Changes

Fixed an issue with Read the Docs build issue related to the build pipeline using a newer version of the `packaging` package and the previous version of the `Pallets-Sphinx-Themes` package.

- Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3

Also, update the Read the Docs build environment from `ubuntu-20.04` and Python 3.8 to `ubuntu-22.04` and Python 3.10.