### PR TITLE
Deprecate Python < 3.10 and Support Python 3.12

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.12"
 
 formats:
   - pdf

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,44 @@
 Changes
 *******
 
+2.5.0
+=====
+
+**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+Application Changes
+-------------------
+
+* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked for deprecated
+* Replace ``dateutil.parser.parse`` with ``datetime.datetime.strptime``
+
+Component Changes
+-----------------
+
+* Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+* Upgrade numpy from 1.24.4 to 1.26.0
+* Remove python-dateutil from dependencies
+
+Documentation Changes
+---------------------
+
+* Change Python version from 3.10 to 3.12
+* Upgrade Sphinx from 6.1.2 to 7.2.6
+* Upgrade sphinx-autodoc-typehints from 1.23.0 to 1.25.2
+* Upgrade sphinx-toolbox from 3.4.0 to 3.5.0
+* Upgrade Pallets-Sphinx-Themes from 2.0.3 to 2.1.1
+* Sync up dependency versions in ``docs/requirements.txt`` with ``requirements-dev.txt``
+
+Development Changes
+-------------------
+
+* Upgrade pytest from 7.3.1 to 7.4.3
+* Upgrade black from 23.7.0 to 23.11.0
+* Upgrade wheel from 0.41.2 to 0.41.3
+* Upgrade build from 0.10.0 to 1.0.3
+* Remove ``py38`` and ``py39`` from ``tool.black`` in ``pyproject.toml``
+* Bump minimum pytest version from 7.0 to 7.4 in ``pyproject.toml``
+
 2.4.1
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requirements
 ============
 
 Starting with version 2.5.0, the minimum supported version of Python has been
-increased from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+changed from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
 be supported.
 
 Testing for this library has been done using Python 3.10 and 3.12.

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,11 @@ library is available at `PyPI`_.
 Requirements
 ============
 
-This version of the library requires a minimum Python version of 3.8 and
-has been tested thoroughly with Python 3.8 and 3.10.
+Starting with version 2.5.0, the minimum supported version of Python has been
+increased from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+be supported.
+
+Testing for this library has been done using Python 3.10 and 3.12.
 
 In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -8,9 +8,3 @@ dependencies:
   - sphinx-copybutton==0.5.2
   - sphinx-toolbox==3.5.0
   - Pallets-Sphinx-Themes==2.1.1
-  #- Sphinx==5.3.0
-  #- sphinx-autobuild==2021.3.14
-  #- sphinx-autodoc-typehints==1.19.5
-  #- sphinx-copybutton==0.5.0
-  #- sphinx-toolbox==3.1.2
-  #- Pallets-Sphinx-Themes==2.0.3

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,9 +2,15 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - Sphinx==5.3.0
+  - Sphinx==7.2.6
   - sphinx-autobuild==2021.3.14
-  - sphinx-autodoc-typehints==1.19.5
-  - sphinx-copybutton==0.5.0
-  - sphinx-toolbox==3.1.2
-  - Pallets-Sphinx-Themes==2.0.3
+  - sphinx-autodoc-typehints==1.25.2
+  - sphinx-copybutton==0.5.2
+  - sphinx-toolbox==3.5.0
+  - Pallets-Sphinx-Themes==2.1.1
+  #- Sphinx==5.3.0
+  #- sphinx-autobuild==2021.3.14
+  #- sphinx-autodoc-typehints==1.19.5
+  #- sphinx-copybutton==0.5.0
+  #- sphinx-toolbox==3.1.2
+  #- Pallets-Sphinx-Themes==2.0.3

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -22,11 +22,11 @@ modules:
 Python Version
 ==============
 
-Python 3.8 or higher is now required for ``wwdtm`` due to dependent packages
-requiring Python 3.8 as the minimum version.
+Starting with version 2.5.0, ``wwdtm`` has deprecated all versions of Python
+prior to 3.10.
 
-Development and testing of ``wwdtm`` version 2 is done using Python 3.8 and
-3.10, with preliminary testing done on 3.11.
+All development and testing of ``wwdtm`` is done using Python 3.10 and
+3.12.
 
 Handling Database Connections
 =============================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,17 +1,16 @@
-flake8==6.0.0
-pycodestyle==2.10.0
-pytest==7.3.1
-black==23.7.0
+flake8==6.1.0
+pycodestyle==2.11.0
+pytest==7.4.3
+black==23.11.0
 
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1
 
-Sphinx==6.1.3
+Sphinx==7.2.6
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.23.0
+sphinx-autodoc-typehints==1.25.2
 sphinx-copybutton==0.5.2
-sphinx-toolbox==3.4.0
-Pallets-Sphinx-Themes==2.0.3
+sphinx-toolbox==3.5.0
+Pallets-Sphinx-Themes==2.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,18 @@ authors = [
 description = "Library used to query data from copy of Wait Wait Stats Database."
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "mysql-connector-python==8.0.33",
-    "numpy==1.24.4",
-    "python-dateutil==2.8.2",
+    "mysql-connector-python==8.2.0",
+    "numpy==1.26.0",
     "python-slugify==8.0.1",
     "pytz==2023.3.post1",
 ]
@@ -38,11 +37,11 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "23.7.0"
-target-version = ["py38", "py39", "py310", "py311"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
 flake8==6.1.0
 pycodestyle==2.11.0
-pytest==7.4.0
-black==23.7.0
-wheel==0.41.2
-build==0.10.0
+pytest==7.4.3
+black==23.11.0
+wheel==0.41.3
+build==1.0.3
 
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.4.1"
+VERSION = "2.5.0"

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -6,12 +6,11 @@
 """Wait Wait Don't Tell Me! Stats Show Data Retrieval Functions
 """
 import datetime
-import dateutil.parser as date_parser
 from decimal import Decimal
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from wwdtm.show.info import ShowInfo
 from wwdtm.show.info_multiple import ShowInfoMultiple
 from wwdtm.show.utility import ShowUtility
@@ -273,12 +272,12 @@ class Show:
             be returned.
         """
         try:
-            parsed_date_string = date_parser.parse(date_string)
+            parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             return {}
 
         id_ = self.utility.convert_date_to_id(
-            parsed_date_string.year, parsed_date_string.month, parsed_date_string.day
+            parsed_date.year, parsed_date.month, parsed_date.day
         )
 
         return self.retrieve_by_id(id_)
@@ -372,7 +371,7 @@ class Show:
             an empty list will be returned.
         """
         try:
-            parsed_year = date_parser.parse(f"{year:04d}")
+            parsed_year = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -404,7 +403,9 @@ class Show:
             retrieved, a list of dictionaries will be returned.
         """
         try:
-            parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
+            parsed_year_month = datetime.datetime.strptime(
+                f"{year:04d}-{month:02d}-01", "%Y-%m-%d"
+            )
         except ValueError:
             return []
 
@@ -468,12 +469,12 @@ class Show:
             will be returned.
         """
         try:
-            parsed_date_string = date_parser.parse(date_string)
+            parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             return {}
 
         id_ = self.utility.convert_date_to_id(
-            parsed_date_string.year, parsed_date_string.month, parsed_date_string.day
+            parsed_date.year, parsed_date.month, parsed_date.day
         )
 
         return self.retrieve_details_by_id(
@@ -586,7 +587,7 @@ class Show:
             empty list will be returned.
         """
         try:
-            parsed_year = date_parser.parse(f"{year:04d}")
+            parsed_year = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -642,7 +643,9 @@ class Show:
             retrieved, an empty list will be returned.
         """
         try:
-            parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
+            parsed_year_month = datetime.datetime.strptime(
+                f"{year:04d}-{month:02d}-01", "%Y-%m-%d"
+            )
         except ValueError:
             return []
 
@@ -697,7 +700,7 @@ class Show:
             could not be retrieved, an empty list will be returned.
         """
         try:
-            _ = date_parser.parse(f"{year:04d}")
+            _ = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -851,7 +854,7 @@ class Show:
             will be returned.
         """
         try:
-            _ = date_parser.parse(f"{year:04d}")
+            _ = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 


### PR DESCRIPTION
## Application Changes

* Remove use of `dateutil` from the `show` module as it uses methods that have been marked for deprecated
* Replace `dateutil.parser.parse` with `datetime.datetime.strptime`

## Component Changes

* Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
* Upgrade numpy from 1.24.4 to 1.26.0
* Remove python-dateutil from dependencies

## Documentation Changes

* Change Python version from 3.10 to 3.12
* Upgrade Sphinx from 6.1.2 to 7.2.6
* Upgrade sphinx-autodoc-typehints from 1.23.0 to 1.25.2
* Upgrade sphinx-toolbox from 3.4.0 to 3.5.0
* Upgrade Pallets-Sphinx-Themes from 2.0.3 to 2.1.1
* Sync up dependency versions in `docs/requirements.txt` with `requirements-dev.txt`

## Development Changes

* Upgrade pytest from 7.3.1 to 7.4.3
* Upgrade black from 23.7.0 to 23.11.0
* Upgrade wheel from 0.41.2 to 0.41.3
* Upgrade build from 0.10.0 to 1.0.3
* Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
* Bump minimum pytest version from 7.0 to 7.4 in `pyproject.toml`