### PR TITLE
Code Cleanup and Migrating to Ruff for Linting and Formatting

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.10"
+    python: "3.12"
 
 formats:
   - pdf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,16 @@
 {
     "python.autoComplete.extraPaths": ["${workspaceFolder}/wwdtm"],
-    "python.linting.pylintArgs": [
-        "--extension-pkg-whitelist=numpy,mysql,slugify,wwdtm"
-    ],
     "python.testing.pytestEnabled": true,
     "python.analysis.extraPaths": [
         "${workspaceFolder}/wwdtm"
     ],
-    "python.formatting.provider": "black"
+    "[python]": {
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit",
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,15 +2,29 @@
 Changes
 *******
 
-2.5.0
+2.6.0
 =====
-
-**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been deprecated.**
 
 Application Changes
 -------------------
 
-* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked for deprecated
+* Starting with version 2.6.0 of this library, the minimum required version of the Wait Wait
+  Stats Database is 4.4.
+* Add support for shows that contain multiple Bluff the Listener-like segments by returning Bluff
+  information as a list of dictionaries. Each dictionary contains a segment number and both the
+  chosen and correct panelist information.
+
+2.5.0
+=====
+
+**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been
+deprecated.**
+
+Application Changes
+-------------------
+
+* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked as
+  deprecated
 * Replace ``dateutil.parser.parse`` with ``datetime.datetime.strptime``
 
 Component Changes
@@ -46,7 +60,8 @@ Development Changes
 Application Changes
 -------------------
 
-* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
+* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should
+  return an empty dictionary and not an empty list when no Bluff the Listener data is available
 
 Component Changes
 -----------------
@@ -61,14 +76,17 @@ Application Changes
 -------------------
 
 * Remove unnecessary checks for existence of the panelist decimal score columns
-* This change means that this library only supports version 4.3 of the Wait Wait Stats Database when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
+* This change means that this library only supports version 4.3 of the Wait Wait Stats Database
+  when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
   Usage with older versions of the database will result in errors.
 
 Development Changes
 -------------------
 
-* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use ``@pytest.mark.parameterize`` to test including or using decimal scores or not
-* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores`` testing parameters
+* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use
+  ``@pytest.mark.parameterize`` to test including or using decimal scores or not
+* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores``
+  testing parameters
 
 2.3.0
 =====
@@ -84,10 +102,12 @@ Application Changes
 Application Changes
 -------------------
 
-* Adding support for panelist decimal scores in ``panelist`` and ``show`` modules and defaulting existing methods to not use decimal scores for backwards compatibility. View docs for more information.
+* Adding support for panelist decimal scores in ``panelist`` and ``show`` modules and defaulting
+  existing methods to not use decimal scores for backwards compatibility. View docs for more information.
 * Add ``encoding="utf-8"`` to every instance of ``with open()``
 * Re-work SQL query strings to use triple-quotes rather than multiple strings wrapped in parentheses
-* Changed rounding of decimals or floats that return values with 4 places after the decimal point to 5 places
+* Changed rounding of decimals or floats that return values with 4 places after the decimal point
+  to 5 places
 
 Component Changes
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changes
 *******
 
+2.4.0
+=====
+
+Application Changes
+-------------------
+
+* Remove unnecessary checks for existence of the panelist decimal score columns
+* This change means that this library only supports version 4.3 of the Wait Wait Stats Database when ``include_decimal_scores`` or ``use_decimal_scores`` parameters are set to ``True``.
+  Usage with older versions of the database will result in errors.
+
+Development Changes
+-------------------
+
+* Re-work ``panelist`` and ``show`` tests to remove separate tests for decimal scores and use ``@pytest.mark.parameterize`` to test including or using decimal scores or not
+* Update documentation to provide details for ``include_decimal_scores`` and ``use_decimal_scores`` testing parameters
+
 2.3.0
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changes
 *******
 
+2.4.1
+=====
+
+Application Changes
+-------------------
+
+* Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
+
 2.4.0
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,12 @@ Application Changes
 
 * Correct the value set for show ``bluff`` value in ``Show.retrieve_all_details``, which should return an empty dictionary and not an empty list when no Bluff the Listener data is available
 
+Component Changes
+-----------------
+
+* Upgrade numpy from 1.24.3 to 1.24.4
+* Upgrade pytz from 2023.3 to 2023.3.post1
+
 2.4.0
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,43 @@
 Changes
 *******
 
+2.7.0
+=====
+
+Application Changes
+-------------------
+
+* Update type hints for parameters and return values to be more specific and to replace the use
+  of :py:class:`typing.Optional` and :py:class:`typing.Union` with the conventions documented in PEP-484 and PEP-604.
+* Replace use of :py:class:`typing.Dict`, :py:class:`typing.List` and :py:class:`typing.Tuple` with :py:class:`dict`,
+  :py:class:`list` and :py:class:`tuple` respectively in type hints
+* Remove use of :py:meth:`functools.lru_cache` as caching should be done by the application consuming
+  the library
+
+Component Changes
+-----------------
+
+* Upgrade NumPy from 1.26.0 to 1.26.3
+
+Development Changes
+-------------------
+
+* Switch to Ruff for code linting and formatting (with the help of Black)
+* Deprecate ``perf_test.py`` for performance testing
+* Upgrade pytest from 7.4.3 to 7.4.4
+* Upgrade black from 23.11.0 to 23.12.0
+* Upgrade wheel from 0.41.3 to 0.42.0
+
+Documentation Changes
+---------------------
+
+* Update Sphinx configuration to be more similar to the conventions used by Pallets projects
+* Change the base font from IBM Plex Sans to IBM Plex Serif
+* Clean up and rewrite docstrings to be more consistent and succint
+* Add table of contents to each module page
+* Update the copyright block at the top of each file to remove ``coding`` line and to include
+  the appropriate SPDX license identifier
+
 2.6.1
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,14 @@
 Changes
 *******
 
+2.3.0
+=====
+
+Application Changes
+-------------------
+
+* Add support for decimal column and values for panelist Lightning round start and correct
+
 2.2.0
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,44 @@
 Changes
 *******
 
+2.5.0
+=====
+
+**Starting with version 2.5.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+Application Changes
+-------------------
+
+* Remove use of ``dateutil`` from the ``show`` module as it uses methods that have been marked for deprecated
+* Replace ``dateutil.parser.parse`` with ``datetime.datetime.strptime``
+
+Component Changes
+-----------------
+
+* Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+* Upgrade numpy from 1.24.4 to 1.26.0
+* Remove python-dateutil from dependencies
+
+Documentation Changes
+---------------------
+
+* Change Python version from 3.10 to 3.12
+* Upgrade Sphinx from 6.1.2 to 7.2.6
+* Upgrade sphinx-autodoc-typehints from 1.23.0 to 1.25.2
+* Upgrade sphinx-toolbox from 3.4.0 to 3.5.0
+* Upgrade Pallets-Sphinx-Themes from 2.0.3 to 2.1.1
+* Sync up dependency versions in ``docs/requirements.txt`` with ``requirements-dev.txt``
+
+Development Changes
+-------------------
+
+* Upgrade pytest from 7.3.1 to 7.4.3
+* Upgrade black from 23.7.0 to 23.11.0
+* Upgrade wheel from 0.41.2 to 0.41.3
+* Upgrade build from 0.10.0 to 1.0.3
+* Remove ``py38`` and ``py39`` from ``tool.black`` in ``pyproject.toml``
+* Bump minimum pytest version from 7.0 to 7.4 in ``pyproject.toml``
+
 2.4.1
 =====
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -22,6 +22,10 @@ Development Changes
 -------------------
 
 * Upgrade Black from 23.3.0 to 23.7.0
+* Upgrade flake8 from 6.0.0 to 6.1.0
+* Upgrade pycodestyle form 2.10.0 to 2.11.0
+* Upgrade pytest from 7.3.1 to 7.4.0
+* Upgrade wheel from 0.40.0 to 0.41.2
 
 2.1.0
 =====

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,15 @@
 Changes
 *******
 
+2.6.1
+=====
+
+Application Changes
+-------------------
+
+* Change ordering of bluff information to be sorted by segment number for individual shows, or
+  sorted by either show ID or show date when retrieving information for multiple shows.
+
 2.6.0
 =====
 

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Requirements
 ============
 
 Starting with version 2.5.0, the minimum supported version of Python has been
-increased from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+changed from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
 be supported.
 
 Testing for this library has been done using Python 3.10 and 3.12.

--- a/README.rst
+++ b/README.rst
@@ -14,8 +14,11 @@ library is available at `PyPI`_.
 Requirements
 ============
 
-This version of the library requires a minimum Python version of 3.8 and
-has been tested thoroughly with Python 3.8 and 3.10.
+Starting with version 2.5.0, the minimum supported version of Python has been
+increased from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+be supported.
+
+Testing for this library has been done using Python 3.10 and 3.12.
 
 In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,10 +1,11 @@
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
+/* @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap'); */
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 
 @media all {
     body, input, div.sphinxsidebar input {
-        font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+        /* font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; */
+        font-family: "IBM Plex Serif", Georgia, Cambria, "Times New Roman", serif;
         font-size: 1.05rem;
     }
 
@@ -19,6 +20,13 @@
 
     div.sphinxsidebar {
         font-size: 1rem;
+    }
+
+    nav#contents {
+        margin-left: 1em;
+        padding-bottom: 1em;
+        padding-left: 1em;
+        width: 90%;
     }
 
     p.caption, .caption-text {

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,0 +1,1 @@
+../CHANGES.rst

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -1,1 +1,0 @@
-../CHANGES.rst

--- a/docs/changes/index.rst
+++ b/docs/changes/index.rst
@@ -1,0 +1,1 @@
+../../CHANGES.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,28 +1,26 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-import os
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
 import sys
+from pathlib import Path
 
-from pallets_sphinx_themes import ProjectLink  # type: ignore
+from pallets_sphinx_themes import ProjectLink  # type: ignore[report-missing-imports]
 
-sys.path.insert(0, os.path.abspath("../"))
+current_path = Path.cwd()
+sys.path.insert(0, str(current_path.parent))
 
 project = "wwdtm"
-copyright = "2021-2023 Linh Pham"
+copyright = "2018-2024 Linh Pham. All Rights Reserved"
 author = "Linh Pham"
 
 extensions = [
     "pallets_sphinx_themes",
-    "sphinx.ext.autodoc",
-    "sphinx.ext.intersphinx",
-    "sphinx.ext.coverage",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
-    "sphinx_toolbox.more_autodoc.typehints",
-    "sphinx_autodoc_typehints",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
 ]
 
 templates_path = [
@@ -79,4 +77,5 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
 }
 
-always_document_param_types = True
+autodoc_typehints = "description"
+python_display_short_literal_types = True

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -8,9 +8,3 @@ dependencies:
   - sphinx-copybutton==0.5.2
   - sphinx-toolbox==3.5.0
   - Pallets-Sphinx-Themes==2.1.1
-  #- Sphinx==5.3.0
-  #- sphinx-autobuild==2021.3.14
-  #- sphinx-autodoc-typehints==1.19.5
-  #- sphinx-copybutton==0.5.0
-  #- sphinx-toolbox==3.1.2
-  #- Pallets-Sphinx-Themes==2.0.3

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,9 +2,15 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - Sphinx==5.3.0
+  - Sphinx==7.2.6
   - sphinx-autobuild==2021.3.14
-  - sphinx-autodoc-typehints==1.19.5
-  - sphinx-copybutton==0.5.0
-  - sphinx-toolbox==3.1.2
-  - Pallets-Sphinx-Themes==2.0.3
+  - sphinx-autodoc-typehints==1.25.2
+  - sphinx-copybutton==0.5.2
+  - sphinx-toolbox==3.5.0
+  - Pallets-Sphinx-Themes==2.1.1
+  #- Sphinx==5.3.0
+  #- sphinx-autobuild==2021.3.14
+  #- sphinx-autodoc-typehints==1.19.5
+  #- sphinx-copybutton==0.5.0
+  #- sphinx-toolbox==3.1.2
+  #- Pallets-Sphinx-Themes==2.0.3

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,13 +32,13 @@ Table of Contents
 =================
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 1
 
     known_issues
     wwdtm/index
     tests/index
     migrating/index
-    changelog
+    changes/index
 
 Indices and tables
 ==================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Table of Contents
     wwdtm/index
     tests/index
     migrating/index
+    changelog
 
 Indices and tables
 ==================

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -22,11 +22,11 @@ modules:
 Python Version
 ==============
 
-Python 3.8 or higher is now required for ``wwdtm`` due to dependent packages
-requiring Python 3.8 as the minimum version.
+Starting with version 2.5.0, ``wwdtm`` has deprecated all versions of Python
+prior to 3.10.
 
-Development and testing of ``wwdtm`` version 2 is done using Python 3.8 and
-3.10, with preliminary testing done on 3.11.
+All development and testing of ``wwdtm`` is done using Python 3.10 and
+3.12.
 
 Handling Database Connections
 =============================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
 flake8==6.1.0
-pycodestyle==2.11.0
 pytest==7.4.3
-black==23.11.0
+black==23.12.0
 
 mysql-connector-python==8.2.0
-numpy==1.26.0
+numpy==1.26.3
 python-slugify==8.0.1
 pytz==2023.3.post1
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,17 +1,16 @@
-flake8==6.0.0
-pycodestyle==2.10.0
-pytest==7.3.1
-black==23.7.0
+flake8==6.1.0
+pycodestyle==2.11.0
+pytest==7.4.3
+black==23.11.0
 
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1
 
-Sphinx==6.1.3
+Sphinx==7.2.6
 sphinx-autobuild==2021.3.14
-sphinx-autodoc-typehints==1.23.0
+sphinx-autodoc-typehints==1.25.2
 sphinx-copybutton==0.5.2
-sphinx-toolbox==3.4.0
-Pallets-Sphinx-Themes==2.0.3
+sphinx-toolbox==3.5.0
+Pallets-Sphinx-Themes==2.1.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,10 +4,10 @@ pytest==7.3.1
 black==23.7.0
 
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1
 
 Sphinx==6.1.3
 sphinx-autobuild==2021.3.14

--- a/docs/tests/guest.rst
+++ b/docs/tests/guest.rst
@@ -4,7 +4,7 @@
 guest
 *****
 
-This module provides functions used to by :py:class:`pytest` to run tests against
+This module provides functions used to by :py:mod:`pytest` to run tests against
 the following objects:
 
 - :py:class:`wwdtm.guest.Guest`

--- a/docs/tests/index.rst
+++ b/docs/tests/index.rst
@@ -4,8 +4,8 @@
 Testing Modules
 ***************
 
-This section of the documentation covers the ``pytest`` testing modules for
-each of the ``wwdtm`` library modules:
+This section of the documentation covers the :py:mod:`pytest` testing modules for
+each of the :py:mod:`wwdtm` library modules:
 
 .. toctree::
     :maxdepth: 2

--- a/docs/wwdtm/guest.rst
+++ b/docs/wwdtm/guest.rst
@@ -1,11 +1,16 @@
 .. module:: wwdtm.guest
 
-*****
-guest
-*****
+*************
+Module: guest
+*************
 
 This module provides objects used to retrieve guests, guest information and
 guest details from a copy of the Wait Wait Don't Tell Me! Stats database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Guest
 =====

--- a/docs/wwdtm/host.rst
+++ b/docs/wwdtm/host.rst
@@ -1,11 +1,16 @@
 .. module:: wwdtm.host
 
-****
-host
-****
+************
+Module: host
+************
 
 This module provides objects used to retrieve hosts, host information and host
 details from a copy of the Wait Wait Don't Tell Me! Stats database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Host
 ====

--- a/docs/wwdtm/location.rst
+++ b/docs/wwdtm/location.rst
@@ -1,12 +1,17 @@
 .. module:: wwdtm.location
 
-********
-location
-********
+****************
+Module: location
+****************
 
 This module provides objects that are used to retrieve locations, location
 information and location recordings from a copy of the Wait Wait Don't Tell Me!
 Stats database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Location
 ========

--- a/docs/wwdtm/panelist.rst
+++ b/docs/wwdtm/panelist.rst
@@ -1,12 +1,17 @@
 .. module:: wwdtm.panelist
 
-********
-panelist
-********
+****************
+Module: panelist
+****************
 
 This module provides objects used to retrieve panelists, panelist information
 and panelist details from a copy of the Wait Wait Don't Tell Me! Stats
 database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Panelist
 ========

--- a/docs/wwdtm/scorekeeper.rst
+++ b/docs/wwdtm/scorekeeper.rst
@@ -1,12 +1,17 @@
 .. module:: wwdtm.scorekeeper
 
-***********
-scorekeeper
-***********
+*******************
+Module: scorekeeper
+*******************
 
 This module provides objects used to retrieve scorekeepers, scorekeeper
 information and scorekeeper details from a copy of the Wait Wait Don't Tell Me!
 Stats database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Scorekeeper
 ===========

--- a/docs/wwdtm/show.rst
+++ b/docs/wwdtm/show.rst
@@ -1,12 +1,17 @@
 .. module:: wwdtm.show
 
-****
-show
-****
+************
+Module: show
+************
 
 This module provides objects used to retrieve shows, show information,
 and show details from a copy of the Wait Wait Don't Tell Me! Stats
 database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
 
 Show
 ====

--- a/docs/wwdtm/validation.rst
+++ b/docs/wwdtm/validation.rst
@@ -1,6 +1,6 @@
-**********
-validation
-**********
+******************
+Module: validation
+******************
 
 This module provides functions used to validate various data types used
 within the library.

--- a/perf_test.py
+++ b/perf_test.py
@@ -1,13 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2022 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Performance testing script for the core modules for wwdtm"""
-
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Deprecated: Performance testing script for the core modules for wwdtm."""
 import json
 import time
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 from wwdtm.guest import Guest
 from wwdtm.host import Host
@@ -17,22 +17,21 @@ from wwdtm.scorekeeper import Scorekeeper
 from wwdtm.show import Show
 
 
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Return database connection settings as a dictionary.
 
     :return: A dictionary containing database connection settings
         for use by mysql.connector
-    :rtype: Dict[str, Any]
     """
-    with open("config.json", "r") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
-def perf_test_guest(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.guest module
+def perf_test_guest(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.guest module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -75,8 +74,8 @@ def perf_test_guest(connect_dict: Dict[str, Any]) -> float:
     return round(end_time - start_time, 5)
 
 
-def perf_test_host(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.host module
+def perf_test_host(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.host module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -119,8 +118,8 @@ def perf_test_host(connect_dict: Dict[str, Any]) -> float:
     return round(end_time - start_time, 5)
 
 
-def perf_test_location(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.location module
+def perf_test_location(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.location module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -167,8 +166,8 @@ def perf_test_location(connect_dict: Dict[str, Any]) -> float:
     return round(end_time - start_time, 5)
 
 
-def perf_test_panelist(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.panelist module
+def perf_test_panelist(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.panelist module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -223,8 +222,8 @@ def perf_test_panelist(connect_dict: Dict[str, Any]) -> float:
     return round(end_time - start_time, 5)
 
 
-def perf_test_scorekeeper(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.scorekeeper module
+def perf_test_scorekeeper(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.scorekeeper module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -267,8 +266,8 @@ def perf_test_scorekeeper(connect_dict: Dict[str, Any]) -> float:
     return round(end_time - start_time, 5)
 
 
-def perf_test_show(connect_dict: Dict[str, Any]) -> float:
-    """Run performance test for the wwdtm.show module
+def perf_test_show(connect_dict: dict[str, Any]) -> float:
+    """Run performance test for the wwdtm.show module.
 
     :param connect_dict: A dictionary containing database connection
         settings for use by mysql.connector
@@ -348,7 +347,7 @@ def perf_test_show(connect_dict: Dict[str, Any]) -> float:
 
 
 def main():
-    """Runs performance testing against each of the wwdtm modules"""
+    """Runs performance testing against each of the wwdtm modules."""
     # Load configuration and set up database connection
     config = get_connect_dict()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,19 +7,18 @@ authors = [
 description = "Library used to query data from copy of Wait Wait Stats Database."
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = {text = "Apache-2.0"}
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "mysql-connector-python==8.0.33",
-    "numpy==1.24.4",
-    "python-dateutil==2.8.2",
+    "mysql-connector-python==8.2.0",
+    "numpy==1.26.0",
     "python-slugify==8.0.1",
     "pytz==2023.3.post1",
 ]
@@ -38,11 +37,11 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "23.7.0"
-target-version = ["py38", "py39", "py310", "py311"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
+minversion = "7.4"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,10 +18,10 @@ classifiers = [
 ]
 dependencies = [
     "mysql-connector-python==8.0.33",
-    "numpy==1.24.3",
+    "numpy==1.24.4",
     "python-dateutil==2.8.2",
     "python-slugify==8.0.1",
-    "pytz==2023.3",
+    "pytz==2023.3.post1",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,15 +18,15 @@ classifiers = [
 ]
 dependencies = [
     "mysql-connector-python==8.2.0",
-    "numpy==1.26.0",
+    "numpy==1.26.3",
     "python-slugify==8.0.1",
     "pytz==2023.3.post1",
 ]
 
 [project.urls]
-documentation = "https://docs.wwdt.me"
-homepage = "https://github.com/questionlp/wwdtm"
-repository = "https://github.com/questionlp/wwdtm"
+Documentation = "https://docs.wwdt.me"
+"Source Code" = "https://github.com/questionlp/wwdtm"
+"Stats Page" = "https://stats.wwdt.me"
 Mastodon = "https://linh.social/@qlp"
 
 [tool.setuptools.dynamic]
@@ -37,8 +37,9 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "23.11.0"
+required-version = "23.12.0"
 target-version = ["py310", "py311", "py312"]
+line-length = 88
 
 [tool.pytest.ini_options]
 minversion = "7.4"
@@ -52,3 +53,81 @@ norecursedirs = [
     ".eggs",
     "wwdtm.egg-info",
 ]
+
+[tool.ruff]
+target-version = "py310"
+select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D",   # pydocstyle
+    "E",   # Error
+    "F",   # pyflakes
+    "I",   # isort
+    "ISC", # flake8-implicit-str-concat
+    "N",   # pep8-naming
+    "PGH", # pygrep-hooks
+    "PTH", # flake8-use-pathlib
+    "Q",   # flake8-quotes
+    "S",   # bandit
+    "SIM", # flake8-simplify
+    "TRY", # tryceratops
+    "UP",  # pyupgrade
+    "W",   # Warning
+    "YTT", # flake8-2020
+]
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+line-length = 88 # Must agree with Black
+
+[tool.ruff.flake8-bugbear]
+extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "S101",   # use of "assert"
+    "S102",   # use of "exec"
+    "S106",   # possible hardcoded password.
+    "PGH001", # use of "eval"
+]
+
+[tool.ruff.pep8-naming]
+staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.urls]
 Documentation = "https://docs.wwdt.me"
 "Source Code" = "https://github.com/questionlp/wwdtm"
+Changes = "https://docs.wwdt.me/latest/changes/"
 "Stats Page" = "https://stats.wwdt.me"
 Mastodon = "https://linh.social/@qlp"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,10 @@
 flake8==6.1.0
-pycodestyle==2.11.0
-pytest==7.4.3
-black==23.11.0
-wheel==0.41.3
+pytest==7.4.4
+black==23.12.0
+wheel==0.42.0
 build==1.0.3
 
 mysql-connector-python==8.2.0
-numpy==1.26.0
+numpy==1.26.3
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ wheel==0.41.2
 build==0.10.0
 
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
 flake8==6.1.0
 pycodestyle==2.11.0
-pytest==7.4.0
-black==23.7.0
-wheel==0.41.2
-build==0.10.0
+pytest==7.4.3
+black==23.11.0
+wheel==0.41.3
+build==1.0.3
 
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-flake8==6.1.0
-pytest==7.4.4
+ruff==0.1.13
 black==23.12.0
+pytest==7.4.4
 wheel==0.42.0
 build==1.0.3
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 mysql-connector-python==8.0.33
-numpy==1.24.3
+numpy==1.24.4
 python-dateutil==2.8.2
 python-slugify==8.0.1
-pytz==2023.3
+pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-mysql-connector-python==8.0.33
-numpy==1.24.4
-python-dateutil==2.8.2
+mysql-connector-python==8.2.0
+numpy==1.26.0
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mysql-connector-python==8.2.0
-numpy==1.26.0
+numpy==1.26.3
 python-slugify==8.0.1
 pytz==2023.3.post1

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Deprecated: Package setup file"""
-
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Deprecated: Package setup file."""
 from setuptools import setup
 
 setup()

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.guest.GuestAppearances`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.guest.GuestAppearances`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.guest import GuestAppearances
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("guest_id", [976])
 def test_guest_appearances_retrieve_appearances_by_id(guest_id: int):
-    """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_id`
+    """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_id`.
 
     :param guest_id: Guest ID to test retrieving guest appearances
     """
@@ -41,7 +42,7 @@ def test_guest_appearances_retrieve_appearances_by_id(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_guest_appearances_retrieve_appearances_by_slug(guest_slug: str):
-    """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_slug`
+    """Testing for :py:meth:`wwdtm.guest.Appearances.retrieve_appearances_by_slug`.
 
     :param guest_slug: Guest slug string to test retrieving guest appearances
     """

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.guest.Guest`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.guest.Guest`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.guest import Guest
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_guest_retrieve_all():
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all`."""
     guest = Guest(connect_dict=get_connect_dict())
     guests = guest.retrieve_all()
 
@@ -36,7 +37,7 @@ def test_guest_retrieve_all():
 
 
 def test_guest_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_details`"""
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_details`."""
     guest = Guest(connect_dict=get_connect_dict())
     guests = guest.retrieve_all_details()
 
@@ -48,7 +49,7 @@ def test_guest_retrieve_all_details():
 
 
 def test_guest_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_ids`."""
     guest = Guest(connect_dict=get_connect_dict())
     ids = guest.retrieve_all_ids()
 
@@ -56,7 +57,7 @@ def test_guest_retrieve_all_ids():
 
 
 def test_guest_retrieve_all_slugs():
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_slugs`"""
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_all_slugs`."""
     guest = Guest(connect_dict=get_connect_dict())
     slugs = guest.retrieve_all_slugs()
 
@@ -65,7 +66,7 @@ def test_guest_retrieve_all_slugs():
 
 @pytest.mark.parametrize("guest_id", [976])
 def test_guest_retrieve_by_id(guest_id: int):
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_id`.
 
     :param guest_id: Guest ID to test retrieving guest information
     """
@@ -78,7 +79,7 @@ def test_guest_retrieve_by_id(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_guest_retrieve_by_slug(guest_slug: str):
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_slug`
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_by_slug`.
 
     :param guest_slug: Guest slug string to test retrieving guest
         information
@@ -92,7 +93,7 @@ def test_guest_retrieve_by_slug(guest_slug: str):
 
 @pytest.mark.parametrize("guest_id", [976])
 def test_guest_retrieve_details_by_id(guest_id: int):
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_id`.
 
     :param guest_id: Guest ID to test retrieving guest details
     """
@@ -106,7 +107,7 @@ def test_guest_retrieve_details_by_id(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_guest_guest_retrieve_details_by_slug(guest_slug: str):
-    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_slug`
+    """Testing for :py:meth:`wwdtm.guest.Guest.retrieve_details_by_slug`.
 
     :param guest_slug: Guest slug string to test retrieving guest details
     """

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wdtm.guest.GuestUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wdtm.guest.GuestUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.guest import GuestUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("guest_id", [54])
 def test_guest_utility_convert_id_to_slug(guest_id: int):
-    """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
+    """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`.
 
     :param guest_id: Guest ID to test converting into guest slug string
     """
@@ -41,7 +42,7 @@ def test_guest_utility_convert_id_to_slug(guest_id: int):
 
 @pytest.mark.parametrize("guest_id", [-54])
 def test_guest_utility_convert_invalid_id_to_slug(guest_id: int):
-    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`
+    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_id_to_slug`.
 
     :param guest_id: Guest ID to test failing to convert into guest slug
         string
@@ -54,7 +55,7 @@ def test_guest_utility_convert_invalid_id_to_slug(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks", "stephen-colbert"])
 def test_guest_utility_convert_slug_to_id(guest_slug: str):
-    """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`
+    """Testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`.
 
     :param guest_slug: Guest slug string to test converting into guest
         ID
@@ -68,7 +69,7 @@ def test_guest_utility_convert_slug_to_id(guest_slug: str):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanx", "steven-colbert"])
 def test_guest_utility_convert_invalid_slug_to_id(guest_slug: str):
-    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`
+    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.convert_slug_to_id`.
 
     :param guest_slug: Guest slug string to test failing to convert into
         guest ID
@@ -81,7 +82,7 @@ def test_guest_utility_convert_invalid_slug_to_id(guest_slug: str):
 
 @pytest.mark.parametrize("guest_id", [54])
 def test_guest_utility_id_exists(guest_id: int):
-    """Testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`.
 
     :param guest_id: Guest ID to test if a guest exists
     """
@@ -93,7 +94,7 @@ def test_guest_utility_id_exists(guest_id: int):
 
 @pytest.mark.parametrize("guest_id", [-1])
 def test_guest_utility_id_not_exists(guest_id: int):
-    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`
+    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.id_exists`.
 
     :param guest_id: Guest ID to test if a guest does not exist
     """
@@ -105,7 +106,7 @@ def test_guest_utility_id_not_exists(guest_id: int):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks", "stephen-colbert"])
 def test_guest_utility_slug_exists(guest_slug: str):
-    """Testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
+    """Testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`.
 
     :param guest_slug: Guest slug string to test if a guest exists
     """
@@ -117,7 +118,7 @@ def test_guest_utility_slug_exists(guest_slug: str):
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanx", "steven-colbert"])
 def test_guest_utility_slug_not_exists(guest_slug: str):
-    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`
+    """Negative testing for :py:meth:`wwdtm.guest.GuestUtility.slug_exists`.
 
     :param guest_slug: Guest slug string to test if a guest does not
         exist

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.host.HostAppearances`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.host.HostAppearances`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.host import HostAppearances
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("host_id", [2])
 def test_host_appearances_retrieve_appearances_by_id(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_id`
+    """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_id`.
 
     :param host_id: Host ID to test retrieving host appearances
     """
@@ -41,7 +42,7 @@ def test_host_appearances_retrieve_appearances_by_id(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_host_appearances_retrieve_appearances_by_slug(host_slug: str):
-    """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_slug`
+    """Testing for :py:meth:`wwdtm.host.HostAppearances.retrieve_appearances_by_slug`.
 
     :param host_slug: Host slug string to test retrieving host
         appearances

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.host.Host`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.host.Host`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.host import Host
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_host_retrieve_all():
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all`."""
     host = Host(connect_dict=get_connect_dict())
     hosts = host.retrieve_all()
 
@@ -36,19 +37,19 @@ def test_host_retrieve_all():
 
 
 def test_host_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_details`"""
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_details`."""
     host = Host(connect_dict=get_connect_dict())
     hosts = host.retrieve_all_details()
 
     assert hosts, "No hosts could be retrieved"
     assert "id" in hosts[0], "'id' was not returned for first list item"
-    assert "appearances" in hosts[0], (
-        "'appearances' was not returned for the" "first list item"
-    )
+    assert (
+        "appearances" in hosts[0]
+    ), "'appearances' was not returned for thefirst list item"
 
 
 def test_host_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_ids`."""
     host = Host(connect_dict=get_connect_dict())
     ids = host.retrieve_all_ids()
 
@@ -56,7 +57,7 @@ def test_host_retrieve_all_ids():
 
 
 def test_host_retrieve_all_slugs():
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_slugs`"""
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_all_slugs`."""
     host = Host(connect_dict=get_connect_dict())
     slugs = host.retrieve_all_slugs()
 
@@ -65,7 +66,7 @@ def test_host_retrieve_all_slugs():
 
 @pytest.mark.parametrize("host_id", [2])
 def test_host_retrieve_by_id(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_id`.
 
     :param host_id: Host ID to test retrieving host information
     """
@@ -78,7 +79,7 @@ def test_host_retrieve_by_id(host_id: int):
 
 @pytest.mark.parametrize("host_id", [2])
 def test_host_retrieve_details_by_id(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`.
 
     :param host_id: Host ID to test retrieving host details
     """
@@ -92,7 +93,7 @@ def test_host_retrieve_details_by_id(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_host_retrieve_by_slug(host_slug: str):
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_slug`
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_slug`.
 
     :param host_slug: Host slug string to test retrieving host
         information
@@ -106,7 +107,7 @@ def test_host_retrieve_by_slug(host_slug: str):
 
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_host_retrieve_details_by_slug(host_slug: str):
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_slug`
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_slug`.
 
     :param host_slug: Host slug string to test retrieving host details
     """

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.host.HostUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.host.HostUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.host import HostUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("host_id", [2])
 def test_host_utility_convert_id_to_slug(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
+    """Testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`.
 
     :param host_id: Host ID to test converting into host slug string
     """
@@ -41,7 +42,7 @@ def test_host_utility_convert_id_to_slug(host_id: int):
 
 @pytest.mark.parametrize("host_id", [-1])
 def test_host_utility_convert_invalid_id_to_slug(host_id: int):
-    """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`
+    """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_id_to_slug`.
 
     :param host_id: Host ID to test failing to convert into host slug
         string
@@ -54,7 +55,7 @@ def test_host_utility_convert_invalid_id_to_slug(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["tom-hanks"])
 def test_host_utility_convert_slug_to_id(host_slug: str):
-    """Testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
+    """Testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`.
 
     :param host_slug: Host slug string to test converting into host ID
     """
@@ -67,7 +68,7 @@ def test_host_utility_convert_slug_to_id(host_slug: str):
 
 @pytest.mark.parametrize("host_slug", ["tom-hanx"])
 def test_host_utility_convert_invalid_slug_to_id(host_slug: str):
-    """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`
+    """Negative testing for :py:meth:`wwdtm.host.HostUtility.convert_slug_to_id`.
 
     :param host_slug: Host slug string to test failing to convert into
         host ID
@@ -80,7 +81,7 @@ def test_host_utility_convert_invalid_slug_to_id(host_slug: str):
 
 @pytest.mark.parametrize("host_id", [2])
 def test_host_utility_id_exists(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.HostUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.host.HostUtility.id_exists`.
 
     :param host_id: Host ID to test if a host exists
     """
@@ -92,7 +93,7 @@ def test_host_utility_id_exists(host_id: int):
 
 @pytest.mark.parametrize("host_id", [-1])
 def test_host_utility_id_not_exists(host_id: int):
-    """Negative testing for :py:meth:`wwdtm.host.HostUtility.id_exists()`
+    """Negative testing for :py:meth:`wwdtm.host.HostUtility.id_exists()`.
 
     :param host_id: Host ID to test if a host does not exist
     """
@@ -104,7 +105,7 @@ def test_host_utility_id_not_exists(host_id: int):
 
 @pytest.mark.parametrize("host_slug", ["tom-hanks"])
 def test_host_utility_slug_exists(host_slug: str):
-    """Testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
+    """Testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`.
 
     :param host_slug: Host slug string to test if a host exists
     """
@@ -116,7 +117,7 @@ def test_host_utility_slug_exists(host_slug: str):
 
 @pytest.mark.parametrize("host_slug", ["tom-hanx"])
 def test_host_utility_slug_not_exists(host_slug: str):
-    """Negative testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`
+    """Negative testing for :py:meth:`wwdtm.host.HostUtility.slug_exists`.
 
     :param host_slug: Host slug string to test if a host does not exist
     """

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.location.Location`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.location.Location`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.location import Location
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_location_retrieve_all():
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all`."""
     location = Location(connect_dict=get_connect_dict())
     locations = location.retrieve_all()
 
@@ -36,19 +37,19 @@ def test_location_retrieve_all():
 
 
 def test_location_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_details`"""
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_details`."""
     location = Location(connect_dict=get_connect_dict())
     locations = location.retrieve_all_details()
 
     assert locations, "No locations could be retrieved"
     assert "id" in locations[0], "'id' was not returned for first list item"
-    assert "recordings" in locations[0], (
-        "'recordings' was not returned for " "the first list item"
-    )
+    assert (
+        "recordings" in locations[0]
+    ), "'recordings' was not returned for the first list item"
 
 
 def test_location_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_ids`."""
     location = Location(connect_dict=get_connect_dict())
     ids = location.retrieve_all_ids()
 
@@ -56,7 +57,7 @@ def test_location_retrieve_all_ids():
 
 
 def test_location_retrieve_all_slugs():
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_slugs`"""
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_all_slugs`."""
     location = Location(connect_dict=get_connect_dict())
     slugs = location.retrieve_all_slugs()
 
@@ -65,7 +66,7 @@ def test_location_retrieve_all_slugs():
 
 @pytest.mark.parametrize("location_id", [95])
 def test_location_retrieve_by_id(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_id`.
 
     :param location_id: Location ID to test retrieving location
         information
@@ -79,7 +80,7 @@ def test_location_retrieve_by_id(location_id: int):
 
 @pytest.mark.parametrize("location_id", [95])
 def test_location_retrieve_details_by_id(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`.
 
     :param location_id: Location ID to test retrieving location details
     """
@@ -93,7 +94,7 @@ def test_location_retrieve_details_by_id(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
 def test_location_retrieve_by_slug(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_slug`
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_slug`.
 
     :param location_slug: Location slug string to test retrieving
         location information
@@ -107,7 +108,7 @@ def test_location_retrieve_by_slug(location_slug: str):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
 def test_location_retrieve_details_by_slug(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.Location.retrieve_details_by_slug`
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_details_by_slug`.
 
     :param location_slug: Location slug string to test retrieving
         location details

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.location.LocationRecordings`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.location.LocationRecordings`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.location import LocationRecordings
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("location_id", [95])
 def test_location_recordings_retrieve_recordings_by_id(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_id`
+    """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_id`.
 
     :param location_id: Location ID to test retrieving location
         recordings
@@ -42,7 +43,7 @@ def test_location_recordings_retrieve_recordings_by_id(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
 def test_location_recordings_retrieve_recordings_by_slug(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_slug`
+    """Testing for :py:meth:`wwdtm.location.LocationRecordings.retrieve_recordings_by_slug`.
 
     :param location_slug: Location slug string to test retrieving
         location recordings

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.location.LocationUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.location.LocationUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.location import LocationUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("location_id", [95])
 def test_location_utility_convert_id_to_slug(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`.
 
     :param location_id: Location ID to test converting into location
         slug string
@@ -41,7 +42,7 @@ def test_location_utility_convert_id_to_slug(location_id: int):
 
 @pytest.mark.parametrize("location_id", [-1])
 def test_location_utility_convert_invalid_id_to_slug(location_id: int):
-    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`
+    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_id_to_slug`.
 
     :param location_id: Location ID to test failing to convert into
         location slug string
@@ -54,7 +55,7 @@ def test_location_utility_convert_invalid_id_to_slug(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
 def test_location_utility_convert_slug_to_id(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`.
 
     :param location_slug: Location slug string to test converting into
         location ID
@@ -67,7 +68,7 @@ def test_location_utility_convert_slug_to_id(location_slug: str):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-li"])
 def test_location_utility_convert_invalid_slug_to_id(location_slug: str):
-    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`
+    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.convert_slug_to_id`.
 
     :param location_slug: Location slug string to test failing to
         convert into location ID
@@ -80,7 +81,7 @@ def test_location_utility_convert_invalid_slug_to_id(location_slug: str):
 
 @pytest.mark.parametrize("location_id", [95])
 def test_location_utility_id_exists(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`.
 
     :param location_id: Location ID to test if a location exists
     """
@@ -92,7 +93,7 @@ def test_location_utility_id_exists(location_id: int):
 
 @pytest.mark.parametrize("location_id", [-1])
 def test_location_utility_id_not_exists(location_id: int):
-    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`
+    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.id_exists`.
 
     :param location_id: Location ID to test if a location does not exist
     """
@@ -104,7 +105,7 @@ def test_location_utility_id_not_exists(location_id: int):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-il"])
 def test_location_utility_slug_exists(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`.
 
     :param location_slug: Location slug string to test if a location
         exists
@@ -117,8 +118,7 @@ def test_location_utility_slug_exists(location_slug: str):
 
 @pytest.mark.parametrize("location_slug", ["the-chicago-theatre-chicago-li"])
 def test_location_utility_slug_not_exists(location_slug: str):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists`
-    with venue name
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slug_exists` with venue name.
 
     :param location_slug: Location slug string to test if a location
         does not exists
@@ -131,8 +131,7 @@ def test_location_utility_slug_not_exists(location_slug: str):
 
 @pytest.mark.parametrize("city", ["Chicago"])
 def test_location_utility_slugify_location_city(city: str):
-    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
-    with city name
+    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location` with city name.
 
     :param city: City to include in the slug string
     """
@@ -146,8 +145,7 @@ def test_location_utility_slugify_location_city(city: str):
 
 @pytest.mark.parametrize("city, state", [("Chicago", "IL")])
 def test_location_utility_slugify_location_city_state(city: str, state: str):
-    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
-    with city and state names
+    """Negative testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location` with city and state names.
 
     :param city: City to include in the slug string
     :param state: State to include in the slug string
@@ -166,8 +164,7 @@ def test_location_utility_slugify_location_city_state(city: str, state: str):
 def test_location_utility_slugify_location_full(
     location_id: int, venue: str, city: str, state: str
 ):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
-    with location ID, venue, city and state names
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location` with location ID, venue, city and state names.
 
     :param location_id: Location ID to include in the slug string
     :param venue: Venue name to include in the slug string
@@ -185,8 +182,7 @@ def test_location_utility_slugify_location_full(
 
 @pytest.mark.parametrize("location_id, venue", [(2, "Chase Auditorium")])
 def test_location_utility_slugify_location_venue(location_id: int, venue: str):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
-    with venue name
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location` with venue name.
 
     :param location_id: Location ID to include in the slug string
     :param venue: Venue name to include in the slug string
@@ -202,7 +198,7 @@ def test_location_utility_slugify_location_venue(location_id: int, venue: str):
 def test_location_utility_slugify_location_venue_city_state(
     venue: str, city: str, state: str
 ):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`.
 
     :param venue: Venue name to include in the slug string
     :param city: City to include in the slug string
@@ -217,8 +213,7 @@ def test_location_utility_slugify_location_venue_city_state(
 
 @pytest.mark.parametrize("location_id", [2])
 def test_location_utility_slugify_location_id(location_id: int):
-    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location`
-    with venue, city and state names
+    """Testing for :py:meth:`wwdtm.location.LocationUtility.slugify_location` with venue, city and state names.
 
     :param location_id: Location ID to include in the slug string
     """

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.PanelistAppearances`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.PanelistAppearances`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import PanelistAppearances
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -33,7 +34,7 @@ def get_connect_dict() -> Dict[str, Any]:
 def test_panelist_appearances_retrieve_appearances_by_id(
     panelist_id: int, use_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         appearances
@@ -63,7 +64,7 @@ def test_panelist_appearances_retrieve_appearances_by_id(
 def test_panelist_appearances_retrieve_appearances_by_slug(
     panelist_slug: str, use_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances
@@ -81,7 +82,7 @@ def test_panelist_appearances_retrieve_appearances_by_slug(
 
 @pytest.mark.parametrize("panelist_id", [14, 73])
 def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving a panelist's
         appearances
@@ -96,7 +97,7 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank", "maeve-higgins"])
 def test_panelist_appearances_retrieve_yearly_appearances_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_yearly_appearances_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -26,31 +26,23 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("panelist_id", [14, 73])
-def test_panelist_appearances_retrieve_appearances_by_id(panelist_id: int):
+@pytest.mark.parametrize(
+    "panelist_id, use_decimal_scores",
+    [(14, True), (14, False), (73, True), (73, False)],
+)
+def test_panelist_appearances_retrieve_appearances_by_id(
+    panelist_id: int, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist
         appearances
-    """
-    appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_id(panelist_id)
-
-    assert "count" in appearance, f"'count' was not returned for ID {panelist_id}"
-    assert "shows" in appearance, f"'shows' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14, 73])
-def test_panelist_appearances_retrieve_appearances_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist
-        appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_id(
-        panelist_id, use_decimal_scores=True
+        panelist_id, use_decimal_scores=use_decimal_scores
     )
 
     assert "count" in appearance, f"'count' was not returned for ID {panelist_id}"
@@ -58,34 +50,29 @@ def test_panelist_appearances_retrieve_appearances_by_id_decimal(panelist_id: in
 
 
 @pytest.mark.parametrize(
-    "panelist_slug", ["luke-burbank", "maeve-higgins", "peter-sagal"]
+    "panelist_slug, use_decimal_scores",
+    [
+        ("luke-burbank", True),
+        ("luke-burbank", False),
+        ("maeve-higgins", True),
+        ("maeve-higgins", False),
+        ("peter-sagal", True),
+        ("peter-sagal", False),
+    ],
 )
-def test_panelist_appearances_retrieve_appearances_by_slug(panelist_slug: str):
+def test_panelist_appearances_retrieve_appearances_by_slug(
+    panelist_slug: str, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist appearances
-    """
-    appearances = PanelistAppearances(connect_dict=get_connect_dict())
-    appearance = appearances.retrieve_appearances_by_slug(panelist_slug)
-
-    assert "count" in appearance, f"'count' was not returned for slug {panelist_slug}"
-    assert "shows" in appearance, f"'shows' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize(
-    "panelist_slug", ["luke-burbank", "maeve-higgins", "peter-sagal"]
-)
-def test_panelist_appearances_retrieve_appearances_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistAppearances.retrieve_appearances_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(
-        panelist_slug, use_decimal_scores=True
+        panelist_slug, use_decimal_scores=use_decimal_scores
     )
 
     assert "count" in appearance, f"'count' was not returned for slug {panelist_slug}"
@@ -98,6 +85,8 @@ def test_panelist_appearances_retrieve_yearly_appearances_by_id(panelist_id: int
 
     :param panelist_id: Panelist ID to test retrieving a panelist's
         appearances
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     appearances = PanelistAppearances(connect_dict=get_connect_dict())
     breakdown = appearances.retrieve_yearly_appearances_by_id(panelist_id)

--- a/tests/panelist/test_panelist_decimal_scores.py
+++ b/tests/panelist/test_panelist_decimal_scores.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.PanelistDecimalScores`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.PanelistDecimalScores`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import PanelistDecimalScores
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -41,7 +42,7 @@ def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -54,7 +55,7 @@ def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_list_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_list_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -68,7 +69,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_list_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_list_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -82,7 +83,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_ordered_pair_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_ordered_pair_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -98,7 +99,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id:
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(
     panelist_slug: str,
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_ordered_pair_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_grouped_ordered_pair_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -112,7 +113,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_list_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_list_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist information
     """
@@ -125,7 +126,7 @@ def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_list_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_list_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -139,7 +140,7 @@ def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_ordered_pair_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_ordered_pair_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -152,7 +153,7 @@ def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_ordered_pair_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistDecimalScores.retrieve_scores_ordered_pair_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving panelist
         information

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -35,23 +35,15 @@ def test_panelist_retrieve_all():
     assert "id" in panelists[0], "'id' was not returned for the first list item"
 
 
-def test_panelist_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`"""
-    panelist = Panelist(connect_dict=get_connect_dict())
-    panelists = panelist.retrieve_all_details()
-
-    assert panelists, "No panelists could be retrieved"
-    assert "id" in panelists[0], "'id' was not returned for first list item"
-    assert (
-        "appearances" in panelists[0]
-    ), "'appearances' was not returned for the first list item"
-
-
-def test_panelist_retrieve_all_details_decimal():
+@pytest.mark.parametrize("use_decimal_scores", [True, False])
+def test_panelist_retrieve_all_details(use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`
-    with decimal scores"""
+
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
+    """
     panelist = Panelist(connect_dict=get_connect_dict())
-    panelists = panelist.retrieve_all_details(use_decimal_scores=True)
+    panelists = panelist.retrieve_all_details(use_decimal_scores=use_decimal_scores)
 
     assert panelists, "No panelists could be retrieved"
     assert "id" in panelists[0], "'id' was not returned for first list item"
@@ -90,29 +82,18 @@ def test_panelist_retrieve_by_id(panelist_id: int):
     assert "name" in info, f"'name' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_retrieve_details_by_id(panelist_id: int):
+@pytest.mark.parametrize("panelist_id, use_decimal_scores", [(14, True), (14, False)])
+def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist details
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_id(panelist_id)
-
-    assert info, f"Panelist ID {panelist_id} not found"
-    assert "name" in info, f"'name' was not returned for ID {panelist_id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_retrieve_details_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist details
-    """
-    panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_id(panelist_id, use_decimal_scores=True)
+    info = panelist.retrieve_details_by_id(
+        panelist_id, use_decimal_scores=use_decimal_scores
+    )
 
     assert info, f"Panelist ID {panelist_id} not found"
     assert "name" in info, f"'name' was not returned for ID {panelist_id}"
@@ -133,33 +114,24 @@ def test_panelist_retrieve_by_slug(panelist_slug: str):
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_retrieve_details_by_slug(panelist_slug: str):
+@pytest.mark.parametrize(
+    "panelist_slug, use_decimal_scores",
+    [("luke-burbank", True), ("luke-burbank", False)],
+)
+def test_panelist_retrieve_details_by_slug(
+    panelist_slug: str, use_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist details
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_slug(panelist_slug)
-
-    assert info, f"Panelist slug {panelist_slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_retrieve_details_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist details
-    """
-    panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_details_by_slug(panelist_slug, use_decimal_scores=True)
+    info = panelist.retrieve_details_by_slug(
+        panelist_slug, use_decimal_scores=use_decimal_scores
+    )
 
     assert info, f"Panelist slug {panelist_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.Panelist`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.Panelist`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import Panelist
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_panelist_retrieve_all():
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all`."""
     panelist = Panelist(connect_dict=get_connect_dict())
     panelists = panelist.retrieve_all()
 
@@ -37,7 +38,7 @@ def test_panelist_retrieve_all():
 
 @pytest.mark.parametrize("use_decimal_scores", [True, False])
 def test_panelist_retrieve_all_details(use_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_details`.
 
     :param use_decimal_scores: Flag set to use decimal score columns
         and values
@@ -53,7 +54,7 @@ def test_panelist_retrieve_all_details(use_decimal_scores: bool):
 
 
 def test_panelist_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_ids`."""
     panelist = Panelist(connect_dict=get_connect_dict())
     ids = panelist.retrieve_all_ids()
 
@@ -61,7 +62,7 @@ def test_panelist_retrieve_all_ids():
 
 
 def test_panelist_retrieve_all_slugs():
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_slugs`"""
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_all_slugs`."""
     panelist = Panelist(connect_dict=get_connect_dict())
     slugs = panelist.retrieve_all_slugs()
 
@@ -70,7 +71,7 @@ def test_panelist_retrieve_all_slugs():
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_retrieve_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -84,7 +85,7 @@ def test_panelist_retrieve_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_id, use_decimal_scores", [(14, True), (14, False)])
 def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist details
     :param use_decimal_scores: Flag set to use decimal score columns
@@ -102,7 +103,7 @@ def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: b
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank", "drew-carey"])
 def test_panelist_retrieve_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -121,7 +122,7 @@ def test_panelist_retrieve_by_slug(panelist_slug: str):
 def test_panelist_retrieve_details_by_slug(
     panelist_slug: str, use_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist details

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.PanelistScores`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.PanelistScores`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import PanelistScores
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -41,7 +42,7 @@ def test_panelist_scores_retrieve_scores_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -54,7 +55,7 @@ def test_panelist_scores_retrieve_scores_by_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -68,7 +69,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_list_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -82,7 +83,7 @@ def test_panelist_scores_retrieve_scores_grouped_list_by_slug(panelist_slug: str
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -98,7 +99,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_id(panelist_id:
 def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(
     panelist_slug: str,
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_grouped_ordered_pair_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -112,7 +113,7 @@ def test_panelist_scores_retrieve_scores_grouped_ordered_pair_by_slug(
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist information
     """
@@ -125,7 +126,7 @@ def test_panelist_scores_retrieve_scores_list_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_list_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -139,7 +140,7 @@ def test_panelist_scores_retrieve_scores_list_by_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -152,7 +153,7 @@ def test_panelist_scores_retrieve_scores_ordered_pair_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_scores_retrieve_scores_ordered_pair_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistScores.retrieve_scores_ordered_pair_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving panelist
         information

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -80,69 +80,54 @@ def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
     assert "first" in ranks, f"'first' was not returned for slug {panelist_slug}"
 
 
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_statistics_retrieve_statistics_by_id(panelist_id: int):
+@pytest.mark.parametrize(
+    "panelist_id, include_decimal_scores", [(14, True), (14, False)]
+)
+def test_panelist_statistics_retrieve_statistics_by_id(
+    panelist_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
-    """
-    statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_id(panelist_id)
-
-    assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
-    assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_id", [14])
-def test_panelist_statistics_retrieve_statistics_by_id_decimal(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
-    with decimal scores
-
-    :param panelist_id: Panelist ID to test retrieving panelist
-        information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_id(
-        panelist_id, include_decimal_scores=True
+        panelist_id, include_decimal_scores=include_decimal_scores
     )
 
     assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
-    assert (
-        "scoring_decimal" in stats
-    ), f"'scoring_decimal' was not returned for ID {panelist_id}"
+    if include_decimal_scores:
+        assert (
+            "scoring_decimal" in stats
+        ), f"'scoring' was not returned for ID {panelist_id}"
     assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
 
 
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_statistics_by_slug(panelist_slug: str):
+@pytest.mark.parametrize(
+    "panelist_slug, include_decimal_scores",
+    [("luke-burbank", True), ("luke-burbank", False)],
+)
+def test_panelist_statistics_retrieve_statistics_by_slug(
+    panelist_slug: str, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
-    """
-    statistics = PanelistStatistics(connect_dict=get_connect_dict())
-    stats = statistics.retrieve_statistics_by_slug(panelist_slug)
-
-    assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
-    assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"
-
-
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
-def test_panelist_statistics_retrieve_statistics_by_slug_decimal(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
-    with decimal scores
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     statistics = PanelistStatistics(connect_dict=get_connect_dict())
     stats = statistics.retrieve_statistics_by_slug(
-        panelist_slug, include_decimal_scores=True
+        panelist_slug, include_decimal_scores=include_decimal_scores
     )
 
     assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
-    assert (
-        "scoring_decimal" in stats
-    ), f"'scoring_decimal' was not returned for slug {panelist_slug}"
+    if include_decimal_scores:
+        assert (
+            "scoring_decimal" in stats
+        ), f"'scoring' was not returned for ID {panelist_slug}"
     assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.PanelistStatistics`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.PanelistStatistics`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import PanelistStatistics
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_statistics_retrieve_bluffs_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -42,7 +43,7 @@ def test_panelist_statistics_retrieve_bluffs_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_statistics_retrieve_bluffs_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_bluffs_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -56,7 +57,7 @@ def test_panelist_statistics_retrieve_bluffs_by_slug(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_statistics_retrieve_rank_info_by_id(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -69,7 +70,7 @@ def test_panelist_statistics_retrieve_rank_info_by_id(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["luke-burbank"])
 def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_rank_info_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information
@@ -86,7 +87,7 @@ def test_panelist_statistics_retrieve_rank_info_by_slug(panelist_slug: str):
 def test_panelist_statistics_retrieve_statistics_by_id(
     panelist_id: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_id`.
 
     :param panelist_id: Panelist ID to test retrieving panelist
         information
@@ -113,7 +114,7 @@ def test_panelist_statistics_retrieve_statistics_by_id(
 def test_panelist_statistics_retrieve_statistics_by_slug(
     panelist_slug: str, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistStatistics.retrieve_statistics_by_slug`.
 
     :param panelist_slug: Panelist slug string to test retrieving
         panelist information

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -1,26 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.panelist.PanelistUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.panelist.PanelistUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.panelist import PanelistUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
 
-    :return: A dictionary containing database connection settings
-        for use by mysql.connector
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -28,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_utility_convert_id_to_slug(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`.
 
     :param panelist_id: Panelist ID to test converting into panelist
         slug string
@@ -42,7 +43,7 @@ def test_panelist_utility_convert_id_to_slug(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_id", [-1])
 def test_panelist_utility_convert_invalid_id_to_slug(panelist_id: int):
-    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`
+    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_id_to_slug`.
 
     :param panelist_id: Panelist ID to test failing to convert into
         panelist slug string
@@ -55,7 +56,7 @@ def test_panelist_utility_convert_invalid_id_to_slug(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelist_utility_convert_slug_to_id(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`.
 
     :param panelist_slug: Panelist slug string to test converting into
         panelist ID
@@ -69,7 +70,7 @@ def test_panelist_utility_convert_slug_to_id(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-sale"])
 def test_panelist_utility_convert_invalid_slug_to_id(panelist_slug: str):
-    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`
+    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.convert_slug_to_id`.
 
     :param panelist_slug: Panelist slug string to test failing to
         convert into panelist ID
@@ -82,7 +83,7 @@ def test_panelist_utility_convert_invalid_slug_to_id(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_id", [14])
 def test_panelist_utility_id_exists(panelist_id: int):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`.
 
     :param panelist_id: Panelist ID to test if a panelist exists
     """
@@ -94,7 +95,7 @@ def test_panelist_utility_id_exists(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_id", [-1])
 def test_panelist_utility_id_not_exists(panelist_id: int):
-    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`
+    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.id_exists`.
 
     :param panelist_id: Panelist ID to test if a panelist does not exist
     """
@@ -106,7 +107,7 @@ def test_panelist_utility_id_not_exists(panelist_id: int):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_panelist_utility_slug_exists(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`
+    """Testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`.
 
     :param panelist_slug: Panelist slug string to test if a panelist
         exists
@@ -119,7 +120,7 @@ def test_panelist_utility_slug_exists(panelist_slug: str):
 
 @pytest.mark.parametrize("panelist_slug", ["faith-sale"])
 def test_panelist_utility_slug_not_exists(panelist_slug: str):
-    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`
+    """Negative testing for :py:meth:`wwdtm.panelist.PanelistUtility.slug_exists`.
 
     :param panelist_slug: Panelist slug string to test if a panelist
         does not exist

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperAppearances`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperAppearances`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.scorekeeper import ScorekeeperAppearances
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -25,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("scorekeeper_id", [13])
 def test_scorekeeper_appearance_retrieve_appearances_by_id(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_id`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_id`.
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         appearances
@@ -39,7 +43,7 @@ def test_scorekeeper_appearance_retrieve_appearances_by_id(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
 def test_scorekeeper_appearance_retrieve_appearances_by_slug(scorekeeper_slug: str):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_slug`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperAppearances.retrieve_appearances_by_slug`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper appearances

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -1,30 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.scorekeeper.Scorekeeper`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.scorekeeper.Scorekeeper`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.scorekeeper import Scorekeeper
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_scorekeeper_retrieve_all():
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all`."""
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     scorekeepers = scorekeeper.retrieve_all()
 
@@ -33,7 +37,7 @@ def test_scorekeeper_retrieve_all():
 
 
 def test_scorekeeper_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_details`"""
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_details`."""
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     scorekeepers = scorekeeper.retrieve_all_details()
 
@@ -45,7 +49,7 @@ def test_scorekeeper_retrieve_all_details():
 
 
 def test_scorekeeper_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_ids`."""
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     ids = scorekeeper.retrieve_all_ids()
 
@@ -53,7 +57,7 @@ def test_scorekeeper_retrieve_all_ids():
 
 
 def test_scorekeeper_retrieve_all_slugs():
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_slugs`"""
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_all_slugs`."""
     scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
     slugs = scorekeeper.retrieve_all_slugs()
 
@@ -62,7 +66,7 @@ def test_scorekeeper_retrieve_all_slugs():
 
 @pytest.mark.parametrize("scorekeeper_id", [13])
 def test_scorekeeper_retrieve_by_id(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_id`.
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         information
@@ -76,7 +80,7 @@ def test_scorekeeper_retrieve_by_id(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_id", [13])
 def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_id`.
 
     :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
         details
@@ -93,7 +97,7 @@ def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_slug`
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_slug`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper information
@@ -107,7 +111,7 @@ def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_slug`
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_slug`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test retrieving
         scorekeeper details

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.scorekeeper import ScorekeeperUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -25,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("scorekeeper_id", [2])
 def test_scorekeeper_utility_convert_id_to_slug(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`.
 
     :param scorekeeper_id: Scorekeeper ID to test converting into
         scorekeeper slug string
@@ -39,7 +43,7 @@ def test_scorekeeper_utility_convert_id_to_slug(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_id", [-1])
 def test_scorekeeper_utility_convert_invalid_id_to_slug(scorekeeper_id: int):
-    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`
+    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_id_to_slug`.
 
     :param scorekeeper_id: Scorekeeper ID to test failing to convert
         into scorekeeper slug string
@@ -52,7 +56,7 @@ def test_scorekeeper_utility_convert_invalid_id_to_slug(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["korva-coleman"])
 def test_scorekeeper_utility_convert_slug_to_id(scorekeeper_slug: str):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test converting
         into scorekeeper ID
@@ -66,7 +70,7 @@ def test_scorekeeper_utility_convert_slug_to_id(scorekeeper_slug: str):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["corva-coleman"])
 def test_scorekeeper_utility_convert_invalid_slug_to_id(scorekeeper_slug: str):
-    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`
+    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.convert_slug_to_id`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test failing to
         convert into scorekeeper ID
@@ -79,7 +83,7 @@ def test_scorekeeper_utility_convert_invalid_slug_to_id(scorekeeper_slug: str):
 
 @pytest.mark.parametrize("scorekeeper_id", [2])
 def test_scorekeeper_utility_id_exists(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`.
 
     :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper
         exists
@@ -92,7 +96,7 @@ def test_scorekeeper_utility_id_exists(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_id", [-1])
 def test_scorekeeper_utility_id_not_exists(scorekeeper_id: int):
-    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`
+    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.id_exists`.
 
     :param scorekeeper_id: Scorekeeper ID to test if a scorekeeper does
         not exist
@@ -105,7 +109,7 @@ def test_scorekeeper_utility_id_not_exists(scorekeeper_id: int):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["korva-coleman"])
 def test_scorekeeper_utility_slug_exists(scorekeeper_slug: str):
-    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
+    """Testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test if a
         scorekeeper exists
@@ -118,7 +122,7 @@ def test_scorekeeper_utility_slug_exists(scorekeeper_slug: str):
 
 @pytest.mark.parametrize("scorekeeper_slug", ["corva-coleman"])
 def test_scorekeeper_utility_slug_not_exists(scorekeeper_slug: str):
-    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`
+    """Negative testing for :py:meth:`wwdtm.scorekeeper.ScorekeeperUtility.slug_exists`.
 
     :param scorekeeper_slug: Scorekeeper slug string to test if a
         scorekeeper does not exist

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -6,7 +6,7 @@
 """Testing for object :py:class:`wwdtm.show.ShowInfo`
 """
 import json
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import pytest
 from wwdtm.show import ShowInfo
@@ -23,7 +23,7 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1162])
+@pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_bluff_info_by_id`
 
@@ -34,19 +34,20 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     bluff = info.retrieve_bluff_info_by_id(show_id)
 
     assert (
-        bluff
-    ), f"Bluff the Listener information for show ID {show_id} could not be retrieved"
-    assert "chosen_panelist" in bluff, (
+        isinstance(bluff, List) and bluff
+    ), f"Bluff the Listener information for the show ID {show_id} could not be retrieved"
+
+    assert "chosen_panelist" in bluff[0], (
         "'chosen_panelist' was not returned with panelist information for show ID "
         f"{show_id}"
     )
-    assert "correct_panelist" in bluff, (
+    assert "correct_panelist" in bluff[0], (
         "'correct_panelist' was not returned with panelist information for show ID "
         f"{show_id}"
     )
 
 
-@pytest.mark.parametrize("show_id", [1162])
+@pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_core_info_by_id(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
 

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object :py:class:`wwdtm.show.ShowInfo`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object :py:class:`wwdtm.show.ShowInfo`."""
 import json
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.show import ShowInfo
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -25,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_bluff_info_by_id(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_bluff_info_by_id`
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_bluff_info_by_id`.
 
     :param show_id: Show ID to test retrieving show Bluff the Listener
         information
@@ -34,7 +38,7 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     bluff = info.retrieve_bluff_info_by_id(show_id)
 
     assert (
-        isinstance(bluff, List) and bluff
+        isinstance(bluff, list) and bluff
     ), f"Bluff the Listener information for the show ID {show_id} could not be retrieved"
 
     assert "chosen_panelist" in bluff[0], (
@@ -49,7 +53,7 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
 
 @pytest.mark.parametrize("show_id", [319, 1162])
 def test_show_info_retrieve_core_info_by_id(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_core_info_by_id`.
 
     :param show_id: Show ID to test retrieving show core information
     """
@@ -68,7 +72,7 @@ def test_show_info_retrieve_core_info_by_id(show_id: int):
 
 @pytest.mark.parametrize("show_id", [1162])
 def test_show_info_retrieve_guest_info_by_id(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_guest_info_by_id`
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_guest_info_by_id`.
 
     :param show_id: Show ID to test retrieving show guest information
     """
@@ -90,7 +94,7 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
 def test_show_info_retrieve_panelist_info_by_id(
     show_id: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
+    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`.
 
     :param show_id: Show ID to test retrieving show panelist information
     :param include_decimal_scores: Flag set to include decimal score columns

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -83,14 +83,22 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
     ), f"'score' was not returned for the first guest for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_panelist_info_by_id(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores", [(1162, True), (1162, False)]
+)
+def test_show_info_retrieve_panelist_info_by_id(
+    show_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
 
     :param show_id: Show ID to test retrieving show panelist information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfo(connect_dict=get_connect_dict())
-    panelists = info.retrieve_panelist_info_by_id(show_id)
+    panelists = info.retrieve_panelist_info_by_id(
+        show_id, include_decimal_scores=include_decimal_scores
+    )
 
     assert (
         panelists
@@ -101,24 +109,7 @@ def test_show_info_retrieve_panelist_info_by_id(show_id: int):
     assert (
         "score" in panelists[0]
     ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_id", [1162])
-def test_show_info_retrieve_panelist_info_by_id_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfo.retrieve_panelist_info_by_id`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show panelist information
-    """
-    info = ShowInfo(connect_dict=get_connect_dict())
-    panelists = info.retrieve_panelist_info_by_id(show_id, include_decimal_scores=True)
-
-    assert (
-        panelists
-    ), f"Panelist information for show ID {show_id} could not be retrieved"
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
+    if include_decimal_scores:
+        assert (
+            "score_decimal" in panelists[0]
+        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -23,33 +23,30 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1083, 1162])
+@pytest.mark.parametrize("show_id", [319, 1083, 1162])
 def test_show_info_retrieve_bluff_info_all(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`
-
-    :param show_id: Show ID to test retrieving show Bluff the Listener
-        information from all shows retrieved
-    """
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`"""
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     bluffs = info.retrieve_bluff_info_all()
 
-    assert bluffs, "Bluff the Listener information for all shows could not be retrieved"
-    assert (
-        show_id in bluffs
+    assert isinstance(
+        bluffs, Dict
+    ), "Bluff the Listener information for all shows could not be retrieved"
+
+    assert show_id in bluffs and isinstance(
+        bluffs[show_id], List
     ), f"Bluff the Listener information was not returned for show ID {show_id}"
 
-    bluff = bluffs[show_id]
-    assert "chosen_panelist" in bluff, (
-        "'chosen_panelist' was not returned with "
-        f"panelist information for show ID {show_id}"
-    )
-    assert "correct_panelist" in bluff, (
-        "'correct_panelist' was not returned with "
-        f"panelist information for show ID {show_id}"
-    )
+    assert (
+        "chosen_panelist" in bluffs[show_id][0]
+    ), f"'chosen_panelist' was not returned with panelist information for show ID {show_id}"
+
+    assert (
+        "correct_panelist" in bluffs[show_id][0]
+    ), f"'correct_panelist' was not returned with panelist information for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_ids", [[1083, 1162]])
+@pytest.mark.parametrize("show_ids", [[319, 1083, 1162]])
 def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_by_ids`
 
@@ -65,14 +62,16 @@ def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
     )
 
     for show_id in show_ids:
-        assert show_id in bluffs, (
+        assert show_id in bluffs and isinstance(bluffs[show_id], List), (
             "Bluff the Listener information was not " f"returned for show ID {show_id}"
         )
-        assert "chosen_panelist" in bluffs[show_id], (
+
+        assert "chosen_panelist" in bluffs[show_id][0], (
             "'chosen_panelist' was not returned with panelist information for show ID "
             f"{show_id}"
         )
-        assert "correct_panelist" in bluffs[show_id], (
+
+        assert "correct_panelist" in bluffs[show_id][0], (
             "'correct_panelist' was not returned with panelist information for show "
             f"ID {show_id}"
         )

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -23,7 +23,7 @@ def get_connect_dict() -> Dict[str, Any]:
             return config_dict["database"]
 
 
-@pytest.mark.parametrize("show_id", [1083])
+@pytest.mark.parametrize("show_id", [1083, 1162])
 def test_show_info_retrieve_bluff_info_all(show_id: int):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`
 
@@ -180,15 +180,23 @@ def test_show_info_retrieve_guest_info_by_ids(show_ids: List[int]):
             ), f"'score' was not returned for the first guest for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1082])
-def test_show_info_retrieve_panelist_info_all(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores", [(1082, True), (1082, False)]
+)
+def test_show_info_retrieve_panelist_info_all(
+    show_id: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
 
     :param show_id: Show ID to test retrieving show panelist information
         for all shows retrieved
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_all()
+    shows_panelists = info.retrieve_panelist_info_all(
+        include_decimal_scores=include_decimal_scores
+    )
 
     assert shows_panelists, "Panelist information for all shows could not be retrieved"
     assert (
@@ -202,72 +210,28 @@ def test_show_info_retrieve_panelist_info_all(show_id: int):
     assert (
         "score" in panelists[0]
     ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_id", [1082])
-def test_show_info_retrieve_panelist_info_all_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show panelist information
-        for all shows retrieved
-    """
-    info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_all(include_decimal_scores=True)
-
-    assert shows_panelists, "Panelist information for all shows could not be retrieved"
-    assert (
-        show_id in shows_panelists
-    ), f"Panelist information could not be retrieved for show ID {show_id}"
-
-    panelists = shows_panelists[show_id]
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
-
-
-@pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_panelist_info_by_ids(show_ids: List[int]):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
-
-    :param show_ids: List of show IDs to test retrieving show panelist
-        information
-    """
-    info = ShowInfoMultiple(connect_dict=get_connect_dict())
-    shows_panelists = info.retrieve_panelist_info_by_ids(show_ids)
-
-    assert (
-        shows_panelists
-    ), f"Panelist information for show IDs {show_ids} could not be retrieved"
-
-    for show_id in shows_panelists:
+    if include_decimal_scores:
         assert (
-            show_id in shows_panelists
-        ), f"Panelist information could not be retrieved for show ID {show_id}"
-        panelists = shows_panelists[show_id]
-        if panelists:
-            assert (
-                "id" in panelists[0]
-            ), f"'id' was not returned for the first panelist for show ID {show_id}"
-            assert "score" in panelists[0], (
-                f"'score' was not returned for the first panelist for show ID "
-                f"{show_id}"
-            )
+            "score_decimal" in panelists[0]
+        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
 
 
-@pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_panelist_info_by_ids_decimal(show_ids: List[int]):
+@pytest.mark.parametrize(
+    "show_ids, include_decimal_scores", [([1082, 1162], True), ([1082, 1162], False)]
+)
+def test_show_info_retrieve_panelist_info_by_ids(
+    show_ids: List[int], include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
 
     :param show_ids: List of show IDs to test retrieving show panelist
         information
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     shows_panelists = info.retrieve_panelist_info_by_ids(
-        show_ids, include_decimal_scores=True
+        show_ids, include_decimal_scores=include_decimal_scores
     )
 
     assert (
@@ -287,3 +251,7 @@ def test_show_info_retrieve_panelist_info_by_ids_decimal(show_ids: List[int]):
                 f"'score' was not returned for the first panelist for show ID "
                 f"{show_id}"
             )
+            if include_decimal_scores:
+                assert (
+                    "score_decimal" in panelists[0]
+                ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object :py:class:`wwdtm.show.ShowInfo`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object :py:class:`wwdtm.show.ShowInfo`."""
 import json
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.show import ShowInfoMultiple
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -25,16 +29,16 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("show_id", [319, 1083, 1162])
 def test_show_info_retrieve_bluff_info_all(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`"""
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_all`."""
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     bluffs = info.retrieve_bluff_info_all()
 
     assert isinstance(
-        bluffs, Dict
+        bluffs, dict
     ), "Bluff the Listener information for all shows could not be retrieved"
 
     assert show_id in bluffs and isinstance(
-        bluffs[show_id], List
+        bluffs[show_id], list
     ), f"Bluff the Listener information was not returned for show ID {show_id}"
 
     assert (
@@ -47,8 +51,8 @@ def test_show_info_retrieve_bluff_info_all(show_id: int):
 
 
 @pytest.mark.parametrize("show_ids", [[319, 1083, 1162]])
-def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_by_ids`
+def test_show_info_retrieve_bluff_info_by_ids(show_ids: list[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_bluff_info_by_ids`.
 
     :param show_ids: List of show IDs to test retrieving show Bluff the
         Listener information
@@ -62,9 +66,9 @@ def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
     )
 
     for show_id in show_ids:
-        assert show_id in bluffs and isinstance(bluffs[show_id], List), (
-            "Bluff the Listener information was not " f"returned for show ID {show_id}"
-        )
+        assert show_id in bluffs and isinstance(
+            bluffs[show_id], list
+        ), f"Bluff the Listener information was not returned for show ID {show_id}"
 
         assert "chosen_panelist" in bluffs[show_id][0], (
             "'chosen_panelist' was not returned with panelist information for show ID "
@@ -79,7 +83,7 @@ def test_show_info_retrieve_bluff_info_by_ids(show_ids: List[int]):
 
 @pytest.mark.parametrize("show_id", [1162])
 def test_show_info_retrieve_core_info_all(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_all`
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_all`.
 
     :param show_id: Show ID to test retrieving show core information
         from all shows retrieved
@@ -102,8 +106,8 @@ def test_show_info_retrieve_core_info_all(show_id: int):
 
 
 @pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_core_info_by_ids(show_ids: List[int]):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_by_ids`
+def test_show_info_retrieve_core_info_by_ids(show_ids: list[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_core_info_by_ids`.
 
     :param show_id: Show ID to test retrieving show core information
     """
@@ -127,7 +131,7 @@ def test_show_info_retrieve_core_info_by_ids(show_ids: List[int]):
 
 @pytest.mark.parametrize("show_id", [1082])
 def test_show_info_retrieve_guest_info_all(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_all`
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_all`.
 
     :param show_id: Show ID to test retrieving show guest information
         for all shows retrieved
@@ -151,8 +155,8 @@ def test_show_info_retrieve_guest_info_all(show_id: int):
 
 
 @pytest.mark.parametrize("show_ids", [[1082, 1162]])
-def test_show_info_retrieve_guest_info_by_ids(show_ids: List[int]):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_by_ids`
+def test_show_info_retrieve_guest_info_by_ids(show_ids: list[int]):
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_guest_info_by_ids`.
 
     :param show_ids: List of show IDs to test retrieving show guest
         information
@@ -185,7 +189,7 @@ def test_show_info_retrieve_guest_info_by_ids(show_ids: List[int]):
 def test_show_info_retrieve_panelist_info_all(
     show_id: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_all`.
 
     :param show_id: Show ID to test retrieving show panelist information
         for all shows retrieved
@@ -219,9 +223,9 @@ def test_show_info_retrieve_panelist_info_all(
     "show_ids, include_decimal_scores", [([1082, 1162], True), ([1082, 1162], False)]
 )
 def test_show_info_retrieve_panelist_info_by_ids(
-    show_ids: List[int], include_decimal_scores: bool
+    show_ids: list[int], include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`
+    """Testing for :py:meth:`wwdtm.show.ShowInfoMultiple.retrieve_panelist_info_by_ids`.
 
     :param show_ids: List of show IDs to test retrieving show panelist
         information

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -32,21 +32,15 @@ def test_show_retrieve_all():
     assert "id" in shows[0], "No Show ID returned for the first list item"
 
 
-def test_show_retrieve_all_details():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`"""
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_all_details()
-
-    assert shows, "No shows could be retrieved"
-    assert "date" in shows[0], "'date' was not returned for the first list item"
-    assert "host" in shows[0], "'host' was not returned for first list item"
-
-
-def test_show_retrieve_all_details_decimal():
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_details(include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`
-    with decimal scores"""
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_all_details(include_decimal_scores=True)
+    shows = show.retrieve_all_details(include_decimal_scores=include_decimal_scores)
 
     assert shows, "No shows could be retrieved"
     assert "date" in shows[0], "'date' was not returned for the first list item"
@@ -196,16 +190,25 @@ def test_show_retrieve_by_year_month(year: int, month: int):
     )
 
 
-@pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
-def test_show_retrieve_details_by_date(year: int, month: int, day: int):
+@pytest.mark.parametrize(
+    "year, month, day, include_decimal_scores",
+    [(2020, 4, 25, True), (2020, 4, 25, False)],
+)
+def test_show_retrieve_details_by_date(
+    year: int, month: int, day: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date(year, month, day)
+    info = show.retrieve_details_by_date(
+        year, month, day, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
     assert "date" in info, (
@@ -216,36 +219,21 @@ def test_show_retrieve_details_by_date(year: int, month: int, day: int):
     )
 
 
-@pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
-def test_show_retrieve_details_by_date_decimal(year: int, month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    :param month: One or two digit month to test retrieving show details
-    :param day: One or two digit day to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date(year, month, day, include_decimal_scores=True)
-
-    assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert "date" in info, (
-        f"'date' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
-    assert "host" in info, (
-        f"'host' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
-
-
-@pytest.mark.parametrize("date", ["2018-10-27"])
-def test_show_retrieve_details_by_date_string(date: str):
+@pytest.mark.parametrize(
+    "date, include_decimal_scores", [("2018-10-27", True), ("2018-10-27", False)]
+)
+def test_show_retrieve_details_by_date_string(date: str, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_date_string(date)
+    info = show.retrieve_details_by_date_string(
+        date, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show for date {date} not found"
     assert "date" in info, f"'date' was not returned for show {date}"
@@ -259,6 +247,8 @@ def test_show_retrieve_details_by_date_string_decimal(date: str):
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
     info = show.retrieve_details_by_date_string(date, include_decimal_scores=True)
@@ -268,44 +258,45 @@ def test_show_retrieve_details_by_date_string_decimal(date: str):
     assert "host" in info, f"'host' was not returned for show {date}"
 
 
-@pytest.mark.parametrize("show_id", [1162, 1246])
-def test_show_retrieve_details_by_id(show_id: int):
+@pytest.mark.parametrize(
+    "show_id, include_decimal_scores",
+    [(1162, True), (1162, False), (1246, True), (1246, False)],
+)
+def test_show_retrieve_details_by_id(show_id: int, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
 
     :param show_id: Show ID to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_id(show_id)
+    info = show.retrieve_details_by_id(
+        show_id, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"Show ID {show_id} not found"
     assert "date" in info, f"'date' was not returned for ID {show_id}"
     assert "host" in info, f"'host' was not returned for ID {show_id}"
 
 
-@pytest.mark.parametrize("show_id", [1162, 1246])
-def test_show_retrieve_details_by_id_decimal(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
-    with decimal scores
-
-    :param show_id: Show ID to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_id(show_id, include_decimal_scores=True)
-
-    assert info, f"Show ID {show_id} not found"
-    assert "date" in info, f"'date' was not returned for ID {show_id}"
-    assert "host" in info, f"'host' was not returned for ID {show_id}"
-
-
-@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
-def test_show_retrieve_details_by_month_day(month: int, day: int):
+@pytest.mark.parametrize(
+    "month, day, include_decimal_scores",
+    [(10, 28, True), (10, 28, False), (8, 19, True), (8, 19, False)],
+)
+def test_show_retrieve_details_by_month_day(
+    month: int, day: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
 
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_details_by_month_day(month, day)
+    shows = show.retrieve_details_by_month_day(
+        month, day, include_decimal_scores=include_decimal_scores
+    )
 
     assert shows, (
         f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
@@ -316,34 +307,16 @@ def test_show_retrieve_details_by_month_day(month: int, day: int):
     )
 
 
-@pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
-def test_show_retrieve_details_by_month_day_decimal(month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
-    with decimal scores
-
-    :param month: One or two digit month to test retrieving show details
-    :param day: One or two digit day to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_details_by_month_day(month, day, include_decimal_scores=True)
-
-    assert shows, (
-        f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
-    )
-    assert "id" in shows[0], (
-        f"'id' was not returned for the first list item "
-        f"for month {month:02d} and day {day:02d}"
-    )
-
-
-@pytest.mark.parametrize("year", [2021])
-def test_show_retrieve_details_by_year(year: int):
+@pytest.mark.parametrize("year, include_decimal_scores", [(2021, True), (2021, False)])
+def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
 
     :param year: Four digit year to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year(year)
+    info = show.retrieve_details_by_year(
+        year, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, f"No shows could be retrieved for year {year:04d}"
     assert "date" in info[0], (
@@ -354,58 +327,21 @@ def test_show_retrieve_details_by_year(year: int):
     )
 
 
-@pytest.mark.parametrize("year", [2021])
-def test_show_retrieve_details_by_year_decimal(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year(year, include_decimal_scores=True)
-
-    assert info, f"No shows could be retrieved for year {year:04d}"
-    assert "date" in info[0], (
-        f"'date' was not returned for first list " f"item for year {year:04d}"
-    )
-    assert "host" in info[0], (
-        f"'host' was not returned for first list " f"item for year {year:04d}"
-    )
-
-
-@pytest.mark.parametrize("year, month", [(2020, 4)])
-def test_show_retrieve_details_by_year_month(year: int, month: int):
+@pytest.mark.parametrize(
+    "year, month, include_decimal_scores", [(2020, 4, True), (2020, 4, False)]
+)
+def test_show_retrieve_details_by_year_month(
+    year: int, month: int, include_decimal_scores: bool
+):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit year to test retrieving show details
     """
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year_month(year, month)
-
-    assert info, (
-        f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
+    info = show.retrieve_details_by_year_month(
+        year, month, include_decimal_scores=include_decimal_scores
     )
-    assert "date" in info[0], (
-        f"'date' was not returned for first list item "
-        f"for year/month {year:04d}-{month:02d}"
-    )
-    assert "host" in info[0], (
-        f"'host' was not returned for first list item "
-        f"for year/month {year:04d}-{month:02d}"
-    )
-
-
-@pytest.mark.parametrize("year, month", [(2020, 4)])
-def test_show_retrieve_details_by_year_month_decimal(year: int, month: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
-    with decimal scores
-
-    :param year: Four digit year to test retrieving show details
-    :param month: One or two digit year to test retrieving show details
-    """
-    show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_details_by_year_month(year, month, include_decimal_scores=True)
 
     assert info, (
         f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
@@ -441,50 +377,28 @@ def test_show_retrieve_recent():
     assert "id" in shows[0], "No Show ID returned for the first list item"
 
 
-def test_show_retrieve_recent_details():
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_recent_details(include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`"""
     show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_recent_details()
+    shows = show.retrieve_recent_details(include_decimal_scores=include_decimal_scores)
 
     assert shows, "No shows could be retrieved"
     assert "date" in shows[0], "'date' was not returned for the first list item"
     assert "host" in shows[0], "'host' was not returned for first list item"
 
 
-def test_show_retrieve_recent_details_decimal():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`
-    with decimal scores"""
-    show = Show(connect_dict=get_connect_dict())
-    shows = show.retrieve_recent_details(include_decimal_scores=True)
-
-    assert shows, "No shows could be retrieved"
-    assert "date" in shows[0], "'date' was not returned for the first list item"
-    assert "host" in shows[0], "'host' was not returned for first list item"
-
-
-@pytest.mark.parametrize("year", [2018])
-def test_show_retrieve_scores_by_year(year: int):
+@pytest.mark.parametrize("year, use_decimal_scores", [(2018, True), (2018, False)])
+def test_show_retrieve_scores_by_year(year: int, use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`
 
     :param year: Four digit year to test retrieving scores for a show
         year
+    :param use_decimal_scores: Flag set to use decimal score columns
+        and values
     """
     show = Show(connect_dict=get_connect_dict())
-    scores = show.retrieve_scores_by_year(year)
-
-    assert scores, f"No scores could be retrieved by year {year:04d}"
-    assert isinstance(scores[0], tuple), "First list item is not a tuple"
-
-
-@pytest.mark.parametrize("year", [2018])
-def test_show_retrieve_scores_by_year_decimal(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`
-
-    :param year: Four digit year to test retrieving scores for a show
-        year
-    """
-    show = Show(connect_dict=get_connect_dict())
-    scores = show.retrieve_scores_by_year(year, use_decimal_scores=True)
+    scores = show.retrieve_scores_by_year(year, use_decimal_scores=use_decimal_scores)
 
     assert scores, f"No scores could be retrieved by year {year:04d}"
     assert isinstance(scores[0], tuple), "First list item is not a tuple"

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -1,30 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object :py:class:`wwdtm.show.Show`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object :py:class:`wwdtm.show.Show`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.show import Show
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
 
 
 def test_show_retrieve_all():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all`."""
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_all()
 
@@ -34,7 +38,7 @@ def test_show_retrieve_all():
 
 @pytest.mark.parametrize("include_decimal_scores", [True, False])
 def test_show_retrieve_all_details(include_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`.
 
     :param include_decimal_scores: Flag set to include decimal score columns
         and values
@@ -48,7 +52,7 @@ def test_show_retrieve_all_details(include_decimal_scores: bool):
 
 
 def test_show_retrieve_all_ids():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_ids`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_ids`."""
     show = Show(connect_dict=get_connect_dict())
     ids = show.retrieve_all_ids()
 
@@ -56,7 +60,7 @@ def test_show_retrieve_all_ids():
 
 
 def test_show_retrieve_all_dates():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates`."""
     show = Show(connect_dict=get_connect_dict())
     dates = show.retrieve_all_dates()
 
@@ -64,7 +68,7 @@ def test_show_retrieve_all_dates():
 
 
 def test_show_retrieve_all_dates_tuple():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates_tuple`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_dates_tuple`."""
     show = Show(connect_dict=get_connect_dict())
     dates = show.retrieve_all_dates_tuple()
 
@@ -73,7 +77,7 @@ def test_show_retrieve_all_dates_tuple():
 
 
 def test_show_retrieve_all_show_years_months():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_show_years_months`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_show_years_months`."""
     show = Show(connect_dict=get_connect_dict())
     dates = show.retrieve_all_show_years_months()
 
@@ -82,7 +86,7 @@ def test_show_retrieve_all_show_years_months():
 
 
 def test_show_retrieve_all_show_years_months_tuple():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_shows_years_months_tuple`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_shows_years_months_tuple`."""
     show = Show(connect_dict=get_connect_dict())
     dates = show.retrieve_all_shows_years_months_tuple()
 
@@ -92,7 +96,7 @@ def test_show_retrieve_all_show_years_months_tuple():
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
 def test_show_retrieve_by_date(year: int, month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date`.
 
     :param year: Four digit year to test retrieving a show's information
     :param month: One or two digit month to test retrieving a show's
@@ -104,14 +108,14 @@ def test_show_retrieve_by_date(year: int, month: int, day: int):
     info = show.retrieve_by_date(year, month, day)
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert "date" in info, (
-        f"'date' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
+    assert (
+        "date" in info
+    ), f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
 
 
 @pytest.mark.parametrize("date", ["2018-10-27"])
 def test_show_retrieve_by_date_string(date: str):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date_string`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_date_string`.
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving a show's information
@@ -125,7 +129,7 @@ def test_show_retrieve_by_date_string(date: str):
 
 @pytest.mark.parametrize("show_id", [1162])
 def test_show_retrieve_by_id(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_id`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_id`.
 
     :param show_id: Show ID to test retrieving show information
     """
@@ -138,7 +142,7 @@ def test_show_retrieve_by_id(show_id: int):
 
 @pytest.mark.parametrize("month, day", [(10, 28), (8, 19)])
 def test_show_retrieve_by_month_day(month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_month_day`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_month_day`.
 
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
@@ -146,9 +150,7 @@ def test_show_retrieve_by_month_day(month: int, day: int):
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_by_month_day(month, day)
 
-    assert shows, (
-        f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
-    )
+    assert shows, f"No shows could be retrieved for month {month:02d} and day {day:02d}"
     assert "id" in shows[0], (
         f"'id' was not returned for the first list item "
         f"for month {month:02d} and day {day:02d}"
@@ -157,7 +159,7 @@ def test_show_retrieve_by_month_day(month: int, day: int):
 
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_by_year(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year`.
 
     :param year: Four digit year to test retrieving show information
     """
@@ -165,14 +167,14 @@ def test_show_retrieve_by_year(year: int):
     shows = show.retrieve_by_year(year)
 
     assert shows, f"No shows could be retrieved for year {year:04d}"
-    assert "id" in shows[0], (
-        f"'id' was not returned for the first list item " f"for year {year:04d}"
-    )
+    assert (
+        "id" in shows[0]
+    ), f"'id' was not returned for the first list item for year {year:04d}"
 
 
 @pytest.mark.parametrize("year, month", [(1998, 1), (2018, 10)])
 def test_show_retrieve_by_year_month(year: int, month: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year_month`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_by_year_month`.
 
     :param year: Four digit year to test retrieving show information
     :param month: One or two digit month to test retrieving show
@@ -181,9 +183,7 @@ def test_show_retrieve_by_year_month(year: int, month: int):
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_by_year_month(year, month)
 
-    assert shows, (
-        f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
-    )
+    assert shows, f"No shows could be retrieved for year/month {year:04d}-{month:02d}"
     assert "id" in shows[0], (
         f"'id' was not returned for the first list "
         f"item for year/month {year:02d}-{month:04d}"
@@ -197,7 +197,7 @@ def test_show_retrieve_by_year_month(year: int, month: int):
 def test_show_retrieve_details_by_date(
     year: int, month: int, day: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date`.
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit month to test retrieving show details
@@ -211,19 +211,19 @@ def test_show_retrieve_details_by_date(
     )
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert "date" in info, (
-        f"'date' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
-    assert "host" in info, (
-        f"'host' was not returned for show " f"{year:04d}-{month:02d}-{day:02d}"
-    )
+    assert (
+        "date" in info
+    ), f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    assert (
+        "host" in info
+    ), f"'host' was not returned for show {year:04d}-{month:02d}-{day:02d}"
 
 
 @pytest.mark.parametrize(
     "date, include_decimal_scores", [("2018-10-27", True), ("2018-10-27", False)]
 )
 def test_show_retrieve_details_by_date_string(date: str, include_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`.
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
@@ -242,8 +242,7 @@ def test_show_retrieve_details_by_date_string(date: str, include_decimal_scores:
 
 @pytest.mark.parametrize("date", ["2018-10-27"])
 def test_show_retrieve_details_by_date_string_decimal(date: str):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string`
-    with decimal scores
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string` with decimal scores.
 
     :param date: Show date string in ``YYYY-MM-DD`` format to test
         retrieving show details
@@ -263,7 +262,7 @@ def test_show_retrieve_details_by_date_string_decimal(date: str):
     [(1162, True), (1162, False), (1246, True), (1246, False)],
 )
 def test_show_retrieve_details_by_id(show_id: int, include_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_id`.
 
     :param show_id: Show ID to test retrieving show details
     :param include_decimal_scores: Flag set to include decimal score columns
@@ -286,7 +285,7 @@ def test_show_retrieve_details_by_id(show_id: int, include_decimal_scores: bool)
 def test_show_retrieve_details_by_month_day(
     month: int, day: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_month_day`.
 
     :param month: One or two digit month to test retrieving show details
     :param day: One or two digit day to test retrieving show details
@@ -298,9 +297,7 @@ def test_show_retrieve_details_by_month_day(
         month, day, include_decimal_scores=include_decimal_scores
     )
 
-    assert shows, (
-        f"No shows could be retrieved for month {month:02d} " "and day {day:02d}"
-    )
+    assert shows, f"No shows could be retrieved for month {month:02d} and day {day:02d}"
     assert "id" in shows[0], (
         f"'id' was not returned for the first list item "
         f"for month {month:02d} and day {day:02d}"
@@ -309,7 +306,7 @@ def test_show_retrieve_details_by_month_day(
 
 @pytest.mark.parametrize("year, include_decimal_scores", [(2021, True), (2021, False)])
 def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year`.
 
     :param year: Four digit year to test retrieving show details
     """
@@ -319,12 +316,12 @@ def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
     )
 
     assert info, f"No shows could be retrieved for year {year:04d}"
-    assert "date" in info[0], (
-        f"'date' was not returned for first list " f"item for year {year:04d}"
-    )
-    assert "host" in info[0], (
-        f"'host' was not returned for first list " f"item for year {year:04d}"
-    )
+    assert (
+        "date" in info[0]
+    ), f"'date' was not returned for first list item for year {year:04d}"
+    assert (
+        "host" in info[0]
+    ), f"'host' was not returned for first list item for year {year:04d}"
 
 
 @pytest.mark.parametrize(
@@ -333,7 +330,7 @@ def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
 def test_show_retrieve_details_by_year_month(
     year: int, month: int, include_decimal_scores: bool
 ):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_year_month`.
 
     :param year: Four digit year to test retrieving show details
     :param month: One or two digit year to test retrieving show details
@@ -343,9 +340,7 @@ def test_show_retrieve_details_by_year_month(
         year, month, include_decimal_scores=include_decimal_scores
     )
 
-    assert info, (
-        f"No shows could be retrieved for year/month " f"{year:04d}-{month:02d}"
-    )
+    assert info, f"No shows could be retrieved for year/month {year:04d}-{month:02d}"
     assert "date" in info[0], (
         f"'date' was not returned for first list item "
         f"for year/month {year:04d}-{month:02d}"
@@ -358,7 +353,7 @@ def test_show_retrieve_details_by_year_month(
 
 @pytest.mark.parametrize("year", [2018])
 def test_show_retrieve_months_by_year(year: int):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_months_by_year`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_months_by_year`.
 
     :param year: Four digit year to test retrieving a list of months
     """
@@ -369,7 +364,7 @@ def test_show_retrieve_months_by_year(year: int):
 
 
 def test_show_retrieve_recent():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent`."""
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_recent()
 
@@ -379,7 +374,7 @@ def test_show_retrieve_recent():
 
 @pytest.mark.parametrize("include_decimal_scores", [True, False])
 def test_show_retrieve_recent_details(include_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_recent_details`."""
     show = Show(connect_dict=get_connect_dict())
     shows = show.retrieve_recent_details(include_decimal_scores=include_decimal_scores)
 
@@ -390,7 +385,7 @@ def test_show_retrieve_recent_details(include_decimal_scores: bool):
 
 @pytest.mark.parametrize("year, use_decimal_scores", [(2018, True), (2018, False)])
 def test_show_retrieve_scores_by_year(year: int, use_decimal_scores: bool):
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_scores_by_year`.
 
     :param year: Four digit year to test retrieving scores for a show
         year
@@ -405,7 +400,7 @@ def test_show_retrieve_scores_by_year(year: int, use_decimal_scores: bool):
 
 
 def test_show_retrieve_years():
-    """Testing for :py:meth:`wwdtm.show.Show.retrieve_years`"""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_years`."""
     show = Show(connect_dict=get_connect_dict())
     years = show.retrieve_years()
 

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -1,23 +1,27 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object :py:class:`wwdtm.show.ShowUtility`
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object :py:class:`wwdtm.show.ShowUtility`."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 import pytest
+
 from wwdtm.show import ShowUtility
 
 
 @pytest.mark.skip
-def get_connect_dict() -> Dict[str, Any]:
-    """Read in database connection settings and return values as a
-    dictionary.
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
     """
-    with open("config.json", "r", encoding="utf-8") as config_file:
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
         config_dict = json.load(config_file)
         if "database" in config_dict:
             return config_dict["database"]
@@ -25,7 +29,7 @@ def get_connect_dict() -> Dict[str, Any]:
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
 def test_show_utility_convert_date_to_id(year: int, month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`
+    """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`.
 
     :param year: Four digit year to test converting into show ID
     :param month: One or two digit month to test converting into show ID
@@ -35,14 +39,14 @@ def test_show_utility_convert_date_to_id(year: int, month: int, day: int):
     id_ = utility.convert_date_to_id(year, month, day)
 
     assert id_, f"Show ID for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert isinstance(id_, int), (
-        f"Invalid value returned for date " f"{year:04d}-{month:02d}-{day:02d}"
-    )
+    assert isinstance(
+        id_, int
+    ), f"Invalid value returned for date {year:04d}-{month:02d}-{day:02d}"
 
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 26)])
 def test_show_utility_convert_invalid_date_to_id(year: int, month: int, day: int):
-    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`
+    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_date_to_id`.
 
     :param year: Four digit year to test failing to convert into show ID
     :param month: One or two digit month to test failing to convert
@@ -58,7 +62,7 @@ def test_show_utility_convert_invalid_date_to_id(year: int, month: int, day: int
 
 @pytest.mark.parametrize("show_id", [1162])
 def test_show_utility_convert_id_to_date(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
+    """Testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`.
 
     :param show_id: Show ID to test converting into show date
     """
@@ -71,7 +75,7 @@ def test_show_utility_convert_id_to_date(show_id: int):
 
 @pytest.mark.parametrize("show_id", [-1])
 def test_show_utility_convert_invalid_id_to_date(show_id: int):
-    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`
+    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.convert_id_to_date`.
 
     :param show_id: Show ID to test failing to convert into show date
     """
@@ -83,7 +87,7 @@ def test_show_utility_convert_invalid_id_to_date(show_id: int):
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 25)])
 def test_show_utility_date_exists(year: int, month: int, day: int):
-    """Testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`
+    """Testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`.
 
     :param year: Four digit year to test if a show exists
     :param month: One or two digit month to test if a show exists
@@ -97,7 +101,7 @@ def test_show_utility_date_exists(year: int, month: int, day: int):
 
 @pytest.mark.parametrize("year, month, day", [(2020, 4, 24)])
 def test_show_utility_date_not_exists(year: int, month: int, day: int):
-    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`
+    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.date_exists`.
 
     :param year: Four digit year to test if a show does not exist
     :param month: One or two digit month to test if a show does not
@@ -112,7 +116,7 @@ def test_show_utility_date_not_exists(year: int, month: int, day: int):
 
 @pytest.mark.parametrize("show_id", [1162])
 def test_show_utility_id_exists(show_id: int):
-    """Testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
+    """Testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`.
 
     :param show_id: Show ID to test if a show exists
     """
@@ -124,7 +128,7 @@ def test_show_utility_id_exists(show_id: int):
 
 @pytest.mark.parametrize("show_id", [-1])
 def test_show_utility_id_not_exists(show_id: int):
-    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`
+    """Negative testing for :py:meth:`wwdtm.show.ShowUtility.id_exists`.
 
     :param show_id: Show ID to test if a show does not exist
     """

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,18 +1,16 @@
-# -*- coding: utf-8 -*-
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Testing for object: :py:class:`wwdtm.validation`
-"""
-
+"""Testing for object: :py:class:`wwdtm.validation`."""
 import pytest
+
 from wwdtm.validation import valid_int_id
 
 
 @pytest.mark.parametrize("test_id", [54, 32767])
 def test_validation_valid_int_id(test_id: int):
-    """Testing for :py:meth:`wwdtm.validation.valid_int_id`
+    """Testing for :py:meth:`wwdtm.validation.valid_int_id`.
 
     :param test_id: ID to test ID validation
     """
@@ -21,7 +19,7 @@ def test_validation_valid_int_id(test_id: int):
 
 @pytest.mark.parametrize("test_id", [-54, 2**32])
 def test_validation_invalid_int_id(test_id: int):
-    """Negative testing for :py:meth:`wwdtm.validation.valid_int_id`
+    """Negative testing for :py:meth:`wwdtm.validation.valid_int_id`.
 
     :param test_id: ID to test failing ID validation
     """

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.6.0"
+VERSION = "2.6.1"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.4.0"
+VERSION = "2.4.1"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Explicitly listing all modules in this package"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Explicitly listing all modules in this package."""
 
 from wwdtm import validation
-
 from wwdtm.guest import Guest, GuestAppearances, GuestUtility
 from wwdtm.host import Host, HostAppearances, HostUtility
 from wwdtm.location import Location, LocationRecordings, LocationUtility
@@ -21,5 +20,4 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-
-VERSION = "2.6.1"
+VERSION = "2.7.0-alpha"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.5.0"
+VERSION = "2.6.0"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -20,4 +20,4 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.7.0-alpha"
+VERSION = "2.7.0"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.3.0"
+VERSION = "2.4.0"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.4.1"
+VERSION = "2.5.0"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -22,4 +22,4 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 
-VERSION = "2.2.0"
+VERSION = "2.3.0"

--- a/wwdtm/guest/__init__.py
+++ b/wwdtm/guest/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Guest module"""
-from wwdtm.guest.appearances import GuestAppearances
-from wwdtm.guest.guest import Guest
-from wwdtm.guest.utility import GuestUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Guest module."""
+from .appearances import GuestAppearances
+from .guest import Guest
+from .utility import GuestUtility

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -1,32 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Guest Appearance Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Guest Appearance Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.guest.utility import GuestUtility
 from wwdtm.validation import valid_int_id
 
 
 class GuestAppearances:
-    """This class contains functions that retrieve guest appearance
-    information from a copy of the Wait Wait Stats database.
+    """Guest appearance information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve Not My Job guest appearance
+    information, scores and scoring exceptions.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -40,15 +42,13 @@ class GuestAppearances:
 
         self.utility = GuestUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, guest_id: int) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested guest ID.
+    def retrieve_appearances_by_id(self, guest_id: int) -> dict[str, Any]:
+        """Retrieves guest appearance information.
 
         :param guest_id: Guest ID
-        :return: Dictionary containing appearance counts and list of
-            appearances for a guest. If guest appearances could not be
-            retrieved, an empty dictionary is returned.
+        :return: A dictionary containing guest appearances with
+            corresponding show dates, Best Of or Repeat show flags,
+            score and score exception flag
         """
         if not valid_int_id(guest_id):
             return {}
@@ -122,15 +122,13 @@ class GuestAppearances:
                 "shows": [],
             }
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, guest_slug: str) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested guest slug string.
+    def retrieve_appearances_by_slug(self, guest_slug: str) -> dict[str, Any]:
+        """Retrieves guest appearance information.
 
         :param guest_slug: Guest slug string
-        :return: Dictionary containing appearance counts and list of
-            appearances for a guest. If guest appearances could not be
-            retrieved, empty dictionary is returned.
+        :return: A dictionary containing guest appearances with
+            corresponding show dates, Best Of or Repeat show flags,
+            score and score exception flag
         """
         id_ = self.utility.convert_slug_to_id(guest_slug)
         if not id_:

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -1,32 +1,33 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Guest Data Utility Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Guest Data Utility Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.validation import valid_int_id
 
 
 class GuestUtility:
-    """This class contains supporting functions used to check whether
-    a Guest ID or slug string exists or to convert an ID to a slug
-    string, or vice versa.
+    """Guest information and utilities class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to convert between guest ID and slug strings,
+    and to check if guest IDs and slug strings exist.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -38,12 +39,12 @@ class GuestUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_id_to_slug(self, guest_id: int) -> Optional[str]:
-        """Converts a guest's ID to the matching guest slug string.
+    def convert_id_to_slug(self, guest_id: int) -> str | None:
+        """Converts a guest ID to the corresponding guest slug string.
 
         :param guest_id: Guest ID
-        :return: Guest slug string, if a match is found
+        :return: Guest slug string if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         if not valid_int_id(guest_id):
             return None
@@ -61,13 +62,12 @@ class GuestUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_slug_to_id(self, guest_slug: str) -> Optional[int]:
-        """Converts a guest's slug string to the matching guest ID, if
-        a match is found. If no match is found, None is returned.
+    def convert_slug_to_id(self, guest_slug: str) -> int | None:
+        """Converts a guest slug string to the corresponding guest ID.
 
         :param guest_slug: Guest slug string
-        :return: Guest ID, if a match is found
+        :return: Guest ID if a corresponding value is found. Otherwise,
+            ``None`` is returned
         """
         try:
             slug = guest_slug.strip()
@@ -89,12 +89,11 @@ class GuestUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def id_exists(self, guest_id: int) -> bool:
-        """Checks to see if a guest ID exists.
+        """Validates if a guest ID exists.
 
         :param guest_id: Guest ID
-        :return: True or False, based on whether the guest ID exists
+        :return: ``True`` if the ID exists, otherwise ``False``
         """
         if not valid_int_id(guest_id):
             return False
@@ -109,13 +108,11 @@ class GuestUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def slug_exists(self, guest_slug: str) -> bool:
-        """Checks to see if a guest slug string exists.
+        """Validates if a guest slug string exists.
 
         :param guest_slug: Guest slug string
-        :return: True or False, based on whether the guest slug string
-            exists
+        :return: ``True`` if the slug string exists, otherwise ``False``
         """
         try:
             slug = guest_slug.strip()

--- a/wwdtm/host/__init__.py
+++ b/wwdtm/host/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Host module"""
-from wwdtm.host.appearances import HostAppearances
-from wwdtm.host.host import Host
-from wwdtm.host.utility import HostUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Host module."""
+from .appearances import HostAppearances
+from .host import Host
+from .utility import HostUtility

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -1,32 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Host Appearance Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Host Appearance Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.host.utility import HostUtility
 from wwdtm.validation import valid_int_id
 
 
 class HostAppearances:
-    """This class contains functions that retrieve host appearance
-    information from a copy of the Wait Wait Stats database.
+    """Host appearance information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve host appearance information,
+    including show flags.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -40,15 +42,12 @@ class HostAppearances:
 
         self.utility = HostUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, host_id: int) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested host ID.
+    def retrieve_appearances_by_id(self, host_id: int) -> dict[str, Any]:
+        """Retrieves host appearance information.
 
         :param host_id: Host ID
-        :return:  Dictionary containing appearance counts and list of
-            appearances for a host. If host appearances could not be
-            retrieved, an empty dictionary is returned.
+        :return: A dictionary containing host appearances with
+            corresponding show dates and Best Of or Repeat show flags
         """
         if not valid_int_id(host_id):
             return {}
@@ -119,15 +118,12 @@ class HostAppearances:
                 "shows": [],
             }
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, host_slug: str) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested host ID.
+    def retrieve_appearances_by_slug(self, host_slug: str) -> dict[str, Any]:
+        """Retrieves host appearance information.
 
         :param host_slug: Host slug string
-        :return:  Dictionary containing appearance counts and list of
-            appearances for a host. If host appearances could not be
-            retrieved, an empty dictionary is returned.
+        :return: A dictionary containing host appearances with
+            corresponding show dates and Best Of or Repeat show flags
         """
         id_ = self.utility.convert_slug_to_id(host_slug)
         if not id_:

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -1,32 +1,33 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Host Data Utility Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Host Data Utility Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.validation import valid_int_id
 
 
 class HostUtility:
-    """This class contains supporting functions used to check whether
-    a host ID or slug string exists or to convert an ID to a slug
-    string, or vice versa.
+    """Host information and utilities class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to convert between host ID and slug strings,
+    and to check if host IDs and slug strings exist.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -38,12 +39,12 @@ class HostUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_id_to_slug(self, host_id: int) -> Optional[str]:
-        """Converts a host's ID to the matching host slug string value.
+    def convert_id_to_slug(self, host_id: int) -> str | None:
+        """Converts a host ID to the corresponding host slug string.
 
         :param host_id: Host ID
-        :return: Host slug string, if a match is found
+        :return: Host slug string if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         if not valid_int_id(host_id):
             return None
@@ -61,12 +62,12 @@ class HostUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_slug_to_id(self, host_slug: str) -> Optional[int]:
-        """Converts a host's slug string to the matching host ID value.
+    def convert_slug_to_id(self, host_slug: str) -> int | None:
+        """Converts a host slug string to the corresponding host ID.
 
         :param host_slug: Host slug string
-        :return: Host ID, if a match is found
+        :return: Host ID as an integer if a corresponding value is
+            found. Otherwise, ``None`` is returned
         """
         try:
             slug = host_slug.strip()
@@ -88,12 +89,11 @@ class HostUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def id_exists(self, host_id: int) -> bool:
-        """Checks to see if a host ID exists.
+        """Validates if a host ID exists.
 
         :param host_id: Host ID
-        :return: True or False, based on whether the host ID exists
+        :return: ``True`` if the ID exists, otherwise ``False``
         """
         if not valid_int_id(host_id):
             return False
@@ -108,13 +108,11 @@ class HostUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def slug_exists(self, host_slug: str) -> bool:
-        """Checks to see if a host slug string exists.
+        """Validates if a host slug string exists.
 
         :param host_slug: Host slug string
-        :return: True or False, based on whether the host slug string
-            exists
+        :return: ``True`` if the slug string exists, otherwise ``False``
         """
         try:
             slug = host_slug.strip()

--- a/wwdtm/location/__init__.py
+++ b/wwdtm/location/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Location module"""
-from wwdtm.location.location import Location
-from wwdtm.location.recordings import LocationRecordings
-from wwdtm.location.utility import LocationUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Location module."""
+from .location import Location
+from .recordings import LocationRecordings
+from .utility import LocationUtility

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -1,32 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Location Recordings Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Location Recordings Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.location.utility import LocationUtility
 from wwdtm.validation import valid_int_id
 
 
 class LocationRecordings:
-    """This class contains functions that retrieve location recordings
-    information from a copy of the Wait Wait Stats database.
+    """Location recording information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve recording information, including
+    show flags.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -40,15 +42,15 @@ class LocationRecordings:
 
         self.utility = LocationUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_recordings_by_id(self, location_id: int) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing recording
-        information for the requested location ID.
+    def retrieve_recordings_by_id(self, location_id: int) -> dict[str, Any]:
+        """Retrieves location recording information.
+
+        Location recording information includes the corresponding show
+        dates and Best Of or Repeat show flags.
 
         :param location_id: Location ID
-        :return: Dictionary containing recording counts and a list of
-            appearances for a location. If location recordings could
-            not be retrieved, an empty dictionary is returned.
+        :return: A dictionary containing location recording counts,
+            dates and show flags
         """
         if not valid_int_id(location_id):
             return {}
@@ -111,15 +113,15 @@ class LocationRecordings:
                 "shows": [],
             }
 
-    @lru_cache(typed=True)
-    def retrieve_recordings_by_slug(self, location_slug: str) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing recording
-        information for the requested location slug string.
+    def retrieve_recordings_by_slug(self, location_slug: str) -> dict[str, Any]:
+        """Retrieves location recording information.
+
+        Location recording information includes the corresponding show
+        dates and Best Of or Repeat show flags.
 
         :param location_slug: Location slug string
-        :return: Dictionary containing recording counts and a list of
-            appearances for a location. If location recordings could
-            not be retrieved, an empty dictionary is returned.
+        :return: A dictionary containing location recording counts,
+            dates and show flags
         """
         id_ = self.utility.convert_slug_to_id(location_slug)
         if not id_:

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -1,33 +1,35 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Location Data Utility Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Location Data Utility Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 from slugify import slugify
+
 from wwdtm.validation import valid_int_id
 
 
 class LocationUtility:
-    """This class contains supporting functions used to check whether
-    a Location ID or slug string exists or to convert an ID to a slug
+    """Location information and utilities class.
+
+    This class contains supporting functions used to check whether
+    a location ID or slug string exists or to convert an ID to a slug
     string, or vice versa.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -39,13 +41,12 @@ class LocationUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_id_to_slug(self, location_id: int) -> Optional[str]:
-        """Converts a location's ID to the matching location slug
-        string value.
+    def convert_id_to_slug(self, location_id: int) -> str | None:
+        """Converts a location ID to the corresponding location slug string.
 
         :param location_id: Location ID
-        :return: Location slug string, if a match is found
+        :return: Location slug string if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         if not valid_int_id(location_id):
             return None
@@ -63,13 +64,12 @@ class LocationUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_slug_to_id(self, location_slug: str) -> Optional[int]:
-        """Converts a location's slug string to the matching location
-        ID value.
+    def convert_slug_to_id(self, location_slug: str) -> int | None:
+        """Converts a location slug string to the corresponding location ID.
 
         :param location_slug: Location slug string
-        :return: Location ID, if a match is found
+        :return: Location ID if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         try:
             slug = location_slug.strip()
@@ -91,12 +91,11 @@ class LocationUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def id_exists(self, location_id: int) -> bool:
-        """Checks to see if a location ID exists.
+        """Validates if a location ID exists.
 
         :param location_id: Location ID
-        :return: True or False, based on whether the location ID exists
+        :return: ``True`` if the ID exists, otherwise ``False``
         """
         if not valid_int_id(location_id):
             return False
@@ -111,13 +110,11 @@ class LocationUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def slug_exists(self, location_slug: str) -> bool:
-        """Checks to see if a location slug string exists.
+        """Validates if a location slug string exists.
 
         :param location_slug: Location slug string
-        :return: True or False, based on whether the location slug
-            string exists
+        :return: ``True`` if the slug string exists, otherwise ``False``
         """
         try:
             slug = location_slug.strip()
@@ -140,13 +137,12 @@ class LocationUtility:
 
     @staticmethod
     def slugify_location(
-        location_id: Optional[int] = None,
-        venue: Optional[str] = None,
-        city: Optional[str] = None,
-        state: Optional[str] = None,
+        location_id: int = None,
+        venue: str = None,
+        city: str = None,
+        state: str = None,
     ) -> str:
-        """Generates a slug string based on the location's venue name,
-        city, state and/or location ID.
+        """Generates a slug string using the location ID, venue, city and/or state.
 
         :param location_id: Location ID
         :param venue: Location venue name

--- a/wwdtm/panelist/__init__.py
+++ b/wwdtm/panelist/__init__.py
@@ -1,12 +1,12 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Panelist module"""
-from wwdtm.panelist.appearances import PanelistAppearances
-from wwdtm.panelist.panelist import Panelist
-from wwdtm.panelist.decimal_scores import PanelistDecimalScores
-from wwdtm.panelist.scores import PanelistScores
-from wwdtm.panelist.statistics import PanelistStatistics
-from wwdtm.panelist.utility import PanelistUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Panelist module."""
+from .appearances import PanelistAppearances
+from .decimal_scores import PanelistDecimalScores
+from .panelist import Panelist
+from .scores import PanelistScores
+from .statistics import PanelistStatistics
+from .utility import PanelistUtility

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -1,32 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Panelist Appearance Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Panelist Appearance Retrieval Functions."""
+from typing import Any
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.panelist.utility import PanelistUtility
 from wwdtm.validation import valid_int_id
 
 
 class PanelistAppearances:
-    """This class contains functions that retrieve panelist appearance
-    information from a copy of the Wait Wait Stats database.
+    """Panelist appearance information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve panelist appearance information
+    and statistics, scores and rankings.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -40,19 +42,16 @@ class PanelistAppearances:
 
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
     def retrieve_appearances_by_id(
         self, panelist_id: int, use_decimal_scores: bool = False
-    ) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested panelist ID.
+    ) -> dict[str, Any]:
+        """Retrieves panelist appearance information.
 
         :param panelist_id: Panelist ID
-        :param use_decimal_scores: Flag set to include panelist decimal
-            scores, if available
-        :return: Dictionary containing appearance counts and list of
-            appearances for a panelist. If panelist appearances could
-            not be retrieved, an empty dictionary is returned.
+        :param use_decimal_scores: A boolean to determine if decimal
+            scores returned instead of integer scores
+        :return: A dictionary containing appearance statistics, scoring
+            and ranking details
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -201,19 +200,16 @@ class PanelistAppearances:
 
         return appearance_info
 
-    @lru_cache(typed=True)
     def retrieve_appearances_by_slug(
         self, panelist_slug: str, use_decimal_scores: bool = False
-    ) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested panelist slug string.
+    ) -> dict[str, Any]:
+        """Retrieves panelist appearance information.
 
         :param panelist_slug: Panelist slug string
-        :param use_decimal_scores: Flag set to include panelist decimal
-            scores, if available
-        :return: Dictionary containing appearance counts and list of
-            appearances for a panelist. If panelist appearances could
-            not be retrieved, an empty dictionary is returned.
+        :param use_decimal_scores: A boolean to determine if decimal
+            scores returned instead of integer scores
+        :return: A dictionary containing appearance statistics, scoring
+            and ranking details
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -223,15 +219,12 @@ class PanelistAppearances:
             id_, use_decimal_scores=use_decimal_scores
         )
 
-    @lru_cache(typed=True)
-    def retrieve_yearly_appearances_by_id(self, panelist_id: int) -> Dict[int, int]:
-        """Returns a dictionary containing panelist appearances broken
-        down by year, for the requested panelist ID.
+    def retrieve_yearly_appearances_by_id(self, panelist_id: int) -> dict[int, int]:
+        """Retrieves panelist appearance counts grouped by year.
 
         :param panelist_id: Panelist ID
-        :return: Dictionary containing scoring breakdown by year. If
-            panelist appearances could not be retrieved, an empty
-            dictionary is returned.
+        :return: A dictionary containing years as keys and appearance
+            counts for each year as values
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -275,15 +268,12 @@ class PanelistAppearances:
 
         return years
 
-    @lru_cache(typed=True)
-    def retrieve_yearly_appearances_by_slug(self, panelist_slug: str) -> Dict[int, int]:
-        """Returns a dictionary containing panelist appearances broken
-        down by year, for the requested panelist slug string.
+    def retrieve_yearly_appearances_by_slug(self, panelist_slug: str) -> dict[int, int]:
+        """Retrieves panelist appearance counts grouped by year.
 
         :param panelist_slug: Panelist slug string
-        :return: Dictionary containing scoring breakdown by year. If
-            panelist appearances could not be retrieved, an empty
-            dictionary is returned.
+        :return: A dictionary containing years as keys and appearance
+            counts for each year as values
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -38,27 +38,6 @@ class PanelistAppearances:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
@@ -154,7 +133,7 @@ class PanelistAppearances:
                 "milestones": None,
             }
 
-        if use_decimal_scores and self.has_decimal_columns:
+        if use_decimal_scores:
             query = """
                 SELECT pm.showid AS show_id, s.showdate AS date,
                 s.bestof AS best_of, s.repeatshowid AS repeat_show_id,

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -1,35 +1,36 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Panelist Decimal Scores Retrieval
-Functions
-"""
-from functools import lru_cache
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Panelist Decimal Scores Retrieval Functions."""
 from decimal import Decimal
 from math import floor
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.panelist.utility import PanelistUtility
 from wwdtm.validation import valid_int_id
 
 
 class PanelistDecimalScores:
-    """This class contains functions used to retrieve panelist decimal
-    scores from a copy of the Wait Wait Stats database.
+    """Panelist decimal score retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve panelist decimal scores and
+    calculate scoring statistics.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -43,14 +44,11 @@ class PanelistDecimalScores:
 
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_scores_by_id(self, panelist_id: int) -> List[Decimal]:
-        """Returns a list of panelist decimal scores for appearances for
-        the requested panelist ID.
+    def retrieve_scores_by_id(self, panelist_id: int) -> list[Decimal]:
+        """Retrieves a list of panelist decimal scores, sorted by show date.
 
         :param panelist_id: Panelist ID
-        :return: List containing panelist decimal scores. If panelist
-            scores could not be retrieved, an empty list is returned.
+        :return: A list containing panelist decimal scores
         """
         if not valid_int_id(panelist_id):
             return []
@@ -78,14 +76,11 @@ class PanelistDecimalScores:
 
         return scores
 
-    @lru_cache(typed=True)
-    def retrieve_scores_by_slug(self, panelist_slug: str) -> List[Decimal]:
-        """Returns a list of panelist decimal scores for appearances for
-        the requested panelist slug string.
+    def retrieve_scores_by_slug(self, panelist_slug: str) -> list[Decimal]:
+        """Retrieves a list of panelist decimal scores, sorted by show date.
 
         :param panelist_slug: Panelist slug string
-        :return: List containing panelist decimal scores. If panelist
-            scores could not be retrieved, an empty list is returned.
+        :return: A list containing panelist decimal scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -93,18 +88,14 @@ class PanelistDecimalScores:
 
         return self.retrieve_scores_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_id(
         self, panelist_id: int
-    ) -> Dict[str, List[Union[str, int]]]:
-        """Returns a panelist's decimal score grouping for the requested
-        panelist ID.
+    ) -> dict[str, list[str | int]]:
+        """Retrieves panelist grouped decimal scores.
 
         :param panelist_id: Panelist ID
-        :return: Dictionary containing two lists, one containing decimal
-            scores and one containing counts of those scores. If
-            panelist scores could not be retrieved, an empty dictionary
-            is returned.
+        :return: A dictionary containing two lists, one containing
+            decimal scores and one containing counts of those scores
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -158,18 +149,14 @@ class PanelistDecimalScores:
             "count": list(scores.values()),
         }
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_slug(
         self, panelist_slug: str
-    ) -> Dict[str, List[int]]:
-        """Returns a panelist's score grouping for the requested
-        panelist slug string.
+    ) -> dict[str, list[int]]:
+        """Retrieves panelist grouped decimal scores.
 
         :param panelist_slug: Panelist slug string
-        :return: Dictionary containing two lists, one containing scores
-            and one containing counts of those scores. If panelist
-            scores could not be retrieved, an empty dictionary is
-            returned.
+        :return: A dictionary containing two lists, one containing
+            decimal scores and one containing counts of those scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -177,18 +164,14 @@ class PanelistDecimalScores:
 
         return self.retrieve_scores_grouped_list_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_id(
         self, panelist_id: int
-    ) -> List[Tuple[str, int]]:
-        """Returns a list of tuples containing a decimal score and the
-        corresponding number of instances a panelist has scored that
-        amount for the requested panelist ID.
+    ) -> list[tuple[str, int]]:
+        """Retrieves a list of panelist decimal scores and counts as a tuple.
 
         :param panelist_id: Panelist ID
-        :return: List of tuples containing decimal scores and score
-            counts. If panelist decimal scores could not be retrieved,
-            an empty list is returned.
+        :return: A list of tuples containing decimal scores and score
+            counts
         """
         if not valid_int_id(panelist_id):
             return []
@@ -238,19 +221,15 @@ class PanelistDecimalScores:
 
         return list(scores.items())
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_slug(
         self,
         panelist_slug: str,
-    ) -> List[Tuple[str, int]]:
-        """Returns a list of tuples containing a decimal score and the
-        corresponding number of instances a panelist has scored that amount
-        for the requested panelist slug string.
+    ) -> list[tuple[str, int]]:
+        """Retrieves a list of panelist decimal scores and counts as a tuple.
 
         :param panelist_slug: Panelist slug string
-        :return: List of tuples containing decimal scores and score
-            counts. If panelist decimal scores could not be retrieved,
-            an empty list is returned.
+        :return: A list of tuples containing decimal scores and score
+            counts
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -258,19 +237,15 @@ class PanelistDecimalScores:
 
         return self.retrieve_scores_grouped_ordered_pair_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_list_by_id(
         self,
         panelist_id: int,
-    ) -> Dict[str, List[Union[str, Decimal]]]:
-        """Returns a dictionary containing two lists, one with show
-        dates and one with corresponding decimal scores for the
-        requested panelist ID.
+    ) -> dict[str, list[str | Decimal]]:
+        """Retrieves panelist appearances and decimal scores as paired lists.
 
         :param panelist_id: Panelist ID
-        :return: Dictionary containing a list show dates and a list
-            of decimal scores. If panelist scores could not be
-            retrieved, an empty dictionary is returned.
+        :return: A dictionary containing a list show dates and a list
+            of decimal scores
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -303,19 +278,15 @@ class PanelistDecimalScores:
             "scores": score_list,
         }
 
-    @lru_cache(typed=True)
     def retrieve_scores_list_by_slug(
         self,
         panelist_slug: str,
-    ) -> Dict[str, List[Union[str, Decimal]]]:
-        """Returns a dictionary containing two lists, one with show
-        dates and one with corresponding decimal scores for the
-        requested panelist slug string.
+    ) -> dict[str, list[str | Decimal]]:
+        """Retrieves panelist appearances and decimal scores as paired lists.
 
         :param panelist_slug: Panelist slug string
-        :return: Dictionary containing a list show dates and a list
-            of decimal scores. If panelist scores could not be
-            retrieved, an empty dictionary is returned.
+        :return: A dictionary containing a list show dates and a list
+            of decimal scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -323,17 +294,14 @@ class PanelistDecimalScores:
 
         return self.retrieve_scores_list_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_id(
         self, panelist_id: int
-    ) -> List[Tuple[str, Decimal]]:
-        """Returns a list of tuples containing a show date and the
-        corresponding decimal score for the requested panelist ID.
+    ) -> list[tuple[str, Decimal]]:
+        """Retrieves panelist appearances and decimal scores as a list of tuples.
 
         :param panelist_id: Panelist ID
-        :return: List of tuples containing show dates and decimal
-            scores. If panelist scores could not be retrieved, an empty
-            list is returned.
+        :return: A list of tuples containing show dates and decimal
+            scores
         """
         if not valid_int_id(panelist_id):
             return []
@@ -363,19 +331,15 @@ class PanelistDecimalScores:
 
         return scores
 
-    @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_slug(
         self,
         panelist_slug: str,
-    ) -> List[Tuple[str, Decimal]]:
-        """Returns a list of tuples containing a show date and the
-        corresponding decimal score for the requested panelist slug
-        string.
+    ) -> list[tuple[str, Decimal]]:
+        """Retrieves panelist appearances and decimal scores as a list of tuples.
 
         :param panelist_slug: Panelist slug string
-        :return: List of tuples containing show dates and decimal
-            scores. If panelist scores could not be retrieved, an empty
-            list is returned.
+        :return: A list of tuples containing show dates and decimal
+            scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -42,19 +42,25 @@ class PanelistDecimalScores:
             self.database_connection = database_connection
 
         try:
+            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
+            cursor = self.database_connection.cursor()
+            cursor.execute(query)
+            start_decimal = cursor.fetchone()
+
             query = (
                 "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
             )
             cursor = self.database_connection.cursor()
             cursor.execute(query)
-            result = cursor.fetchone()
+            score_decimal = cursor.fetchone()
             cursor.close()
-            if result:
-                self.has_decimal_column: bool = True
+
+            if start_decimal and score_decimal:
+                self.has_decimal_columns: bool = True
             else:
-                self.has_decimal_column: bool = False
+                self.has_decimal_columns: bool = False
         except DatabaseError:
-            self.has_decimal_column: bool = False
+            self.has_decimal_columns: bool = False
 
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
@@ -67,19 +73,19 @@ class PanelistDecimalScores:
         :return: List containing panelist decimal scores. If panelist
             scores could not be retrieved, an empty list is returned.
         """
-        if not self.has_decimal_column or not valid_int_id(panelist_id):
+        if not self.has_decimal_columns or not valid_int_id(panelist_id):
             return []
 
         scores = []
         cursor = self.database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT pm.panelistscore_decimal AS score "
-            "FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "WHERE panelistid = %s "
-            "AND s.bestof = 0 and s.repeatshowid IS NULL "
-            "ORDER BY s.showdate ASC;"
-        )
+        query = """
+            SELECT pm.panelistscore_decimal AS score
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE panelistid = %s
+            AND s.bestof = 0 and s.repeatshowid IS NULL
+            ORDER BY s.showdate ASC;
+            """
         cursor.execute(query, (panelist_id,))
         result = cursor.fetchall()
         cursor.close()
@@ -121,16 +127,16 @@ class PanelistDecimalScores:
             panelist scores could not be retrieved, an empty dictionary
             is returned.
         """
-        if not self.has_decimal_column or not valid_int_id(panelist_id):
+        if not self.has_decimal_columns or not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT MIN(pm.panelistscore_decimal) AS min, "
-            "MAX(pm.panelistscore_decimal) AS max "
-            "FROM ww_showpnlmap pm "
-            "LIMIT 1;"
-        )
+        query = """
+            SELECT MIN(pm.panelistscore_decimal) AS min,
+            MAX(pm.panelistscore_decimal) AS max
+            FROM ww_showpnlmap pm
+            LIMIT 1;
+            """
         cursor.execute(query)
         result = cursor.fetchone()
 
@@ -147,17 +153,17 @@ class PanelistDecimalScores:
             scores[f"{score.normalize():f}"] = 0
             scores[f"{score_plus_half.normalize():f}"] = 0
 
-        query = (
-            "SELECT pm.panelistscore_decimal AS score, "
-            "COUNT(pm.panelistscore_decimal) AS score_count "
-            "FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "WHERE pm.panelistid = %s "
-            "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-            "AND pm.panelistscore_decimal IS NOT NULL "
-            "GROUP BY pm.panelistscore_decimal "
-            "ORDER BY pm.panelistscore_decimal ASC;"
-        )
+        query = """
+            SELECT pm.panelistscore_decimal AS score,
+            COUNT(pm.panelistscore_decimal) AS score_count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            GROUP BY pm.panelistscore_decimal
+            ORDER BY pm.panelistscore_decimal ASC;
+            """
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -205,15 +211,15 @@ class PanelistDecimalScores:
             counts. If panelist decimal scores could not be retrieved,
             an empty list is returned.
         """
-        if not self.has_decimal_column or not valid_int_id(panelist_id):
+        if not self.has_decimal_columns or not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT MIN(pm.panelistscore_decimal) AS min, "
-            "MAX(pm.panelistscore_decimal) AS max "
-            "FROM ww_showpnlmap pm;"
-        )
+        query = """
+            SELECT MIN(pm.panelistscore_decimal) AS min,
+            MAX(pm.panelistscore_decimal) AS max
+            FROM ww_showpnlmap pm;
+            """
         cursor.execute(query)
         result = cursor.fetchone()
 
@@ -230,17 +236,17 @@ class PanelistDecimalScores:
             scores[f"{score.normalize():f}"] = 0
             scores[f"{score_plus_half.normalize():f}"] = 0
 
-        query = (
-            "SELECT pm.panelistscore_decimal AS score, "
-            "COUNT(pm.panelistscore_decimal) AS score_count "
-            "FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "WHERE pm.panelistid = %s "
-            "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-            "AND pm.panelistscore_decimal IS NOT NULL "
-            "GROUP BY pm.panelistscore_decimal "
-            "ORDER BY pm.panelistscore_decimal ASC;"
-        )
+        query = """
+            SELECT pm.panelistscore_decimal AS score,
+            COUNT(pm.panelistscore_decimal) AS score_count
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            GROUP BY pm.panelistscore_decimal
+            ORDER BY pm.panelistscore_decimal ASC;
+            """
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -287,19 +293,19 @@ class PanelistDecimalScores:
             of decimal scores. If panelist scores could not be
             retrieved, an empty dictionary is returned.
         """
-        if not self.has_decimal_column or not valid_int_id(panelist_id):
+        if not self.has_decimal_columns or not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT s.showdate AS date, pm.panelistscore_decimal AS score "
-            "FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "WHERE pm.panelistid = %s "
-            "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-            "AND pm.panelistscore_decimal IS NOT NULL "
-            "ORDER BY s.showdate ASC;"
-        )
+        query = """
+            SELECT s.showdate AS date, pm.panelistscore_decimal AS score
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            ORDER BY s.showdate ASC;
+            """
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -350,19 +356,19 @@ class PanelistDecimalScores:
             scores. If panelist scores could not be retrieved, an empty
             list is returned.
         """
-        if not self.has_decimal_column or not valid_int_id(panelist_id):
+        if not self.has_decimal_columns or not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)
-        query = (
-            "SELECT s.showdate AS date, pm.panelistscore_decimal AS score "
-            "FROM ww_showpnlmap pm "
-            "JOIN ww_shows s ON s.showid = pm.showid "
-            "WHERE pm.panelistid = %s "
-            "AND s.bestof = 0 AND s.repeatshowid IS NULL "
-            "AND pm.panelistscore_decimal IS NOT NULL "
-            "ORDER BY s.showdate ASC;"
-        )
+        query = """
+            SELECT s.showdate AS date, pm.panelistscore_decimal AS score
+            FROM ww_showpnlmap pm
+            JOIN ww_shows s ON s.showid = pm.showid
+            WHERE pm.panelistid = %s
+            AND s.bestof = 0 AND s.repeatshowid IS NULL
+            AND pm.panelistscore_decimal IS NOT NULL
+            ORDER BY s.showdate ASC;
+            """
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -41,27 +41,6 @@ class PanelistDecimalScores:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
     @lru_cache(typed=True)
@@ -73,7 +52,7 @@ class PanelistDecimalScores:
         :return: List containing panelist decimal scores. If panelist
             scores could not be retrieved, an empty list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         scores = []
@@ -127,7 +106,7 @@ class PanelistDecimalScores:
             panelist scores could not be retrieved, an empty dictionary
             is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -211,7 +190,7 @@ class PanelistDecimalScores:
             counts. If panelist decimal scores could not be retrieved,
             an empty list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -293,7 +272,7 @@ class PanelistDecimalScores:
             of decimal scores. If panelist scores could not be
             retrieved, an empty dictionary is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return {}
 
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -356,7 +335,7 @@ class PanelistDecimalScores:
             scores. If panelist scores could not be retrieved, an empty
             list is returned.
         """
-        if not self.has_decimal_columns or not valid_int_id(panelist_id):
+        if not valid_int_id(panelist_id):
             return []
 
         cursor = self.database_connection.cursor(named_tuple=True)

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -8,7 +8,7 @@
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from slugify import slugify
 from wwdtm.panelist.appearances import PanelistAppearances
 from wwdtm.panelist.statistics import PanelistStatistics

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -41,27 +41,6 @@ class Panelist:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.appearances = PanelistAppearances(
             database_connection=self.database_connection
         )
@@ -118,9 +97,6 @@ class Panelist:
             information and appearances. If panelists could not be
             retrieved, an empty list is returned.
         """
-        if use_decimal_scores and not self.has_decimal_columns:
-            return []
-
         query = """
             SELECT panelistid AS id, panelist AS name, panelistslug AS slug,
             panelistgender AS gender
@@ -273,9 +249,6 @@ class Panelist:
             an empty dictionary is returned.
         """
         if not valid_int_id(panelist_id):
-            return {}
-
-        if use_decimal_scores and not self.has_decimal_columns:
             return {}
 
         info = self.retrieve_by_id(panelist_id)

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -42,19 +42,25 @@ class Panelist:
             self.database_connection = database_connection
 
         try:
+            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
+            cursor = self.database_connection.cursor()
+            cursor.execute(query)
+            start_decimal = cursor.fetchone()
+
             query = (
                 "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
             )
             cursor = self.database_connection.cursor()
             cursor.execute(query)
-            result = cursor.fetchone()
+            score_decimal = cursor.fetchone()
             cursor.close()
-            if result:
-                self.has_decimal_column: bool = True
+
+            if start_decimal and score_decimal:
+                self.has_decimal_columns: bool = True
             else:
-                self.has_decimal_column: bool = False
+                self.has_decimal_columns: bool = False
         except DatabaseError:
-            self.has_decimal_column: bool = False
+            self.has_decimal_columns: bool = False
 
         self.appearances = PanelistAppearances(
             database_connection=self.database_connection
@@ -112,7 +118,7 @@ class Panelist:
             information and appearances. If panelists could not be
             retrieved, an empty list is returned.
         """
-        if use_decimal_scores and not self.has_decimal_column:
+        if use_decimal_scores and not self.has_decimal_columns:
             return []
 
         query = """
@@ -269,7 +275,7 @@ class Panelist:
         if not valid_int_id(panelist_id):
             return {}
 
-        if use_decimal_scores and not self.has_decimal_column:
+        if use_decimal_scores and not self.has_decimal_columns:
             return {}
 
         info = self.retrieve_by_id(panelist_id)

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -1,32 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Panelist Scores Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, List, Optional, Tuple
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Panelist Scores Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.panelist.utility import PanelistUtility
 from wwdtm.validation import valid_int_id
 
 
 class PanelistScores:
-    """This class contains functions used to retrieve panelist scores
-    from a copy of the Wait Wait Stats database.
+    """Panelist score retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve panelist scores and calculate
+    scoring statistics.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -40,14 +42,11 @@ class PanelistScores:
 
         self.utility = PanelistUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_scores_by_id(self, panelist_id: int) -> List[int]:
-        """Returns a list of panelist scores for appearances for the
-        requested panelist ID.
+    def retrieve_scores_by_id(self, panelist_id: int) -> list[int]:
+        """Retrieves a list of panelist scores, sorted by show date.
 
         :param panelist_id: Panelist ID
-        :return: List containing panelist scores. If panelist scores
-            could not be retrieved, an empty list is returned.
+        :return: A list containing panelist decimal scores
         """
         if not valid_int_id(panelist_id):
             return []
@@ -75,14 +74,11 @@ class PanelistScores:
 
         return scores
 
-    @lru_cache(typed=True)
-    def retrieve_scores_by_slug(self, panelist_slug: str) -> List[int]:
-        """Returns a list of panelist scores for appearances for the
-        requested panelist slug string.
+    def retrieve_scores_by_slug(self, panelist_slug: str) -> list[int]:
+        """Retrieves a list of panelist scores, sorted by show date.
 
         :param panelist_slug: Panelist slug string
-        :return: List containing panelist scores. If panelist scores
-            could not be retrieved, an empty list is returned.
+        :return: A list containing panelist scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -90,18 +86,14 @@ class PanelistScores:
 
         return self.retrieve_scores_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_id(
         self, panelist_id: int
-    ) -> Dict[str, List[int]]:
-        """Returns a panelist's score grouping for the requested
-        panelist ID.
+    ) -> dict[str, list[int]]:
+        """Retrieves panelist grouped scores.
 
         :param panelist_id: Panelist ID
-        :return: Dictionary containing two lists, one containing scores
-            and one containing counts of those scores. If panelist
-            scores could not be retrieved, an empty dictionary is
-            returned.
+        :return: A dictionary containing two lists, one containing
+            scores and one containing counts of those scores
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -152,18 +144,14 @@ class PanelistScores:
             "count": list(scores.values()),
         }
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_list_by_slug(
         self, panelist_slug: str
-    ) -> Dict[str, List[int]]:
-        """Returns a panelist's score grouping for the requested
-        panelist slug string.
+    ) -> dict[str, list[int]]:
+        """Retrieves panelist grouped scores.
 
         :param panelist_slug: Panelist slug string
-        :return: Dictionary containing two lists, one containing scores
-            and one containing counts of those scores. If panelist
-            scores could not be retrieved, an empty dictionary is
-            returned.
+        :return: A dictionary containing two lists, one containing
+            scores and one containing counts of those scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -171,18 +159,13 @@ class PanelistScores:
 
         return self.retrieve_scores_grouped_list_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_id(
         self, panelist_id: int
-    ) -> List[Tuple[int, int]]:
-        """Returns a list of tuples containing a score and the
-        corresponding number of instances a panelist has scored that amount
-        for the requested panelist ID.
+    ) -> list[tuple[int, int]]:
+        """Retrieves a list of panelist scores and counts as a tuple.
 
         :param panelist_id: Panelist ID
-        :return: List of tuples containing scores and score counts. If
-            panelist scores could not be retrieved, an empty list is
-            returned.
+        :return: A list of tuples containing scores and score counts
         """
         if not valid_int_id(panelist_id):
             return []
@@ -229,19 +212,14 @@ class PanelistScores:
 
         return list(scores.items())
 
-    @lru_cache(typed=True)
     def retrieve_scores_grouped_ordered_pair_by_slug(
         self,
         panelist_slug: str,
-    ) -> List[Tuple[int, int]]:
-        """Returns a list of tuples containing a score and the
-        corresponding number of instances a panelist has scored that amount
-        for the requested panelist slug string.
+    ) -> list[tuple[int, int]]:
+        """Retrieves a list of panelist scores and counts as a tuple.
 
         :param panelist_slug: Panelist slug string
-        :return: List of tuples containing scores and score counts. If
-            panelist scores could not be retrieved, an empty list is
-            returned.
+        :return: A list of tuples containing scores and score counts
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -249,19 +227,15 @@ class PanelistScores:
 
         return self.retrieve_scores_grouped_ordered_pair_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_list_by_id(
         self,
         panelist_id: int,
-    ) -> Dict[str, List]:
-        """Returns a dictionary containing two lists, one with show
-        dates and one with corresponding scores for the requested
-        panelist ID.
+    ) -> dict[str, list]:
+        """Retrieves panelist appearances and scores as paired lists.
 
         :param panelist_id: Panelist ID
-        :return: Dictionary containing a list show dates and a list
-            of scores. If panelist scores could not be retrieved, an
-            empty dictionary is returned.
+        :return: A dictionary containing a list show dates and a list
+            of scores
         """
         if not valid_int_id(panelist_id):
             return {}
@@ -294,19 +268,15 @@ class PanelistScores:
             "scores": score_list,
         }
 
-    @lru_cache(typed=True)
     def retrieve_scores_list_by_slug(
         self,
         panelist_slug: str,
-    ) -> Dict[str, List]:
-        """Returns a dictionary containing two lists, one with show
-        dates and one with corresponding scores for the requested
-        panelist slug string.
+    ) -> dict[str, list]:
+        """Retrieves panelist appearances and scores as paired lists.
 
         :param panelist_slug: Panelist slug string
-        :return: Dictionary containing a list show dates and a list
-            of scores. If panelist scores could not be retrieved, an
-            empty dictionary is returned.
+        :return: A dictionary containing a list show dates and a list
+            of scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:
@@ -314,17 +284,13 @@ class PanelistScores:
 
         return self.retrieve_scores_list_by_id(id_)
 
-    @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_id(
         self, panelist_id: int
-    ) -> List[Tuple[str, int]]:
-        """Returns a list of tuples containing a show date and the
-        corresponding score for the requested panelist ID.
+    ) -> list[tuple[str, int]]:
+        """Retrieves panelist appearances and scores as a list of tuples.
 
         :param panelist_id: Panelist ID
-        :return: List of tuples containing show dates and scores. If
-            panelist scores could not be retrieved, an empty list is
-            returned.
+        :return: A list of tuples containing show dates and scores
         """
         if not valid_int_id(panelist_id):
             return []
@@ -354,18 +320,14 @@ class PanelistScores:
 
         return scores
 
-    @lru_cache(typed=True)
     def retrieve_scores_ordered_pair_by_slug(
         self,
         panelist_slug: str,
-    ) -> List[Tuple[str, int]]:
-        """Returns a list of tuples containing a show date and the
-        corresponding score for the requested panelist slug string.
+    ) -> list[tuple[str, int]]:
+        """Retrieves panelist appearances and scores as a list of tuples.
 
         :param panelist_slug: Panelist slug string
-        :return: List of tuples containing show dates and scores. If
-            panelist scores could not be retrieved, an empty list is
-            returned.
+        :return: A list of tuples containing show dates and scores
         """
         id_ = self.utility.convert_slug_to_id(panelist_slug)
         if not id_:

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -9,7 +9,7 @@ from decimal import Decimal
 from functools import lru_cache
 from typing import Any, Dict, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 import numpy
 from wwdtm.panelist.scores import PanelistScores
 from wwdtm.panelist.decimal_scores import PanelistDecimalScores

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -43,27 +43,6 @@ class PanelistStatistics:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.has_decimal_columns: bool = True
-            else:
-                self.has_decimal_columns: bool = False
-        except DatabaseError:
-            self.has_decimal_columns: bool = False
-
         self.scores = PanelistScores(database_connection=self.database_connection)
         self.scores_decimal = PanelistDecimalScores(
             database_connection=self.database_connection
@@ -227,7 +206,7 @@ class PanelistStatistics:
         if not score_data or not ranks:
             return {}
 
-        if self.has_decimal_columns and include_decimal_scores:
+        if include_decimal_scores:
             score_data_decimal = self.scores_decimal.retrieve_scores_by_id(panelist_id)
             if not score_data_decimal:
                 return {}
@@ -271,15 +250,15 @@ class PanelistStatistics:
             "percentage": ranks_percentage,
         }
 
-        if not include_decimal_scores:
+        if include_decimal_scores:
             return {
                 "scoring": scoring,
+                "scoring_decimal": scoring_decimal,
                 "ranking": ranking,
             }
         else:
             return {
                 "scoring": scoring,
-                "scoring_decimal": scoring_decimal,
                 "ranking": ranking,
             }
 

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -44,19 +44,25 @@ class PanelistStatistics:
             self.database_connection = database_connection
 
         try:
+            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
+            cursor = self.database_connection.cursor()
+            cursor.execute(query)
+            start_decimal = cursor.fetchone()
+
             query = (
                 "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
             )
             cursor = self.database_connection.cursor()
             cursor.execute(query)
-            result = cursor.fetchone()
+            score_decimal = cursor.fetchone()
             cursor.close()
-            if result:
-                self.has_decimal_column: bool = True
+
+            if start_decimal and score_decimal:
+                self.has_decimal_columns: bool = True
             else:
-                self.has_decimal_column: bool = False
+                self.has_decimal_columns: bool = False
         except DatabaseError:
-            self.has_decimal_column: bool = False
+            self.has_decimal_columns: bool = False
 
         self.scores = PanelistScores(database_connection=self.database_connection)
         self.scores_decimal = PanelistDecimalScores(
@@ -221,7 +227,7 @@ class PanelistStatistics:
         if not score_data or not ranks:
             return {}
 
-        if self.has_decimal_column and include_decimal_scores:
+        if self.has_decimal_columns and include_decimal_scores:
             score_data_decimal = self.scores_decimal.retrieve_scores_by_id(panelist_id)
             if not score_data_decimal:
                 return {}

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -1,32 +1,33 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Panelist Data Utility Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Panelist Data Utility Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.validation import valid_int_id
 
 
 class PanelistUtility:
-    """This class contains supporting functions used to check whether
-    a panelist ID or slug string exists or to convert an ID to a slug
-    string, or vice versa.
+    """Panelist information and utilities class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to convert between panelist ID and slug
+    strings, and to check if panelist IDs and slug strings exist.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -38,13 +39,12 @@ class PanelistUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_id_to_slug(self, panelist_id: int) -> Optional[str]:
-        """Converts a panelist's ID to the matching panelist slug
-        string value.
+    def convert_id_to_slug(self, panelist_id: int) -> str | None:
+        """Converts a panelist ID to the corresponding panelist slug string.
 
         :param panelist_id: Panelist ID
-        :return: Panelist slug string, if a match is found
+        :return: Panelist slug string if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         if not valid_int_id(panelist_id):
             return None
@@ -62,13 +62,12 @@ class PanelistUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_slug_to_id(self, panelist_slug: str) -> Optional[int]:
-        """Converts a panelist's slug string to the matching panelist ID
-        value.
+    def convert_slug_to_id(self, panelist_slug: str) -> int | None:
+        """Converts a panelist slug string to the corresponding panelist ID.
 
         :param panelist_slug: Panelist slug string
-        :return: Panelists ID, if a match is found
+        :return: Panelist ID if a corresponding value is found.
+            Otherwise, ``None`` is returned
         """
         try:
             slug = panelist_slug.strip()
@@ -90,12 +89,11 @@ class PanelistUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def id_exists(self, panelist_id: int) -> bool:
-        """Checks to see if a panelist ID exists.
+        """Validates if a panelist ID exists.
 
         :param panelist_id: Panelist ID
-        :return: True or False, based on whether the panelist ID exists
+        :return: ``True`` if the ID exists, otherwise ``False``
         """
         if not valid_int_id(panelist_id):
             return False
@@ -110,13 +108,11 @@ class PanelistUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def slug_exists(self, panelist_slug: str) -> bool:
-        """Checks to see if a panelist slug string exists.
+        """Validates if a panelist slug string exists.
 
         :param panelist_slug: Panelist slug string
-        :return: True or False, based on whether the panelist slug
-            string exists
+        :return: ``True`` if the slug string exists, otherwise ``False``
         """
         try:
             slug = panelist_slug.strip()

--- a/wwdtm/scorekeeper/__init__.py
+++ b/wwdtm/scorekeeper/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Scorekeeper module"""
-from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
-from wwdtm.scorekeeper.scorekeeper import Scorekeeper
-from wwdtm.scorekeeper.utility import ScorekeeperUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Scorekeeper module."""
+from .appearances import ScorekeeperAppearances
+from .scorekeeper import Scorekeeper
+from .utility import ScorekeeperUtility

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Scorekeeper Appearance Retrieval
-Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Scorekeeper Appearance Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
 from wwdtm.validation import valid_int_id
 
 
 class ScorekeeperAppearances:
-    """This class contains functions that retrieve scorekeeper
-    appearance information from a copy of the Wait Wait Stats database.
+    """Scorekeeper appearance information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve scorekeeper appearance
+    information, including show flags.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -41,16 +42,12 @@ class ScorekeeperAppearances:
 
         self.utility = ScorekeeperUtility(database_connection=self.database_connection)
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested scorekeeper ID.
+    def retrieve_appearances_by_id(self, scorekeeper_id: int) -> dict[str, Any]:
+        """Retrieves scorekeeper appearance information.
 
         :param scorekeeper_id: Scorekeeper ID
-        :return: Dictionary containing appearance counts and list of
-            appearances for a scorekeeper. If scorekeeper appearances
-            could not be retrieved, an empty dictionary would be
-            returned.
+        :return: A dictionary containing scorekeeper appearances with
+            corresponding show dates and Best Of or Repeat show flags
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -124,16 +121,12 @@ class ScorekeeperAppearances:
                 "shows": [],
             }
 
-    @lru_cache(typed=True)
-    def retrieve_appearances_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
-        """Returns a list of dictionary objects containing appearance
-        information for the requested scorekeeper ID.
+    def retrieve_appearances_by_slug(self, scorekeeper_slug: str) -> dict[str, Any]:
+        """Retrieves scorekeeper appearance information.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :return: Dictionary containing appearance counts and list of
-            appearances for a scorekeeper. If scorekeeper appearances
-            could not be retrieved, an empty dictionary would be
-            returned.
+        :return: A dictionary containing scorekeeper appearances with
+            corresponding show dates and Best Of or Repeat show flags
         """
         id_ = self.utility.convert_slug_to_id(scorekeeper_slug)
         if not id_:

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -1,34 +1,36 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Scorekeeper Data Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, List, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Scorekeeper Data Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 from slugify import slugify
+
 from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
 from wwdtm.scorekeeper.utility import ScorekeeperUtility
 from wwdtm.validation import valid_int_id
 
 
 class Scorekeeper:
-    """This class contains functions used to retrieve scorekeeper data
-    from a copy of the Wait Wait Stats database.
+    """Scorekeeper information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve scorekeeper information, including
+    IDs, names, slug strings and appearances.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -45,13 +47,11 @@ class Scorekeeper:
         )
         self.utility = ScorekeeperUtility(database_connection=self.database_connection)
 
-    def retrieve_all(self) -> List[Dict[str, Any]]:
-        """Returns a list of dictionary objects containing scorekeeper
-        ID, name and slug string for all scorekeepers.
+    def retrieve_all(self) -> list[dict[str, Any]]:
+        """Retrieves scorekeeper information for all scorekeepers.
 
-        :return: List of all scorekeepers and their corresponding
-            information. If scorekeeper information could not be
-            retrieved, an empty list will be returned.
+        :return: A list of dictionaries containing scorekeeper ID, name,
+            gender and slug string for each scorekeeper
         """
         query = """
             SELECT scorekeeperid AS id, scorekeeper AS name,
@@ -80,14 +80,12 @@ class Scorekeeper:
 
         return scorekeepers
 
-    def retrieve_all_details(self) -> List[Dict[str, Any]]:
-        """Returns a list of dictionary objects containing scorekeeper
-        ID, name, slug string and appearance information for all
-        scorekeepers.
+    def retrieve_all_details(self) -> list[dict[str, Any]]:
+        """Retrieves scorekeeper information and appearances for all scorekeepers.
 
-        :return: List of all scorekeepers and their corresponding
-            information and appearances. If scorekeeper information
-            could not be retrieved, an empty list will be returned.
+        :return: A list of dictionaries containing scorekeeper ID, name,
+            slug string, gender and a list of appearances with show
+            flags for each scorekeeper
         """
         query = """
             SELECT scorekeeperid AS id, scorekeeper AS name,
@@ -117,12 +115,10 @@ class Scorekeeper:
 
         return scorekeepers
 
-    def retrieve_all_ids(self) -> List[int]:
-        """Returns a list of all scorekeeper IDs from the database,
-        sorted by scorekeeper name.
+    def retrieve_all_ids(self) -> list[int]:
+        """Retrieves all scorekeeper IDs, sorted by scorekeeper name.
 
-        :return: List of all scorekeeper IDs. If scorekeeper IDs could
-            not be retrieved, an empty list would be returned.
+        :return: A list of scorekeeper IDs as integers
         """
         query = """
             SELECT scorekeeperid FROM ww_scorekeepers ORDER BY scorekeeper ASC;
@@ -137,13 +133,10 @@ class Scorekeeper:
 
         return [v[0] for v in results]
 
-    def retrieve_all_slugs(self) -> List[str]:
-        """Returns a list of all scorekeeper slug strings from the
-        database, sorted by scorekeeper name.
+    def retrieve_all_slugs(self) -> list[str]:
+        """Retrieves all scorekeeper slug strings, sorted by scorekeeper name.
 
-        :return: List of all scorekeeper slug strings. If scorekeeper
-            slug strings could not be retrieved, an empty list will be
-            returned.
+        :return: A list of scorekeeper slug strings
         """
         query = """
             SELECT scorekeeperslug FROM ww_scorekeepers ORDER BY scorekeeper ASC;
@@ -158,15 +151,12 @@ class Scorekeeper:
 
         return [v[0] for v in results]
 
-    @lru_cache(typed=True)
-    def retrieve_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
-        """Returns a dictionary object containing scorekeeper ID, name
-        and slug string for the requested scorekeeper ID.
+    def retrieve_by_id(self, scorekeeper_id: int) -> dict[str, Any]:
+        """Retrieves scorekeeper information.
 
         :param scorekeeper_id: Scorekeeper ID
-        :return: Dictionary containing scorekeeper information. If
-            scorekeeper information could not be retrieved, an empty
-            dictionary will be returned.
+        :return: A dictionary containing host ID, name, slug string and
+            gender
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -193,15 +183,12 @@ class Scorekeeper:
             "gender": result.gender,
         }
 
-    @lru_cache(typed=True)
-    def retrieve_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
-        """Returns a dictionary object containing scorekeeper ID, name
-        and slug string for the requested scorekeeper slug string.
+    def retrieve_by_slug(self, scorekeeper_slug: str) -> dict[str, Any]:
+        """Retrieves scorekeeper information.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :return: Dictionary containing scorekeeper information. If
-            scorekeeper information could not be retrieved, an empty
-            dictionary will be returned.
+        :return: A dictionary containing host ID, name, slug string and
+            gender
         """
         try:
             slug = scorekeeper_slug.strip()
@@ -216,16 +203,12 @@ class Scorekeeper:
 
         return self.retrieve_by_id(id_)
 
-    @lru_cache(typed=True)
-    def retrieve_details_by_id(self, scorekeeper_id: int) -> Dict[str, Any]:
-        """Returns a dictionary object containing scorekeeper ID, name,
-        slug string and appearance information for the requested
-        scorekeeper ID.
+    def retrieve_details_by_id(self, scorekeeper_id: int) -> dict[str, Any]:
+        """Retrieves scorekeeper information and appearances.
 
         :param scorekeeper_id: Scorekeeper ID
-        :return: Dictionary containing scorekeeper information and
-            their appearances. If scorekeeper information could not be
-            retrieved, an empty dictionary will be returned.
+        :return: A dictionaries containing scorekeeper ID, name, slug
+            string, gender and a list of appearances with show flags
         """
         if not valid_int_id(scorekeeper_id):
             return {}
@@ -240,16 +223,12 @@ class Scorekeeper:
 
         return info
 
-    @lru_cache(typed=True)
-    def retrieve_details_by_slug(self, scorekeeper_slug: str) -> Dict[str, Any]:
-        """Returns a dictionary object containing scorekeeper ID, name,
-        slug string and appearance information for the requested
-        scorekeeper slug string.
+    def retrieve_details_by_slug(self, scorekeeper_slug: str) -> dict[str, Any]:
+        """Retrieves scorekeeper information and appearances.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :return: Dictionary containing scorekeeper information and
-            their appearances. If scorekeeper information could not be
-            retrieved, an empty dictionary will be returned.
+        :return: A dictionaries containing scorekeeper ID, name, slug
+            string, gender and a list of appearances with show flags
         """
         try:
             slug = scorekeeper_slug.strip()

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -1,32 +1,33 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Scorekeeper Data Utility Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Scorekeeper Data Utility Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.validation import valid_int_id
 
 
 class ScorekeeperUtility:
-    """This class contains supporting functions used to check whether
-    a scorekeeper ID or slug string exists or to convert an ID to a slug
-    string, or vice versa.
+    """Scorekeeper information and utilities class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to convert between scorekeeper ID and slug
+    strings, and to check if scorekeeper IDs and slug strings exist.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -38,13 +39,12 @@ class ScorekeeperUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_id_to_slug(self, scorekeeper_id: int) -> Optional[str]:
-        """Converts a scorekeeper's ID to the matching scorekeeper slug
-        string value.
+    def convert_id_to_slug(self, scorekeeper_id: int) -> str | None:
+        """Converts a scorekeeper ID to the corresponding scorekeeper slug string.
 
         :param scorekeeper_id: Scorekeeper ID
-        :return: Scorekeeper slug string, if a match is found
+        :return: Scorekeeper slug string if a corresponding value is
+            found. Otherwise, ``None`` is returned
         """
         if not valid_int_id(scorekeeper_id):
             return None
@@ -64,13 +64,12 @@ class ScorekeeperUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_slug_to_id(self, scorekeeper_slug: str) -> Optional[int]:
-        """Converts a scorekeeper's slug string to the matching
-        scorekeeper ID value.
+    def convert_slug_to_id(self, scorekeeper_slug: str) -> int | None:
+        """Converts a scorekeeper slug string to the corresponding scorekeeper ID.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :return: Scorekeeper ID, if a match is found
+        :return: Scorekeeper ID as an integer if a corresponding value
+            is found. Otherwise, ``None`` is returned
         """
         try:
             slug = scorekeeper_slug.strip()
@@ -94,13 +93,11 @@ class ScorekeeperUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def id_exists(self, scorekeeper_id: int) -> bool:
-        """Checks to see if a scorekeeper ID exists.
+        """Validates if a scorekeeper ID exists.
 
         :param scorekeeper_id: Scorekeeper ID
-        :return: True or False, based on whether the scorekeeper ID
-            exists
+        :return: ``True`` if the ID exists, otherwise ``False``
         """
         if not valid_int_id(scorekeeper_id):
             return False
@@ -117,13 +114,11 @@ class ScorekeeperUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def slug_exists(self, scorekeeper_slug: str) -> bool:
-        """Checks to see if a scorekeeper slug string exists.
+        """Validates if a scorekeeper slug string exists.
 
         :param scorekeeper_slug: Scorekeeper slug string
-        :return: True or False, based on whether the scorekeeper slug
-            string exists
+        :return: ``True`` if the slug string exists, otherwise ``False``
         """
         try:
             slug = scorekeeper_slug.strip()

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -1,10 +1,10 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Stats: Show module"""
-from wwdtm.show.info import ShowInfo
-from wwdtm.show.info_multiple import ShowInfoMultiple
-from wwdtm.show.show import Show
-from wwdtm.show.utility import ShowUtility
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Show module."""
+from .info import ShowInfo
+from .info_multiple import ShowInfoMultiple
+from .show import Show
+from .utility import ShowUtility

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -42,27 +42,6 @@ class ShowInfo:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.panelist_decimal_columns: bool = True
-            else:
-                self.panelist_decimal_columns: bool = False
-        except DatabaseError:
-            self.panelist_decimal_columns: bool = False
-
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
 
@@ -307,7 +286,7 @@ class ShowInfo:
         if not valid_int_id(show_id):
             return []
 
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT pm.panelistid AS id, p.panelist AS name,
                 p.panelistslug AS slug,

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -90,7 +90,8 @@ class ShowInfo:
             SELECT segment, chosenbluffpnlid AS chosen_id,
             correctbluffpnlid AS correct_id
             FROM ww_showbluffmap
-            WHERE showid = %s;
+            WHERE showid = %s
+            ORDER BY segment ASC;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query, (show_id,))

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -1,36 +1,36 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Supplemental Show Information
-Retrieval Functions
-"""
-from functools import lru_cache
-from typing import Any, Dict, List, Optional
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Show Detailed Information Retrieval Functions."""
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 from slugify import slugify
-from wwdtm.show.utility import ShowUtility
+
 from wwdtm.location.location import LocationUtility
+from wwdtm.show.utility import ShowUtility
 from wwdtm.validation import valid_int_id
 
 
 class ShowInfo:
-    """This class contains functions that retrieve show supplemental
-    show information, including panelist, guest and Bluff the Listener
-    information from a copy of the Wait Wait Stats database.
+    """Show information retrieval class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods used to retrieve panelist, guest and Bluff the
+    Listener information.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -46,7 +46,7 @@ class ShowInfo:
         self.loc_util = LocationUtility(database_connection=self.database_connection)
         self.panelists = self._retrieve_panelists()
 
-    def _retrieve_panelists(self) -> Dict[int, Dict[str, str]]:
+    def _retrieve_panelists(self) -> dict[int, dict[str, str]]:
         """Returns a dictionary of panelist information.
 
         :return: Dictionary containing panelist ID as the key and
@@ -74,14 +74,13 @@ class ShowInfo:
 
         return panelists
 
-    @lru_cache(typed=True)
-    def retrieve_bluff_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:
-        """Returns a list of Bluff the Listener information for the
-        requested show ID.
+    def retrieve_bluff_info_by_id(self, show_id: int) -> list[dict[str, Any]]:
+        """Retrieves Bluff the Listener information.
 
         :param show_id: Show ID
-        :return: List containing each of the correct and chosen Bluff
-            the Listener information.
+        :return: A dictionary containing Bluff the Listener segment ID
+            and information about the chosen Bluff panelist and correct
+            Bluff panelist.
         """
         if not valid_int_id(show_id):
             return {}
@@ -161,14 +160,12 @@ class ShowInfo:
 
         return bluffs
 
-    def retrieve_core_info_by_id(self, show_id: int) -> Dict[str, Any]:
-        """Returns a dictionary with core information for the requested
-        show ID.
+    def retrieve_core_info_by_id(self, show_id: int) -> dict[str, Any]:
+        """Retrieves core information.
 
-        :param show_ids: List of show IDs
-        :return: Dictionary containing host, scorekeeper, location,
-            description and notes. If show core information could not be
-            retrieved, an empty dictionary will be returned.
+        :param show_id: Show ID
+        :return: A dictionary containing host, scorekeeper, location,
+            description and notes
         """
         if not valid_int_id(show_id):
             return {}
@@ -245,10 +242,7 @@ class ShowInfo:
         else:
             description = None
 
-        if result.show_notes:
-            notes = str(result.show_notes).strip()
-        else:
-            notes = None
+        notes = str(result.show_notes).strip() if result.show_notes else None
 
         show_info = {
             "id": result.show_id,
@@ -275,15 +269,12 @@ class ShowInfo:
 
         return show_info
 
-    @lru_cache(typed=True)
-    def retrieve_guest_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:
-        """Returns a list of dictionary objects containing Not My Job
-        guest information for the requested show ID.
+    def retrieve_guest_info_by_id(self, show_id: int) -> list[dict[str, Any]]:
+        """Retrieves Not My Job guest information.
 
         :param show_id: Show ID
-        :return: Dictionary containing Not My Job guest information. If
-            Not My Job information could not be retrieved, an empty list
-            will be returned.
+        :return: A dictionary containing Not My Job guest information,
+            including score and scoring exception for each guest
         """
         if not valid_int_id(show_id):
             return []
@@ -320,19 +311,16 @@ class ShowInfo:
 
         return guests
 
-    @lru_cache(typed=True)
     def retrieve_panelist_info_by_id(
         self, show_id: int, include_decimal_scores: bool = False
-    ) -> List[Dict[str, Any]]:
-        """Returns a list of dictionary objects containing panelist
-        information for the requested show ID.
+    ) -> list[dict[str, Any]]:
+        """Retrieves panelist information.
 
         :param show_id: Show ID
-        :param include_decimal_scores: Flag set to include panelist
-            decimal scores, if available
-        :return: List of panelists with corresponding scores and
-            ranking information. If panelist information could not be
-            retrieved, an empty list will be returned.
+        :param use_decimal_scores: A boolean to determine if decimal
+            scores should be used and returned instead of integer scores
+        :return: A dictionary containing panelist information, scores
+            and rankings
         """
         if not valid_int_id(show_id):
             return []

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -9,7 +9,7 @@ Retrieval Functions
 from functools import lru_cache
 from typing import Any, Dict, List, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from slugify import slugify
 from wwdtm.show.utility import ShowUtility
 from wwdtm.location.location import LocationUtility
@@ -44,71 +44,121 @@ class ShowInfo:
 
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
+        self.panelists = self._retrieve_panelists()
+
+    def _retrieve_panelists(self) -> Dict[int, Dict[str, str]]:
+        """Returns a dictionary of panelist information.
+
+        :return: Dictionary containing panelist ID as the key and
+            panelist name and slug string as a dictionary as a value.
+        """
+        query = """
+            SELECT panelistid, panelist, panelistslug
+            FROM ww_panelists
+            ORDER BY panelistid ASC;
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        panelists = {}
+        for row in results:
+            panelists[row.panelistid] = {
+                "name": row.panelist,
+                "slug": row.panelistslug,
+            }
+
+        return panelists
 
     @lru_cache(typed=True)
-    def retrieve_bluff_info_by_id(self, show_id: int) -> Dict[str, Any]:
-        """Returns a dictionary containing Bluff the Listener information
-        for the requested show ID.
+    def retrieve_bluff_info_by_id(self, show_id: int) -> List[Dict[str, Any]]:
+        """Returns a list of Bluff the Listener information for the
+        requested show ID.
 
         :param show_id: Show ID
-        :return: Dictionary containing correct and chosen Bluff the
-            Listener information.
+        :return: List containing each of the correct and chosen Bluff
+            the Listener information.
         """
         if not valid_int_id(show_id):
             return {}
 
         query = """
-            SELECT blm.chosenbluffpnlid AS id,
-            p.panelist AS name, p.panelistslug As slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.chosenbluffpnlid
-            WHERE s.showid = %s;
+            SELECT segment, chosenbluffpnlid AS chosen_id,
+            correctbluffpnlid AS correct_id
+            FROM ww_showbluffmap
+            WHERE showid = %s;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query, (show_id,))
-        chosen_result = cursor.fetchone()
+        result = cursor.fetchall()
 
-        if chosen_result:
-            chosen_bluff_info = {
-                "id": chosen_result.id,
-                "name": chosen_result.name,
-                "slug": chosen_result.slug
-                if chosen_result.slug
-                else slugify(chosen_result.name),
-            }
-        else:
-            chosen_bluff_info = None
+        if not result:
+            return []
 
-        query = """
-            SELECT blm.correctbluffpnlid AS id,
-            p.panelist AS name, p.panelistslug AS slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.correctbluffpnlid
-            WHERE s.showid = %s;
-            """
-        cursor.execute(query, (show_id,))
-        correct_result = cursor.fetchone()
-        cursor.close()
+        bluffs = []
+        for row in result:
+            if not row.chosen_id and not row.correct_id:
+                bluffs.append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.chosen_id and not row.correct_id:
+                bluffs.append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.correct_id and not row.chosen_id:
+                bluffs.append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
+            else:
+                bluffs.append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
 
-        if correct_result:
-            correct_bluff_info = {
-                "id": correct_result.id,
-                "name": correct_result.name,
-                "slug": correct_result.slug
-                if correct_result.slug
-                else slugify(correct_result.name),
-            }
-        else:
-            correct_bluff_info = None
-
-        return {
-            "chosen_panelist": chosen_bluff_info,
-            "correct_panelist": correct_bluff_info,
-        }
+        return bluffs
 
     def retrieve_core_info_by_id(self, show_id: int) -> Dict[str, Any]:
         """Returns a dictionary with core information for the requested

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -83,9 +83,11 @@ class ShowInfoMultiple:
         """
 
         query = """
-            SELECT showid, segment, chosenbluffpnlid AS chosen_id,
-            correctbluffpnlid AS correct_id
-            FROM ww_showbluffmap;
+            SELECT blm.showid, blm.segment, blm.chosenbluffpnlid AS chosen_id,
+            blm.correctbluffpnlid AS correct_id
+            FROM ww_showbluffmap blm
+            JOIN ww_shows s on s.showid = blm.showid
+            ORDER BY s.showid ASC, blm.segment ASC;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
@@ -177,7 +179,8 @@ class ShowInfoMultiple:
             SELECT showid, segment, chosenbluffpnlid AS chosen_id,
             correctbluffpnlid AS correct_id
             FROM ww_showbluffmap
-            WHERE showid IN ({ids});""".format(ids=", ".join(str(v) for v in show_ids))
+            WHERE showid IN ({ids})
+            ORDER BY showid ASC, segment ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
         results = cursor.fetchall()

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -8,7 +8,7 @@ Retrieval Functions for Multiple Shows
 """
 from typing import Any, Dict, List, Optional
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from slugify import slugify
 from wwdtm.show.utility import ShowUtility
 from wwdtm.location.location import LocationUtility
@@ -44,63 +44,118 @@ class ShowInfoMultiple:
 
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
+        self.panelists = self._retrieve_panelists()
 
-    def retrieve_bluff_info_all(self) -> Dict[int, List[Dict[str, Any]]]:
-        """Returns a dictionary containing Bluff the Listener information
-        for all shows.
+    def _retrieve_panelists(self) -> Dict[int, Dict[str, str]]:
+        """Returns a dictionary of panelist information.
 
-        :return: Dictionary containing correct and chosen Bluff the
-            Listener information.
+        :return: Dictionary containing panelist ID as the key and
+            panelist name and slug string as a dictionary as a value.
         """
         query = """
-            SELECT s.showid AS show_id,
-            blm.chosenbluffpnlid AS panelist_id,
-            p.panelist AS name, p.panelistslug AS slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.chosenbluffpnlid;
+            SELECT panelistid, panelist, panelistslug
+            FROM ww_panelists
+            ORDER BY panelistid ASC;
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        panelists = {}
+        for row in results:
+            panelists[row.panelistid] = {
+                "name": row.panelist,
+                "slug": row.panelistslug,
+            }
+
+        return panelists
+
+    def retrieve_bluff_info_all(self) -> Dict[int, List[Dict[str, Any]]]:
+        """Returns a dictionary of Bluff the Listener information for
+        all shows.
+
+        :return: Dictionary containing each of the correct and chosen
+            Bluff the Listener information.
+        """
+
+        query = """
+            SELECT showid, segment, chosenbluffpnlid AS chosen_id,
+            correctbluffpnlid AS correct_id
+            FROM ww_showbluffmap;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
-        chosen_results = cursor.fetchall()
-
-        query = """
-            SELECT s.showid AS show_id,
-            blm.correctbluffpnlid AS panelist_id,
-            p.panelist AS name, p.panelistslug AS slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.correctbluffpnlid;
-            """
-        cursor.execute(query)
-        correct_results = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not chosen_results or not correct_results:
+        if not results:
             return {}
 
         bluff_info = {}
-        for show in chosen_results:
-            if show.show_id not in bluff_info:
-                bluff_info[show.show_id] = {}
+        for row in results:
+            if row.showid not in bluff_info:
+                bluff_info[row.showid] = []
 
-            bluff_info[show.show_id]["chosen_panelist"] = {
-                "id": show.panelist_id,
-                "name": show.name,
-                "slug": show.slug if show.slug else slugify(show.name),
-            }
-
-        for show in correct_results:
-            if show.show_id not in bluff_info:
-                bluff_info[show.show_id] = {}
-
-            bluff_info[show.show_id]["correct_panelist"] = {
-                "id": show.panelist_id,
-                "name": show.name,
-                "slug": show.slug if show.slug else slugify(show.name),
-            }
+            if not row.chosen_id and not row.correct_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.chosen_id and not row.correct_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.correct_id and not row.chosen_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
+            else:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
 
         return bluff_info
 
@@ -119,58 +174,79 @@ class ShowInfoMultiple:
                 return {}
 
         query = """
-            SELECT s.showid AS show_id,
-            blm.chosenbluffpnlid AS panelist_id,
-            p.panelist AS name, p.panelistslug AS slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.chosenbluffpnlid
-            WHERE s.showid IN ({ids});""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
+            SELECT showid, segment, chosenbluffpnlid AS chosen_id,
+            correctbluffpnlid AS correct_id
+            FROM ww_showbluffmap
+            WHERE showid IN ({ids});""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
-        chosen_results = cursor.fetchall()
-
-        query = """
-            SELECT s.showid AS show_id,
-            blm.correctbluffpnlid AS panelist_id,
-            p.panelist AS name, p.panelistslug AS slug
-            FROM ww_showbluffmap blm
-            JOIN ww_shows s ON s.showid = blm.showid
-            JOIN ww_panelists p ON
-            p.panelistid = blm.correctbluffpnlid
-            WHERE s.showid IN ({ids});""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
-        cursor.execute(query)
-        correct_results = cursor.fetchall()
+        results = cursor.fetchall()
         cursor.close()
 
-        if not chosen_results or not correct_results:
+        if not results:
             return {}
 
         bluff_info = {}
-        for show in chosen_results:
-            if show.show_id not in bluff_info:
-                bluff_info[show.show_id] = {}
+        for row in results:
+            if row.showid not in bluff_info:
+                bluff_info[row.showid] = []
 
-            bluff_info[show.show_id]["chosen_panelist"] = {
-                "id": show.panelist_id,
-                "name": show.name,
-                "slug": show.slug if show.slug else slugify(show.name),
-            }
-
-        for show in correct_results:
-            if show.show_id not in bluff_info:
-                bluff_info[show.show_id] = {}
-
-            bluff_info[show.show_id]["correct_panelist"] = {
-                "id": show.panelist_id,
-                "name": show.name,
-                "slug": show.slug if show.slug else slugify(show.name),
-            }
+            if not row.chosen_id and not row.correct_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.chosen_id and not row.correct_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": None,
+                    }
+                )
+            elif row.correct_id and not row.chosen_id:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": None,
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
+            else:
+                bluff_info[row.showid].append(
+                    {
+                        "segment": row.segment,
+                        "chosen_panelist": {
+                            "id": row.chosen_id,
+                            "name": self.panelists[row.chosen_id]["name"],
+                            "slug": self.panelists[row.chosen_id]["slug"]
+                            if self.panelists[row.chosen_id]["slug"]
+                            else slugify(self.panelists[row.chosen_id]["name"]),
+                        },
+                        "correct_panelist": {
+                            "id": row.correct_id,
+                            "name": self.panelists[row.correct_id]["name"],
+                            "slug": self.panelists[row.correct_id]["slug"]
+                            if self.panelists[row.correct_id]["slug"]
+                            else slugify(self.panelists[row.correct_id]["name"]),
+                        },
+                    }
+                )
 
         return bluff_info
 
@@ -323,9 +399,7 @@ class ShowInfoMultiple:
             JOIN ww_showdescriptions sd ON sd.showid = s.showid
             JOIN ww_shownotes sn ON sn.showid = s.showid
             WHERE s.showid IN ({ids})
-            ORDER BY s.showdate ASC;""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
+            ORDER BY s.showdate ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -474,9 +548,7 @@ class ShowInfoMultiple:
             JOIN ww_shows s ON s.showid = gm.showid
             WHERE gm.showid IN ({ids})
             ORDER BY s.showdate ASC,
-            gm.showguestmapid ASC;""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
+            gm.showguestmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -614,9 +686,7 @@ class ShowInfoMultiple:
                 JOIN ww_shows s ON s.showid = pm.showid
                 WHERE pm.showid IN ({ids})
                 ORDER by s.showdate ASC, pm.panelistscore DESC,
-                pm.showpnlmapid ASC;""".format(
-                ids=", ".join(str(v) for v in show_ids)
-            )
+                pm.showpnlmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         else:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
@@ -629,9 +699,7 @@ class ShowInfoMultiple:
                 JOIN ww_shows s ON s.showid = pm.showid
                 WHERE pm.showid IN ({ids})
                 ORDER by s.showdate ASC, pm.panelistscore DESC,
-                pm.showpnlmapid ASC;""".format(
-                ids=", ".join(str(v) for v in show_ids)
-            )
+                pm.showpnlmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
 
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -42,27 +42,6 @@ class ShowInfoMultiple:
 
             self.database_connection = database_connection
 
-        try:
-            query = "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistlrndstart_decimal';"
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            start_decimal = cursor.fetchone()
-
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            score_decimal = cursor.fetchone()
-            cursor.close()
-
-            if start_decimal and score_decimal:
-                self.panelist_decimal_columns: bool = True
-            else:
-                self.panelist_decimal_columns: bool = False
-        except DatabaseError:
-            self.panelist_decimal_columns: bool = False
-
         self.utility = ShowUtility(database_connection=self.database_connection)
         self.loc_util = LocationUtility(database_connection=self.database_connection)
 
@@ -535,7 +514,7 @@ class ShowInfoMultiple:
             ranking information. If panelist information could not be
             retrieved, an empty list will be returned.
         """
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
                 p.panelist AS name, p.panelistslug AS slug,
@@ -619,7 +598,7 @@ class ShowInfoMultiple:
             if not valid_int_id(show_id):
                 return {}
 
-        if include_decimal_scores and self.panelist_decimal_columns:
+        if include_decimal_scores:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
                 p.panelist AS name, p.panelistslug AS slug,

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -6,12 +6,11 @@
 """Wait Wait Don't Tell Me! Stats Show Data Retrieval Functions
 """
 import datetime
-import dateutil.parser as date_parser
 from decimal import Decimal
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from mysql.connector import connect, DatabaseError
+from mysql.connector import connect
 from wwdtm.show.info import ShowInfo
 from wwdtm.show.info_multiple import ShowInfoMultiple
 from wwdtm.show.utility import ShowUtility
@@ -273,12 +272,12 @@ class Show:
             be returned.
         """
         try:
-            parsed_date_string = date_parser.parse(date_string)
+            parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             return {}
 
         id_ = self.utility.convert_date_to_id(
-            parsed_date_string.year, parsed_date_string.month, parsed_date_string.day
+            parsed_date.year, parsed_date.month, parsed_date.day
         )
 
         return self.retrieve_by_id(id_)
@@ -372,7 +371,7 @@ class Show:
             an empty list will be returned.
         """
         try:
-            parsed_year = date_parser.parse(f"{year:04d}")
+            parsed_year = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -404,7 +403,9 @@ class Show:
             retrieved, a list of dictionaries will be returned.
         """
         try:
-            parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
+            parsed_year_month = datetime.datetime.strptime(
+                f"{year:04d}-{month:02d}-01", "%Y-%m-%d"
+            )
         except ValueError:
             return []
 
@@ -468,12 +469,12 @@ class Show:
             will be returned.
         """
         try:
-            parsed_date_string = date_parser.parse(date_string)
+            parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         except ValueError:
             return {}
 
         id_ = self.utility.convert_date_to_id(
-            parsed_date_string.year, parsed_date_string.month, parsed_date_string.day
+            parsed_date.year, parsed_date.month, parsed_date.day
         )
 
         return self.retrieve_details_by_id(
@@ -586,7 +587,7 @@ class Show:
             empty list will be returned.
         """
         try:
-            parsed_year = date_parser.parse(f"{year:04d}")
+            parsed_year = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -642,7 +643,9 @@ class Show:
             retrieved, an empty list will be returned.
         """
         try:
-            parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
+            parsed_year_month = datetime.datetime.strptime(
+                f"{year:04d}-{month:02d}-01", "%Y-%m-%d"
+            )
         except ValueError:
             return []
 
@@ -697,7 +700,7 @@ class Show:
             could not be retrieved, an empty list will be returned.
         """
         try:
-            _ = date_parser.parse(f"{year:04d}")
+            _ = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 
@@ -851,7 +854,7 @@ class Show:
             will be returned.
         """
         try:
-            _ = date_parser.parse(f"{year:04d}")
+            _ = datetime.datetime.strptime(f"{year:04d}", "%Y")
         except ValueError:
             return []
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -121,9 +121,9 @@ class Show:
                 info[show]["panelists"] = []
 
             if info[show]["id"] in bluffs:
-                info[show]["bluff"] = bluffs[info[show]["id"]]
+                info[show]["bluffs"] = bluffs[info[show]["id"]]
             else:
-                info[show]["bluff"] = {}
+                info[show]["bluffs"] = {}
 
             if info[show]["id"] in guests:
                 info[show]["guests"] = guests[info[show]["id"]]
@@ -506,7 +506,7 @@ class Show:
         info["panelists"] = self.info.retrieve_panelist_info_by_id(
             show_id, include_decimal_scores=include_decimal_scores
         )
-        info["bluff"] = self.info.retrieve_bluff_info_by_id(show_id)
+        info["bluffs"] = self.info.retrieve_bluff_info_by_id(show_id)
         info["guests"] = self.info.retrieve_guest_info_by_id(show_id)
 
         return info
@@ -561,7 +561,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -616,7 +616,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -680,7 +680,7 @@ class Show:
                 info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                     info[show]["id"], include_decimal_scores=include_decimal_scores
                 )
-                info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
                     info[show]["id"]
                 )
                 info[show]["guests"] = self.info.retrieve_guest_info_by_id(
@@ -833,7 +833,7 @@ class Show:
             info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
                 show, include_decimal_scores=include_decimal_scores
             )
-            info[show]["bluff"] = self.info.retrieve_bluff_info_by_id(show)
+            info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(show)
             info[show]["guests"] = self.info.retrieve_guest_info_by_id(show)
             shows.append(info[show])
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -43,21 +43,6 @@ class Show:
 
             self.database_connection = database_connection
 
-        try:
-            query = (
-                "SHOW COLUMNS FROM ww_showpnlmap WHERE Field = 'panelistscore_decimal';"
-            )
-            cursor = self.database_connection.cursor()
-            cursor.execute(query)
-            result = cursor.fetchone()
-            cursor.close()
-            if result:
-                self.panelist_decimal_column: bool = True
-            else:
-                self.panelist_decimal_column: bool = False
-        except DatabaseError:
-            self.panelist_decimal_column: bool = False
-
         self.info = ShowInfo(database_connection=self.database_connection)
         self.info_multiple = ShowInfoMultiple(
             database_connection=self.database_connection
@@ -118,9 +103,6 @@ class Show:
             If show information could not be retrieved, an empty list
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         info = self.info_multiple.retrieve_core_info_all()
 
         if not info:
@@ -180,9 +162,7 @@ class Show:
         :return: List of all show date strings. If show dates could not
             be retrieved, an empty list will be returned.
         """
-        query = """
-            SELECT showdate FROM ww_shows ORDER BY showdate ASC;
-            """
+        query = "SELECT showdate FROM ww_shows ORDER BY showdate ASC;"
         cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -464,9 +444,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         id_ = self.utility.convert_date_to_id(year, month, day)
         if not id_:
             return {}
@@ -490,9 +467,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         try:
             parsed_date_string = date_parser.parse(date_string)
         except ValueError:
@@ -521,9 +495,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return {}
-
         if not valid_int_id(show_id):
             return {}
 
@@ -555,9 +526,6 @@ class Show:
             show information could not be retrieved, an empty dictionary
             will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         if not 1 <= month <= 12 or not 1 <= day <= 31:
             return []
 
@@ -617,9 +585,6 @@ class Show:
             details. If show information could not be retrieved, an
             empty list will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             parsed_year = date_parser.parse(f"{year:04d}")
         except ValueError:
@@ -676,9 +641,6 @@ class Show:
             corresponding details. If show information could not be
             retrieved, an empty list will be returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             parsed_year_month = date_parser.parse(f"{year:04d}-{month:02d}-01")
         except ValueError:
@@ -826,9 +788,6 @@ class Show:
             information could not be retrieved, an empty list will be
             returned.
         """
-        if include_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             past_days = int(include_days_back)
             future_days = int(include_days_ahead)
@@ -891,9 +850,6 @@ class Show:
             scores. If show scores could not be retrieved, an empty list
             will be returned.
         """
-        if use_decimal_scores and not self.panelist_decimal_column:
-            return []
-
         try:
             _ = date_parser.parse(f"{year:04d}")
         except ValueError:

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -124,7 +124,7 @@ class Show:
             if info[show]["id"] in bluffs:
                 info[show]["bluff"] = bluffs[info[show]["id"]]
             else:
-                info[show]["bluff"] = []
+                info[show]["bluff"] = {}
 
             if info[show]["id"] in guests:
                 info[show]["guests"] = guests[info[show]["id"]]

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -1,33 +1,34 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Wait Wait Don't Tell Me! Stats Show Data Utility Functions
-"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Show Data Utility Functions."""
 import datetime
-from functools import lru_cache
-from typing import Any, Dict, Optional
+from typing import Any
 
 from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
 from wwdtm.validation import valid_int_id
 
 
 class ShowUtility:
-    """This class contains supporting functions used to check whether
-    a show ID or show date exists or to convert between show ID, and
-    show dates.
+    """Show information and utility class.
 
-    :param connect_dict: Dictionary containing database connection
-        settings as required by mysql.connector.connect
-    :param database_connection: mysql.connector.connect database
-        connection
+    Contains methods to convert between show ID and date, and to check
+    if show IDs and dates exist.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
     """
 
     def __init__(
         self,
-        connect_dict: Optional[Dict[str, Any]] = None,
-        database_connection: Optional[connect] = None,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
     ):
         """Class initialization method."""
         if connect_dict:
@@ -39,14 +40,14 @@ class ShowUtility:
 
             self.database_connection = database_connection
 
-    @lru_cache(typed=True)
-    def convert_date_to_id(self, year: int, month: int, day: int) -> Optional[int]:
-        """Converts a show date to the matching show ID value.
+    def convert_date_to_id(self, year: int, month: int, day: int) -> int | None:
+        """Converts a show date to the corresponding show ID.
 
         :param year: Year portion of a show date
         :param month: Month portion of a show date
         :param day: Day portion of a show date
-        :return: Show ID, if a match is found
+        :return: Show ID if a corresponding value is found. Otherwise,
+            ``None`` is returned
         """
         try:
             show_date = datetime.datetime(year, month, day)
@@ -66,12 +67,12 @@ class ShowUtility:
 
         return None
 
-    @lru_cache(typed=True)
-    def convert_id_to_date(self, show_id: int) -> Optional[str]:
-        """Converts a show's ID to the matching show date.
+    def convert_id_to_date(self, show_id: int) -> str | None:
+        """Converts a show ID to the corresponding show date.
 
         :param show_id: Show ID
-        :return: Show date, if a match is found
+        :return: Show date if a corresponding value is found. Otherwise,
+            ``None`` is returned
         """
         if not valid_int_id(show_id):
             return None
@@ -89,14 +90,13 @@ class ShowUtility:
 
         return None
 
-    @lru_cache(typed=True)
     def date_exists(self, year: int, month: int, day: int) -> bool:
-        """Checks to see if a show date exists.
+        """Validates if a show date exists.
 
         :param year: Year portion of a show date
         :param month: Month portion of a show date
         :param day: Day portion of a show date
-        :return: True or False, based on whether the show date exists
+        :return: ``True`` if the show date exists, otherwise ``False``
         """
         try:
             show_date = datetime.datetime(year, month, day)
@@ -113,12 +113,11 @@ class ShowUtility:
 
         return bool(result)
 
-    @lru_cache(typed=True)
     def id_exists(self, show_id: int) -> bool:
-        """Checks to see if a show ID exists.
+        """Validates if a show ID exists.
 
         :param show_id: Show ID
-        :return: True or False, based on whether the show ID exists
+        :return: ``True`` if the show ID exists, otherwise ``False``
         """
         if not valid_int_id(show_id):
             return False

--- a/wwdtm/validation.py
+++ b/wwdtm/validation.py
@@ -1,14 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
-"""Type validation module"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Type validation module."""
 
 
 def valid_int_id(int_id: int) -> bool:
-    """Validates an ID value as a signed 32-bit integer used
-    in ID fields in MySQL tables.
+    """Validates an ID value as a signed 32-bit integer used in ID fields in MySQL tables.
 
     :param int_id: ID number to validate
     :return: True or False, based on if the integer falls inclusively


### PR DESCRIPTION
## Application Changes

* Update type hints for parameters and return values to be more specific and to replace the use of :py:class:`typing.Optional` and :py:class:`typing.Union` with the conventions documented in PEP-484 and PEP-604.
* Replace use of :py:class:`typing.Dict`, :py:class:`typing.List` and :py:class:`typing.Tuple` with :py:class:`dict`, :py:class:`list` and :py:class:`tuple` respectively in type hints
* Remove use of :py:meth:`functools.lru_cache` as caching should be done by the application consuming the library

Component Changes
-----------------

* Upgrade NumPy from 1.26.0 to 1.26.3

Development Changes
-------------------

* Switch to Ruff for code linting and formatting (with the help of Black)
* Deprecate ``perf_test.py`` for performance testing
* Upgrade pytest from 7.4.3 to 7.4.4
* Upgrade black from 23.11.0 to 23.12.0
* Upgrade wheel from 0.41.3 to 0.42.0

Documentation Changes
---------------------

* Update Sphinx configuration to be more similar to the conventions used by Pallets projects
* Change the base font from IBM Plex Sans to IBM Plex Serif
* Clean up and rewrite docstrings to be more consistent and succint
* Add table of contents to each module page
* Update the copyright block at the top of each file to remove ``coding`` line and to include the appropriate SPDX license identifier