### PR TITLE
Fix sorting of panelists by decimal scores for show details

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,16 @@
 Changes
 *******
 
+2.8.1
+=====
+
+Application Changes
+-------------------
+
+* Correct sorting of panelists when retrieving panelist information for show details with
+  decimal scores. Previously, the sorting was based on integer score, which causes
+  panelists to be ordered incorrectly.
+
 2.8.0
 =====
 

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -240,7 +240,7 @@ def test_show_retrieve_details_by_date_string(date: str, include_decimal_scores:
     assert "host" in info, f"'host' was not returned for show {date}"
 
 
-@pytest.mark.parametrize("date", ["2018-10-27"])
+@pytest.mark.parametrize("date", ["1999-02-13", "2018-10-27"])
 def test_show_retrieve_details_by_date_string_decimal(date: str):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_details_by_date_string` with decimal scores.
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -20,4 +20,4 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.8.0"
+VERSION = "2.8.1"

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -341,7 +341,8 @@ class ShowInfo:
                 FROM ww_showpnlmap pm
                 JOIN ww_panelists p on p.panelistid = pm.panelistid
                 WHERE pm.showid = %s
-                ORDER by pm.panelistscore DESC, pm.showpnlmapid ASC;
+                ORDER by pm.panelistscore_decimal DESC,
+                pm.showpnlmapid ASC;
                 """
         else:
             query = """

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -597,7 +597,7 @@ class ShowInfoMultiple:
                 FROM ww_showpnlmap pm
                 JOIN ww_panelists p ON p.panelistid = pm.panelistid
                 JOIN ww_shows s ON s.showid = pm.showid
-                ORDER by s.showdate ASC, pm.panelistscore DESC,
+                ORDER by s.showdate ASC, pm.panelistscore_decimal DESC,
                 pm.showpnlmapid ASC;
                 """
         else:
@@ -680,7 +680,7 @@ class ShowInfoMultiple:
                 JOIN ww_panelists p ON p.panelistid = pm.panelistid
                 JOIN ww_shows s ON s.showid = pm.showid
                 WHERE pm.showid IN ({ids})
-                ORDER by s.showdate ASC, pm.panelistscore DESC,
+                ORDER by s.showdate ASC, pm.panelistscore_decimal DESC,
                 pm.showpnlmapid ASC;""".format(
                 ids=", ".join(str(v) for v in show_ids)
             )


### PR DESCRIPTION
## Application Changes

- Correct sorting of panelists when retrieving panelist information for show details with decimal scores. Previously, the sorting was based on integer score, which causes panelists to be ordered incorrectly.