### PR TITLE
Fixed issue with Show.retrieve_all_details() with shows w/o bluff info

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changes
 *******
 
+2.4.1
+=====
+
+Application Changes
+-------------------
+
+* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
+
 2.4.0
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Application Changes
 
 * Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
 
+Component Changes
+-----------------
+
+* Upgrade numpy from 1.24.3 to 1.24.4
+* Upgrade pytz from 2023.3 to 2023.3.post1
+
 2.4.0
 =====
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+../CHANGES.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Table of Contents
     wwdtm/index
     tests/index
     migrating/index
+    changelog
 
 Indices and tables
 ==================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,10 +4,10 @@ pytest==7.3.1
 black==23.7.0
 
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1
 
 Sphinx==6.1.3
 sphinx-autobuild==2021.3.14

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
 ]
 dependencies = [
     "mysql-connector-python==8.0.33",
-    "numpy==1.24.3",
+    "numpy==1.24.4",
     "python-dateutil==2.8.2",
     "python-slugify==8.0.1",
-    "pytz==2023.3",
+    "pytz==2023.3.post1",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ wheel==0.41.2
 build==0.10.0
 
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.4.0"
+VERSION = "2.4.1"

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -124,7 +124,7 @@ class Show:
             if info[show]["id"] in bluffs:
                 info[show]["bluff"] = bluffs[info[show]["id"]]
             else:
-                info[show]["bluff"] = []
+                info[show]["bluff"] = {}
 
             if info[show]["id"] in guests:
                 info[show]["guests"] = guests[info[show]["id"]]


### PR DESCRIPTION
## Application Changes

- Correct the value set for show `bluff` value in `Show.retrieve_all_details`, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available

## Component Changes

- Upgrade numpy from 1.24.3 to 1.24.4
- Upgrade pytz from 2023.3 to 2023.3.post1