### PR TITLE
Sort bluff data by segment number

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changes
 *******
 
+2.6.1
+=====
+
+Application Changes
+-------------------
+
+* Change ordering of bluff information to be sorted by segment number for individual shows, or
+  sorted by either show ID or show date when retrieving information for multiple shows.
+
 2.6.0
 =====
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.6.0"
+VERSION = "2.6.1"

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -90,7 +90,8 @@ class ShowInfo:
             SELECT segment, chosenbluffpnlid AS chosen_id,
             correctbluffpnlid AS correct_id
             FROM ww_showbluffmap
-            WHERE showid = %s;
+            WHERE showid = %s
+            ORDER BY segment ASC;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query, (show_id,))

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -83,9 +83,11 @@ class ShowInfoMultiple:
         """
 
         query = """
-            SELECT showid, segment, chosenbluffpnlid AS chosen_id,
-            correctbluffpnlid AS correct_id
-            FROM ww_showbluffmap;
+            SELECT blm.showid, blm.segment, blm.chosenbluffpnlid AS chosen_id,
+            blm.correctbluffpnlid AS correct_id
+            FROM ww_showbluffmap blm
+            JOIN ww_shows s on s.showid = blm.showid
+            ORDER BY s.showid ASC, blm.segment ASC;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
@@ -177,7 +179,8 @@ class ShowInfoMultiple:
             SELECT showid, segment, chosenbluffpnlid AS chosen_id,
             correctbluffpnlid AS correct_id
             FROM ww_showbluffmap
-            WHERE showid IN ({ids});""".format(ids=", ".join(str(v) for v in show_ids))
+            WHERE showid IN ({ids})
+            ORDER BY showid ASC, segment ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
         results = cursor.fetchall()


### PR DESCRIPTION
## Application Changes

- Change ordering of bluff information to be sorted by segment number for individual shows, or sorted by either show ID or show date when retrieving information for multiple shows.