### PR TITLE
Bump versions for most dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,17 +5,32 @@ Changes
 2.0.9
 =====
 
+Component Changes
+-----------------
+
+* Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
+* Upgrade NumPy from 1.23.4 to 1.24.2
+* Upgrade python-slugify from 6.1.2 to 8.0.1
+* Upgrade pytz from 2022.6 to 2023.3
+
+Development Changes
+-------------------
+
+* Upgrade flake8 from 5.0.4 to 6.0.0
+* Upgrade pycodestyle from 2.9.1 to 2.10.0
+* Upgrade pytest from 7.2.0 to 7.3.1
+* Upgrade Black from 22.10.0 to 23.3.0
+
 Documentation Changes
 ---------------------
 
-Fixed an issue with Read the Docs build issue related to the build pipeline
-using a newer version of the ``packaging`` package and the previous version of
-the ``Pallets-Sphinx-Themes`` package.
-
+* Upgrade Sphinx from 5.3.0 to 6.1.3
+* Upgrade sphinx-autodoc-typehints from 1.19.5 to 1.23.0
+* Upgrade sphinx-copybutton from 0.5.0 to 0.5.2
+* Upgrade sphinx-toolbox from 3.2.0 to 3.4.0
 * Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3
-
-Also, update the Read the Docs build environment from ``ubuntu-20.04`` and
-Python 3.8 to ``ubuntu-22.04`` and Python 3.10.
+* Update the Read the Docs build environment from ``ubuntu-20.04`` and Python
+  3.8 to ``ubuntu-22.04`` and Python 3.10.
 
 2.0.8
 =====

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -3,17 +3,17 @@
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 
 @media all {
-    body, input {
-        font-family: "IBM Plex Sans", "Fira Sans", Calibri, sans-serif;
+    body, input, div.sphinxsidebar input {
+        font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
         font-size: 1.05rem;
     }
 
     h1, h2, h3, h4, h5, h6 {
-        font-family: "IBM Plex Serif", Georgia, Cambria, serif;
+        font-family: "IBM Plex Serif", Georgia, Cambria, "Times New Roman", serif;
     }
 
     code, kbd, pre, textarea {
-        font-family: "IBM Plex Mono", "Fira Code", Consolas, monospace;
+        font-family: "IBM Plex Mono", Menlo, Consolas, Monaco, "Liberation Mono", "Lucida Console", monospace;
         font-size: 1rem;
     }
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 import os
 import sys
@@ -58,7 +58,7 @@ html_sidebars = {
     ],
     "**": [
         "globaltoc.html",
-        "localtoc.html",
+        # "localtoc.html",
         "relations.html",
         "project.html",
         "searchbox.html",

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,17 +1,17 @@
-flake8==5.0.4
-pycodestyle==2.9.1
-pytest==7.2.0
-black==22.10.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.3.1
+black==23.3.0
 
-mysql-connector-python==8.0.31
-numpy==1.23.4
+mysql-connector-python==8.0.33
+numpy==1.24.2
 python-dateutil==2.8.2
-python-slugify==6.1.2
-pytz==2022.6
+python-slugify==8.0.1
+pytz==2023.3
 
-Sphinx==5.3.0
+Sphinx==6.1.3
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.19.5
-sphinx-copybutton==0.5.0
-sphinx-toolbox==3.2.0
+sphinx-autodoc-typehints==1.23.0
+sphinx-copybutton==0.5.2
+sphinx-toolbox==3.4.0
 Pallets-Sphinx-Themes==2.0.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,5 +3,5 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "22.10.0"
+required-version = "23.3.0"
 target-version = ["py38", "py39", "py310", "py311"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,11 @@
-flake8==5.0.4
-pycodestyle==2.9.1
-pytest==7.2.0
-black==22.10.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.3.1
+black==23.3.0
+wheel==0.40.0
 
-mysql-connector-python==8.0.31
-numpy==1.23.4
+mysql-connector-python==8.0.33
+numpy==1.24.2
 python-dateutil==2.8.2
-python-slugify==6.1.2
-pytz==2022.6
+python-slugify==8.0.1
+pytz==2023.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-mysql-connector-python==8.0.31
-numpy==1.23.4
+mysql-connector-python==8.0.33
+numpy==1.24.2
 python-dateutil==2.8.2
-python-slugify==6.1.2
-pytz==2022.6
+python-slugify==8.0.1
+pytz==2023.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,11 +27,11 @@ packages=find:
 include_package_data = true
 python_requires = >= 3.8
 install_requires =
-    mysql-connector-python==8.0.31
-    numpy==1.23.5
+    mysql-connector-python==8.0.33
+    numpy==1.24.2
     python-dateutil==2.8.2
-    python-slugify==6.1.2
-    pytz==2022.6
+    python-slugify==8.0.1
+    pytz==2023.3
 
 [options.packages.find]
 where=.

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2023 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 """Package setup file"""
 
@@ -10,10 +10,10 @@ from setuptools import setup
 setup(
     name="wwdtm",
     install_requires=[
-        "mysql-connector-python==8.0.31",
-        "numpy==1.23.4",
+        "mysql-connector-python==8.0.33",
+        "numpy==1.24.2",
         "python-dateutil==2.8.2",
-        "python-slugify==6.1.2",
-        "pytz==2022.6",
+        "python-slugify==8.0.1",
+        "pytz==2023.3",
     ],
 )


### PR DESCRIPTION
## Component Changes

* Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
* Upgrade NumPy from 1.23.4 to 1.24.2
* Upgrade python-slugify from 6.1.2 to 8.0.1
* Upgrade pytz from 2022.6 to 2023.3

## Development Changes

* Upgrade flake8 from 5.0.4 to 6.0.0
* Upgrade pycodestyle from 2.9.1 to 2.10.0
* Upgrade pytest from 7.2.0 to 7.3.1
* Upgrade Black from 22.10.0 to 23.3.0

## Documentation Changes

* Upgrade Sphinx from 5.3.0 to 6.1.3
* Upgrade sphinx-autodoc-typehints from 1.19.5 to 1.23.0
* Upgrade sphinx-copybutton from 0.5.0 to 0.5.2
* Upgrade sphinx-toolbox from 3.2.0 to 3.4.0
* Upgrade Pallets-Sphinx-Themes from 2.0.2 to 2.0.3
* Update the Read the Docs build environment from ``ubuntu-20.04`` and Python 3.8 to ``ubuntu-22.04`` and Python 3.10.