### PR TITLE
Adding Support for Shows with Multiple Bluff Segments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,15 +2,29 @@
 Changes
 *******
 
-2.5.0
+2.6.0
 =====
-
-**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been deprecated.**
 
 Application Changes
 -------------------
 
-* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked for deprecated
+* Starting with version 2.6.0 of this library, the minimum required version of the Wait Wait
+  Stats Database is 4.4.
+* Add support for shows that contain multiple Bluff the Listener-like segments by returning Bluff
+  information as a list of dictionaries. Each dictionary contains a segment number and both the
+  chosen and correct panelist information.
+
+2.5.0
+=====
+
+**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been
+deprecated.**
+
+Application Changes
+-------------------
+
+* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked as
+  deprecated
 * Replace ``dateutil.parser.parse`` with ``datetime.datetime.strptime``
 
 Component Changes
@@ -46,7 +60,8 @@ Development Changes
 Application Changes
 -------------------
 
-* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
+* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should
+  return an empty dictionary and not an empty list when no Bluff the Listener data is available
 
 Component Changes
 -----------------
@@ -61,14 +76,17 @@ Application Changes
 -------------------
 
 * Remove unnecessary checks for existence of the panelist decimal score columns
-* This change means that this library only supports version 4.3 of the Wait Wait Stats Database when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
+* This change means that this library only supports version 4.3 of the Wait Wait Stats Database
+  when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
   Usage with older versions of the database will result in errors.
 
 Development Changes
 -------------------
 
-* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use ``@pytest.mark.parameterize`` to test including or using decimal scores or not
-* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores`` testing parameters
+* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use
+  ``@pytest.mark.parameterize`` to test including or using decimal scores or not
+* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores``
+  testing parameters
 
 2.3.0
 =====
@@ -84,10 +102,12 @@ Application Changes
 Application Changes
 -------------------
 
-* Adding support for panelist decimal scores in ``panelist`` and ``show`` modules and defaulting existing methods to not use decimal scores for backwards compatibility. View docs for more information.
+* Adding support for panelist decimal scores in ``panelist`` and ``show`` modules and defaulting
+  existing methods to not use decimal scores for backwards compatibility. View docs for more information.
 * Add ``encoding="utf-8"`` to every instance of ``with open()``
 * Re-work SQL query strings to use triple-quotes rather than multiple strings wrapped in parentheses
-* Changed rounding of decimals or floats that return values with 4 places after the decimal point to 5 places
+* Changed rounding of decimals or floats that return values with 4 places after the decimal point
+  to 5 places
 
 Component Changes
 -----------------

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -6,7 +6,7 @@
 """Testing for object :py:class:`wwdtm.show.ShowInfo`
 """
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 from wwdtm.show import ShowInfo
@@ -23,7 +23,7 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1162])
+@pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_bluff_info_by_id`
 
@@ -34,19 +34,20 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     bluff = info.retrieve_bluff_info_by_id(show_id)
 
     assert (
-        bluff
-    ), f"Bluff the Listener information for show ID {show_id} could not be retrieved"
-    assert "chosen_panelist" in bluff, (
+        isinstance(bluff, List) and bluff
+    ), f"Bluff the Listener information for the show ID {show_id} could not be retrieved"
+
+    assert "chosen_panelist" in bluff[0], (
         "'chosen_panelist' was not returned with panelist information for show ID "
         f"{show_id}"
     )
-    assert "correct_panelist" in bluff, (
+    assert "correct_panelist" in bluff[0], (
         "'correct_panelist' was not returned with panelist information for show ID "
         f"{show_id}"
     )
 
 
-@pytest.mark.parametrize("show_id", [1162])
+@pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_core_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
 

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -23,33 +23,30 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1083, 1162])
+@pytest.mark.parametrize("show_id", [319, 1083, 1162])
 def test_show_info_retrieve_bluff_info_all(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`
-
-    :param show_id: Show ID to test retrieving show Bluff the Listener
-        information from all shows retrieved
-    """
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`"""
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     bluffs = info.retrieve_bluff_info_all()
 
-    assert bluffs, "Bluff the Listener information for all shows could not be retrieved"
-    assert (
-        show_id in bluffs
+    assert isinstance(
+        bluffs, Dict
+    ), "Bluff the Listener information for all shows could not be retrieved"
+
+    assert show_id in bluffs and isinstance(
+        bluffs[show_id], List
     ), f"Bluff the Listener information was not returned for show ID {show_id}"
 
-    bluff = bluffs[show_id]
-    assert "chosen_panelist" in bluff, (
-        "'chosen_panelist' was not returned with "
-        f"panelist information for show ID {show_id}"
-    )
-    assert "correct_panelist" in bluff, (
-        "'correct_panelist' was not returned with "
-        f"panelist information for show ID {show_id}"
-    )
+    assert (
+        "chosen_panelist" in bluffs[show_id][0]
+    ), f"'chosen_panelist' was not returned with panelist information for show ID {show_id}"
+
+    assert (
+        "correct_panelist" in bluffs[show_id][0]
+    ), f"'correct_panelist' was not returned with panelist information for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_ids", [[1083, 1162]])
+@pytest.mark.parametrize("show_ids", [[319, 1083, 1162]])
 def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_by_ids`
 
@@ -65,14 +62,16 @@ def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
     )
 
     for show_id in show_ids:
-        assert show_id in bluffs, (
+        assert show_id in bluffs and isinstance(bluffs[show_id], List), (
             "Bluff the Listener information was not " f"returned for show ID {show_id}"
         )
-        assert "chosen_panelist" in bluffs[show_id], (
+
+        assert "chosen_panelist" in bluffs[show_id][0], (
             "'chosen_panelist' was not returned with panelist information for show ID "
             f"{show_id}"
         )
-        assert "correct_panelist" in bluffs[show_id], (
+
+        assert "correct_panelist" in bluffs[show_id][0], (
             "'correct_panelist' was not returned with panelist information for show "
             f"ID {show_id}"
         )

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.5.0"
+VERSION = "2.6.0"

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -8,7 +8,7 @@
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from slugify import slugify
 from wwdtm.panelist.appearances import PanelistAppearances
 from wwdtm.panelist.statistics import PanelistStatistics

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 import numpy
 from wwdtm.panelist.scores import PanelistScores
 from wwdtm.panelist.decimal_scores import PanelistDecimalScores

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -105,8 +105,8 @@ class ShowInfo:
                 bluffs.append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
-                        "correct_panelist": {},
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
                     }
                 )
             elif row.chosen_id and not row.correct_id:
@@ -120,14 +120,14 @@ class ShowInfo:
                             if self.panelists[row.chosen_id]["slug"]
                             else slugify(self.panelists[row.chosen_id]["name"]),
                         },
-                        "correct_panelist": {},
+                        "correct_panelist": None,
                     }
                 )
             elif row.correct_id and not row.chosen_id:
                 bluffs.append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
+                        "chosen_panelist": None,
                         "correct_panelist": {
                             "id": row.correct_id,
                             "name": self.panelists[row.correct_id]["name"],

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -104,8 +104,8 @@ class ShowInfoMultiple:
                 bluff_info[row.showid].append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
-                        "correct_panelist": {},
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
                     }
                 )
             elif row.chosen_id and not row.correct_id:
@@ -119,14 +119,14 @@ class ShowInfoMultiple:
                             if self.panelists[row.chosen_id]["slug"]
                             else slugify(self.panelists[row.chosen_id]["name"]),
                         },
-                        "correct_panelist": {},
+                        "correct_panelist": None,
                     }
                 )
             elif row.correct_id and not row.chosen_id:
                 bluff_info[row.showid].append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
+                        "chosen_panelist": None,
                         "correct_panelist": {
                             "id": row.correct_id,
                             "name": self.panelists[row.correct_id]["name"],
@@ -195,8 +195,8 @@ class ShowInfoMultiple:
                 bluff_info[row.showid].append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
-                        "correct_panelist": {},
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
                     }
                 )
             elif row.chosen_id and not row.correct_id:
@@ -210,14 +210,14 @@ class ShowInfoMultiple:
                             if self.panelists[row.chosen_id]["slug"]
                             else slugify(self.panelists[row.chosen_id]["name"]),
                         },
-                        "correct_panelist": {},
+                        "correct_panelist": None,
                     }
                 )
             elif row.correct_id and not row.chosen_id:
                 bluff_info[row.showid].append(
                     {
                         "segment": row.segment,
-                        "chosen_panelist": {},
+                        "chosen_panelist": None,
                         "correct_panelist": {
                             "id": row.correct_id,
                             "name": self.panelists[row.correct_id]["name"],

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -121,9 +121,9 @@ class Show:
                 info[show]["panelists"] = []
 
             if info[show]["id"] in bluffs:
-                info[show]["bluff"] = bluffs[info[show]["id"]]
+                info[show]["bluffs"] = bluffs[info[show]["id"]]
             else:
-                info[show]["bluff"] = {}
+                info[show]["bluffs"] = {}
 
             if info[show]["id"] in guests:
                 info[show]["guests"] = guests[info[show]["id"]]
@@ -506,7 +506,7 @@ class Show:
         info["panelists"] = self.info.retrieve_panelist_info_by_id(
             show_id, include_decimal_scores=include_decimal_scores
         )
-        info["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
+        info["bluffs"] = self.info.retrieve_bluff_info_by_id(show_id)
         info["guests"] = self.info.retrieve_guest_info_by_id(show_id)
 
         return info
@@ -561,7 +561,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -616,7 +616,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -680,7 +680,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -833,7 +833,7 @@ class Show:
             info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                 show, include_decimal_scores=include_decimal_scores
             )
-            info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(show)
+            info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(show)
             info[show]["guests"] = self.info.retrieve_guest_info_by_id(show)
             shows.append(info[show])
 


### PR DESCRIPTION
## Application Changes

- Starting with version 2.6.0 of this library, the minimum required version of the Wait Wait Stats Database is 4.4.
- Add support for shows that contain multiple Bluff the Listener-like segments by returning Bluff information as a list of dictionaries. Each dictionary contains a segment number and both the chosen and correct panelist information.