### PR TITLE
Remove unnecessary checks that were included in previous version

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changes
 *******
 
+2.4.0
+=====
+
+Application Changes
+-------------------
+
+* Remove unnecessary checks for existence of the panelist decimal score columns
+* This change means that this library only supports version 4.3 of the Wait Wait Stats Database when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
+  Usage with older versions of the database will result in errors.
+
+Development Changes
+-------------------
+
+* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use ``@pytest.mark.parameterize`` to test including or using decimal scores or not
+* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores`` testing parameters
+
 2.3.0
 =====
 

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -26,31 +26,23 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("panelist_id", [14, 73])
-def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
+@pytest.mark.parametrize(
+    "panelist_id, use_decimal_scores",
+    [(14, True), (14, False), (73, True), (73, False)],
+)
+def test_panelist_appearances_retrieve_appearances_by_id(
+    panelist_id: int, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist
         appearances
-    """
-    appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(panelist_id)
-
-    assert "count" in appearance, f"'count' was not returned for ID {panelist_id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14, 73])
-def test_panelist_appearances_retrieve_appearances_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist
-        appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(
-        panelist_id, use_decimal_scores=True
+        panelist_id, use_decimal_scores=use_decimal_scores
     )
 
     assert "count" in appearance, f"'count' was not returned for ID {panelist_id}"
@@ -58,34 +50,29 @@ def test_panelist_appearances_retrieve_appearances_by_id_decimal(panelist_id: in
 
 
 @pytest.mark.parametrize(
-    "panelist_slug", ["luke-burbank", "maeve-higgins", "peter-sagal"]
+    "panelist_slug, use_decimal_scores",
+    [
+        ("luke-burbank", True),
+        ("luke-burbank", False),
+        ("maeve-higgins", True),
+        ("maeve-higgins", False),
+        ("peter-sagal", True),
+        ("peter-sagal", False),
+    ],
 )
-def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
+def test_panelist_appearances_retrieve_appearances_by_slug(
+    panelist_slug: str, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances
-    """
-    appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(panelist_slug)
-
-    assert "count" in appearance, f"'count' was not returned for slug {panelist_slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize(
-    "panelist_slug", ["luke-burbank", "maeve-higgins", "peter-sagal"]
-)
-def test_panelist_appearances_retrieve_appearances_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(
-        panelist_slug, use_decimal_scores=True
+        panelist_slug, use_decimal_scores=use_decimal_scores
     )
 
     assert "count" in appearance, f"'count' was not returned for slug {panelist_slug}"
@@ -98,6 +85,8 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int
 
     :param panelist_id: Panelist ID to test retrieving a panelist's
         appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_id(panelist_id)

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -35,23 +35,15 @@ def test_panelist_retrieve_all():
     assert "id" in panelists[0], "'id' was not returned for the first list item"
 
 
-def test_panelist_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`"""
-    panelist = Panelist(connect_dict=get_connect_dict())
-    panelists = panelist.retrieve_all_details()
-
-    assert panelists, "No panelists could be retrieved"
-    assert "id" in panelists[0], "'id' was not returned for first list item"
-    assert (
-        "appearances" in panelists[0]
-    ), "'appearances' was not returned for the first list item"
-
-
-def test_panelist_retrieve_all_details_decimal():
+@pytest.mark.parametrize("use_decimal_scores", [True, False])
+def test_panelist_retrieve_all_details(use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`
-    with decimal scores"""
+
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
+    """
     panelist = Panelist(connect_dict=get_connect_dict())
-    panelists = panelist.retrieve_all_details(use_decimal_scores=True)
+    panelists = panelist.retrieve_all_details(use_decimal_scores=use_decimal_scores)
 
     assert panelists, "No panelists could be retrieved"
     assert "id" in panelists[0], "'id' was not returned for first list item"
@@ -90,29 +82,18 @@ def test_panelist_retrieve_by_id(panelist_id: int):
     assert "name" in info, f"'name' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_retrieve_details_by_id(panelist_id: int):
+@pytest.mark.parametrize("panelist_id, use_decimal_scores", [(14, True), (14, False)])
+def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist details
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_id(panelist_id)
-
-    assert info, f"Panelist ID {panelist_id} not found"
-    assert "name" in info, f"'name' was not returned for ID {panelist_id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_retrieve_details_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist details
-    """
-    panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_id(panelist_id, use_decimal_scores=True)
+    info = panelist.retrieve_details_by_id(
+        panelist_id, use_decimal_scores=use_decimal_scores
+    )
 
     assert info, f"Panelist ID {panelist_id} not found"
     assert "name" in info, f"'name' was not returned for ID {panelist_id}"
@@ -133,33 +114,24 @@ def test_panelist_retrieve_by_slug(panelist_slug: str):
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_retrieve_details_by_slug(panelist_slug: str):
+@pytest.mark.parametrize(
+    "panelist_slug, use_decimal_scores",
+    [("luke-burbank", True), ("luke-burbank", False)],
+)
+def test_panelist_retrieve_details_by_slug(
+    panelist_slug: str, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist details
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_slug(panelist_slug)
-
-    assert info, f"Panelist slug {panelist_slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_retrieve_details_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist details
-    """
-    panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_slug(panelist_slug, use_decimal_scores=True)
+    info = panelist.retrieve_details_by_slug(
+        panelist_slug, use_decimal_scores=use_decimal_scores
+    )
 
     assert info, f"Panelist slug {panelist_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -80,69 +80,54 @@ def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
     assert "first" in ranks, f"'first' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_statistics_retrieve_statistics_by_id(panelist_id: int):
+@pytest.mark.parametrize(
+    "panelist_id, include_decimal_scores", [(14, True), (14, False)]
+)
+def test_panelist_statistics_retrieve_statistics_by_id(
+    panelist_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    """
-    statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_id(panelist_id)
-
-    assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
-    assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_statistics_retrieve_statistics_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist
-        information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_id(
-        panelist_id, include_decimal_scores=True
+        panelist_id, include_decimal_scores=include_decimal_scores
     )
 
     assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
-    assert (
-        "scoring_decimal" in stats
-    ), f"'scoring_decimal' was not returned for ID {panelist_id}"
+    if include_decimal_scores:
+        assert (
+            "scoring_decimal" in stats
+        ), f"'scoring' was not returned for ID {panelist_id}"
     assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_statistics_by_slug(panelist_slug: str):
+@pytest.mark.parametrize(
+    "panelist_slug, include_decimal_scores",
+    [("luke-burbank", True), ("luke-burbank", False)],
+)
+def test_panelist_statistics_retrieve_statistics_by_slug(
+    panelist_slug: str, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    """
-    statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_slug(panelist_slug)
-
-    assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
-    assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_statistics_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_slug(
-        panelist_slug, include_decimal_scores=True
+        panelist_slug, include_decimal_scores=include_decimal_scores
     )
 
     assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
-    assert (
-        "scoring_decimal" in stats
-    ), f"'scoring_decimal' was not returned for slug {panelist_slug}"
+    if include_decimal_scores:
+        assert (
+            "scoring_decimal" in stats
+        ), f"'scoring' was not returned for ID {panelist_slug}"
     assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -83,14 +83,22 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
     ), f"'score' was not returned for the first guest for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_panelist_info_by_id(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores", [(1162, True), (1162, False)]
+)
+def test_show_info_retrieve_panelist_info_by_id(
+    show_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
 
     :param show_id: Show ID to test retrieving show panelist information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    panelists = info.retrieve_panelist_info_by_id(show_id)
+    panelists = info.retrieve_panelist_info_by_id(
+        show_id, include_decimal_scores=include_decimal_scores
+    )
 
     assert (
         panelists
@@ -101,24 +109,7 @@ def test_show_info_retrieve_panelist_info_by_id(show_id: int):
     assert (
         "score" in panelists[0]
     ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_panelist_info_by_id_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show panelist information
-    """
-    info = ShowInfo(connect_dict=get_connect_dict())
-    panelists = info.retrieve_panelist_info_by_id(show_id, include_decimal_scores=True)
-
-    assert (
-        panelists
-    ), f"Panelist information for show ID {show_id} could not be retrieved"
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
+    if include_decimal_scores:
+        assert (
+            "score_decimal" in panelists[0]
+        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -23,7 +23,7 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1083])
+@pytest.mark.parametrize("show_id", [1083, 1162])
 def test_show_info_retrieve_bluff_info_all(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`
 
@@ -180,15 +180,23 @@ def test_show_info_retrieve_guest_info_by_ids(show_ids: List[int]):
             ), f"'score' was not returned for the first guest for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1082])
-def test_show_info_retrieve_panelist_info_all(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores", [(1082, True), (1082, False)]
+)
+def test_show_info_retrieve_panelist_info_all(
+    show_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
 
     :param show_id: Show ID to test retrieving show panelist information
         for all shows retrieved
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_all()
+    shows_panelists = info.retrieve_panelist_info_all(
+        include_decimal_scores=include_decimal_scores
+    )
 
     assert shows_panelists, "Panelist information for all shows could not be retrieved"
     assert (
@@ -202,72 +210,28 @@ def test_show_info_retrieve_panelist_info_all(show_id: int):
     assert (
         "score" in panelists[0]
     ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_id", [1082])
-def test_show_info_retrieve_panelist_info_all_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show panelist information
-        for all shows retrieved
-    """
-    info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_all(include_decimal_scores=True)
-
-    assert shows_panelists, "Panelist information for all shows could not be retrieved"
-    assert (
-        show_id in shows_panelists
-    ), f"Panelist information could not be retrieved for show ID {show_id}"
-
-    panelists = shows_panelists[show_id]
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_panelist_info_by_ids(show_ids: List[int]):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
-
-    :param show_ids: List of show IDs to test retrieving show panelist
-        information
-    """
-    info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_by_ids(show_ids)
-
-    assert (
-        shows_panelists
-    ), f"Panelist information for show IDs {show_ids} could not be retrieved"
-
-    for show_id in shows_panelists:
+    if include_decimal_scores:
         assert (
-            show_id in shows_panelists
-        ), f"Panelist information could not be retrieved for show ID {show_id}"
-        panelists = shows_panelists[show_id]
-        if panelists:
-            assert (
-                "id" in panelists[0]
-            ), f"'id' was not returned for the first panelist for show ID {show_id}"
-            assert "score" in panelists[0], (
-                f"'score' was not returned for the first panelist for show ID "
-                f"{show_id}"
-            )
+            "score_decimal" in panelists[0]
+        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_panelist_info_by_ids_decimal(show_ids: List[int]):
+@pytest.mark.parametrize(
+    "show_ids, include_decimal_scores", [([1082, 1162], True), ([1082, 1162], False)]
+)
+def test_show_info_retrieve_panelist_info_by_ids(
+    show_ids: List[int], include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
 
     :param show_ids: List of show IDs to test retrieving show panelist
         information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     shows_panelists = info.retrieve_panelist_info_by_ids(
-        show_ids, include_decimal_scores=True
+        show_ids, include_decimal_scores=include_decimal_scores
     )
 
     assert (
@@ -287,3 +251,7 @@ def test_show_info_retrieve_panelist_info_by_ids_decimal(show_ids: List[int]):
                 f"'score' was not returned for the first panelist for show ID "
                 f"{show_id}"
             )
+            if include_decimal_scores:
+                assert (
+                    "score_decimal" in panelists[0]
+                ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -32,21 +32,15 @@ def test_show_retrieve_all():
     assert "id" in shows[0], "No Show ID returned for the first list item"
 
 
-def test_show_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`"""
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_all_details()
-
-    assert shows, "No shows could be retrieved"
-    assert "date" in shows[0], "'date' was not returned for the first list item"
-    assert "host" in shows[0], "'host' was not returned for first list item"
-
-
-def test_show_retrieve_all_details_decimal():
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_details(include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`
-    with decimal scores"""
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_all_details(include_decimal_scores=True)
+    shows = show.retrieve_all_details(include_decimal_scores=include_decimal_scores)
 
     assert shows, "No shows could be retrieved"
     assert "date" in shows[0], "'date' was not returned for the first list item"
@@ -196,16 +190,25 @@ def test_show_retrieve_by_year_month(year: int, month: int):
     )
 
 
-@pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
-def test_show_retrieve_details_by_date(year: int, month: int, day: int):
+@pytest.mark.parametrize(
+    "year, month, day, include_decimal_scores",
+    [(2020, 4, 25, True), (2020, 4, 25, False)],
+)
+def test_show_retrieve_details_by_date(
+    year: int, month: int, day: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date(year, month, day)
+    info = show.retrieve_details_by_date(
+        year, month, day, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
     assert "date" in info, (
@@ -216,36 +219,21 @@ def test_show_retrieve_details_by_date(year: int, month: int, day: int):
     )
 
 
-@pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
-def test_show_retrieve_details_by_date_decimal(year: int, month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    :param month: One or two digit month to test retrieving show details
-    :param day: One or two digit day to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date(year, month, day, include_decimal_scores=True)
-
-    assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert "date" in info, (
-        f"'date' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
-    assert "host" in info, (
-        f"'host' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
-
-
-@pytest.mark.parametrize("date", ["2018-10-27"])
-def test_show_retrieve_details_by_date_string(date: str):
+@pytest.mark.parametrize(
+    "date, include_decimal_scores", [("2018-10-27", True), ("2018-10-27", False)]
+)
+def test_show_retrieve_details_by_date_string(date: str, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date_string(date)
+    info = show.retrieve_details_by_date_string(
+        date, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show for date {date} not found"
     assert "date" in info, f"'date' was not returned for show {date}"
@@ -259,6 +247,8 @@ def test_show_retrieve_details_by_date_string_decimal(date: str):
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_date_string(date, include_decimal_scores=True)
@@ -268,44 +258,45 @@ def test_show_retrieve_details_by_date_string_decimal(date: str):
     assert "host" in info, f"'host' was not returned for show {date}"
 
 
-@pytest.mark.parametrize("show_id", [1162, 1246])
-def test_show_retrieve_details_by_id(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores",
+    [(1162, True), (1162, False), (1246, True), (1246, False)],
+)
+def test_show_retrieve_details_by_id(show_id: int, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
 
     :param show_id: Show ID to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_id(show_id)
+    info = show.retrieve_details_by_id(
+        show_id, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show ID {show_id} not found"
     assert "date" in info, f"'date' was not returned for ID {show_id}"
     assert "host" in info, f"'host' was not returned for ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1162, 1246])
-def test_show_retrieve_details_by_id_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_id(show_id, include_decimal_scores=True)
-
-    assert info, f"Show ID {show_id} not found"
-    assert "date" in info, f"'date' was not returned for ID {show_id}"
-    assert "host" in info, f"'host' was not returned for ID {show_id}"
-
-
-@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
-def test_show_retrieve_details_by_month_day(month: int, day: int):
+@pytest.mark.parametrize(
+    "month, day, include_decimal_scores",
+    [(10, 28, True), (10, 28, False), (8, 19, True), (8, 19, False)],
+)
+def test_show_retrieve_details_by_month_day(
+    month: int, day: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
 
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_details_by_month_day(month, day)
+    shows = show.retrieve_details_by_month_day(
+        month, day, include_decimal_scores=include_decimal_scores
+    )
 
     assert shows, (
         f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
@@ -316,34 +307,16 @@ def test_show_retrieve_details_by_month_day(month: int, day: int):
     )
 
 
-@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
-def test_show_retrieve_details_by_month_day_decimal(month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
-    with decimal scores
-
-    :param month: One or two digit month to test retrieving show details
-    :param day: One or two digit day to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_details_by_month_day(month, day, include_decimal_scores=True)
-
-    assert shows, (
-        f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
-    )
-    assert "id" in shows[0], (
-        f"'id' was not returned for the first list item "
-        f"for month {month:02d} and day {day:02d}"
-    )
-
-
-@pytest.mark.parametrize("year", [2021])
-def test_show_retrieve_details_by_year(year: int):
+@pytest.mark.parametrize("year, include_decimal_scores", [(2021, True), (2021, False)])
+def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
 
     :param year: Four digit year to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year(year)
+    info = show.retrieve_details_by_year(
+        year, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"No shows could be retrieved for year {year:04d}"
     assert "date" in info[0], (
@@ -354,58 +327,21 @@ def test_show_retrieve_details_by_year(year: int):
     )
 
 
-@pytest.mark.parametrize("year", [2021])
-def test_show_retrieve_details_by_year_decimal(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year(year, include_decimal_scores=True)
-
-    assert info, f"No shows could be retrieved for year {year:04d}"
-    assert "date" in info[0], (
-        f"'date' was not returned for first list " f"item for year {year:04d}"
-    )
-    assert "host" in info[0], (
-        f"'host' was not returned for first list " f"item for year {year:04d}"
-    )
-
-
-@pytest.mark.parametrize("year, month", [(2020, 4)])
-def test_show_retrieve_details_by_year_month(year: int, month: int):
+@pytest.mark.parametrize(
+    "year, month, include_decimal_scores", [(2020, 4, True), (2020, 4, False)]
+)
+def test_show_retrieve_details_by_year_month(
+    year: int, month: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit year to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year_month(year, month)
-
-    assert info, (
-        f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
+    info = show.retrieve_details_by_year_month(
+        year, month, include_decimal_scores=include_decimal_scores
     )
-    assert "date" in info[0], (
-        f"'date' was not returned for first list item "
-        f"for year/month {year:04d}-{month:02d}"
-    )
-    assert "host" in info[0], (
-        f"'host' was not returned for first list item "
-        f"for year/month {year:04d}-{month:02d}"
-    )
-
-
-@pytest.mark.parametrize("year, month", [(2020, 4)])
-def test_show_retrieve_details_by_year_month_decimal(year: int, month: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    :param month: One or two digit year to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year_month(year, month, include_decimal_scores=True)
 
     assert info, (
         f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
@@ -441,50 +377,28 @@ def test_show_retrieve_recent():
     assert "id" in shows[0], "No Show ID returned for the first list item"
 
 
-def test_show_retrieve_recent_details():
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_recent_details(include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`"""
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_recent_details()
+    shows = show.retrieve_recent_details(include_decimal_scores=include_decimal_scores)
 
     assert shows, "No shows could be retrieved"
     assert "date" in shows[0], "'date' was not returned for the first list item"
     assert "host" in shows[0], "'host' was not returned for first list item"
 
 
-def test_show_retrieve_recent_details_decimal():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`
-    with decimal scores"""
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_recent_details(include_decimal_scores=True)
-
-    assert shows, "No shows could be retrieved"
-    assert "date" in shows[0], "'date' was not returned for the first list item"
-    assert "host" in shows[0], "'host' was not returned for first list item"
-
-
-@pytest.mark.parametrize("year", [2018])
-def test_show_retrieve_scores_by_year(year: int):
+@pytest.mark.parametrize("year, use_decimal_scores", [(2018, True), (2018, False)])
+def test_show_retrieve_scores_by_year(year: int, use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`
 
     :param year: Four digit year to test retrieving scores for a show
         year
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    scores = show.retrieve_scores_by_year(year)
-
-    assert scores, f"No scores could be retrieved by year {year:04d}"
-    assert isinstance(scores[0], tuple), "First list item is not a tuple"
-
-
-@pytest.mark.parametrize("year", [2018])
-def test_show_retrieve_scores_by_year_decimal(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`
-
-    :param year: Four digit year to test retrieving scores for a show
-        year
-    """
-    show = Show(connect_dict=get_connect_dict())
-    scores = show.retrieve_scores_by_year(year, use_decimal_scores=True)
+    scores = show.retrieve_scores_by_year(year, use_decimal_scores=use_decimal_scores)
 
     assert scores, f"No scores could be retrieved by year {year:04d}"
     assert isinstance(scores[0], tuple), "First list item is not a tuple"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.3.0"
+VERSION = "2.4.0"

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -38,27 +38,6 @@ class PanelistAppearances:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
@@ -154,7 +133,7 @@ class PanelistAppearances:
                 "milestones": None,
             }
 
-        if use_decimal_scores and self.has_decimal_columns:
+        if use_decimal_scores:
             query = """
                 SELECT pm.showid AS show_id, s.showdate AS date,
                 s.bestof AS best_of, s.repeatshowid AS repeat_show_id,

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -41,27 +41,6 @@ class PanelistDecimalScores:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
@@ -73,7 +52,7 @@ class PanelistDecimalScores:
         :return: List containing panelist decimal scores. If panelist
             scores could not be retrieved, an empty list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         scores = []
@@ -127,7 +106,7 @@ class PanelistDecimalScores:
             panelist scores could not be retrieved, an empty dictionary
             is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -211,7 +190,7 @@ class PanelistDecimalScores:
             counts. If panelist decimal scores could not be retrieved,
             an empty list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -293,7 +272,7 @@ class PanelistDecimalScores:
             of decimal scores. If panelist scores could not be
             retrieved, an empty dictionary is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -356,7 +335,7 @@ class PanelistDecimalScores:
             scores. If panelist scores could not be retrieved, an empty
             list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -41,27 +41,6 @@ class Panelist:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.appearances = PanelistAppearances(
             database_connection=self.database_connection
         )
@@ -118,9 +97,6 @@ class Panelist:
             information and appearances. If panelists could not be
             retrieved, an empty list is returned.
         """
-        if use_decimal_scores and not self.has_decimal_columns:
-            return []
-
         query = """
             SELECT panelistid AS id, panelist AS name, panelistslug AS slug,
             panelistgender AS gender
@@ -273,9 +249,6 @@ class Panelist:
             an empty dictionary is returned.
         """
         if not valid_int_id(panelist_id):
-            return {}
-
-        if use_decimal_scores and not self.has_decimal_columns:
             return {}
 
         info = self.retrieve_by_id(panelist_id)

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -43,27 +43,6 @@ class PanelistStatistics:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.scores = PanelistScores(database_connection=self.database_connection)
         self.scores_decimal = PanelistDecimalScores(
             database_connection=self.database_connection
@@ -227,7 +206,7 @@ class PanelistStatistics:
         if not score_data or not ranks:
             return {}
 
-        if self.has_decimal_columns and include_decimal_scores:
+        if include_decimal_scores:
             score_data_decimal = self.scores_decimal.retrieve_scores_by_id(panelist_id)
             if not score_data_decimal:
                 return {}
@@ -271,15 +250,15 @@ class PanelistStatistics:
             "percentage": ranks_percentage,
         }
 
-        if not include_decimal_scores:
+        if include_decimal_scores:
             return {
                 "scoring": scoring,
+                "scoring_decimal": scoring_decimal,
                 "ranking": ranking,
             }
         else:
             return {
                 "scoring": scoring,
-                "scoring_decimal": scoring_decimal,
                 "ranking": ranking,
             }
 

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -42,27 +42,6 @@ class ShowInfo:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.panelist_decimal_columns: bool = True
-            else:
-                self.panelist_decimal_columns: bool = False
-        except DatabaseError:
-            self.panelist_decimal_columns: bool = False
-
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
 
@@ -307,7 +286,7 @@ class ShowInfo:
         if not valid_int_id(show_id):
             return []
 
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT pm.panelistid AS id, p.panelist AS name,
                 p.panelistslug AS slug,

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -42,27 +42,6 @@ class ShowInfoMultiple:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.panelist_decimal_columns: bool = True
-            else:
-                self.panelist_decimal_columns: bool = False
-        except DatabaseError:
-            self.panelist_decimal_columns: bool = False
-
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
 
@@ -535,7 +514,7 @@ class ShowInfoMultiple:
             ranking information. If panelist information could not be
             retrieved, an empty list will be returned.
         """
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
                 p.panelist AS name, p.panelistslug AS slug,
@@ -619,7 +598,7 @@ class ShowInfoMultiple:
             if not valid_int_id(show_id):
                 return {}
 
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
                 p.panelist AS name, p.panelistslug AS slug,

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -43,21 +43,6 @@ class Show:
 
             self.database_connection = database_connection
 
-        try:
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            result = cursor.fetchone()
-            cursor.close()
-            if result:
-                self.panelist_decimal_column: bool = True
-            else:
-                self.panelist_decimal_column: bool = False
-        except DatabaseError:
-            self.panelist_decimal_column: bool = False
-
         self.info = ShowInfo(database_connection=self.database_connection)
         self.info_multiple = ShowInfoMultiple(
             database_connection=self.database_connection
@@ -118,9 +103,6 @@ class Show:
             If show information could not be retrieved, an empty list
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         info = self.info_multiple.retrieve_core_info_all()
 
         if not info:
@@ -180,9 +162,7 @@ class Show:
         :return: List of all show date strings. If show dates could not
             be retrieved, an empty list will be returned.
         """
-        query = """
-            SELECT showdate FROM ww_shows ORDER BY showdate ASC;
-            """
+        query = "SELECT showdate FROM ww_shows ORDER BY showdate ASC;"
         cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -464,9 +444,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         id_ = self.utility.convert_date_to_id(year, month, day)
         if not id_:
             return {}
@@ -490,9 +467,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         try:
             parsed_date_string = date_parser.parse(date_string)
         except ValueError:
@@ -521,9 +495,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         if not valid_int_id(show_id):
             return {}
 
@@ -555,9 +526,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         if not 1 <= month <= 12 or not 1 <= day <= 31:
             return []
 
@@ -617,9 +585,6 @@ class Show:
             details. If show information could not be retrieved, an
             empty list will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
         except ValueError:
@@ -676,9 +641,6 @@ class Show:
             corresponding details. If show information could not be
             retrieved, an empty list will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
         except ValueError:
@@ -826,9 +788,6 @@ class Show:
             information could not be retrieved, an empty list will be
             returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             past_days = int(include_days_back)
             future_days = int(include_days_ahead)
@@ -891,9 +850,6 @@ class Show:
             scores. If show scores could not be retrieved, an empty list
             will be returned.
         """
-        if use_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             _ = date_parser.parse(f"{year:04d}")
         except ValueError:


### PR DESCRIPTION
## Application Changes

- Remove unnecessary checks for existence of the panelist decimal score columns
- This change means that this library only supports version 4.3 of the Wait Wait Stats Database when `include_decimal_scores` or `use_decimal_scores` parameters are set to `True`. Usage with older versions of the database will result in errors.

## Development Changes

- Re-work `panelist` and `show` tests to remove separate tests for decimal scores and use `@pytest.mark.parameterize` to test including or using decimal scores or not
- Update documentation to provide details for `include_decimal_scores` and `use_decimal_scores` testing parameters
