### PR TITLE
Refactor Preferred Pronouns for Hosts, Panelists and Scorekeepers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,21 @@
 Changes
 *******
 
+2.10.0
+======
+
+Application Changes
+-------------------
+
+* Starting with version 2.10.0 of this library, the minimum required
+  version of the Wait Wait Stats Database is 4.7
+* Change handling of Host, Panelist and Scorekeeper pronouns to reflect
+  the addition of corresponding pronouns mapping tables introduced with
+  Wait Wait Stats Database version 4.7
+* The ``pronouns`` property for Hosts, Panelists and Scorekeepers is now
+  in the form of a list of pronouns strings
+* Add ``Pronouns`` class that retrieves information from
+
 2.9.1
 =====
 

--- a/docs/tests/index.rst
+++ b/docs/tests/index.rst
@@ -14,6 +14,7 @@ each of the :py:mod:`wwdtm` library modules:
     host
     location
     panelist
+    pronoun
     scorekeeper
     show
     validation

--- a/docs/tests/pronoun.rst
+++ b/docs/tests/pronoun.rst
@@ -1,0 +1,17 @@
+.. module:: tests.pronoun
+
+*******
+pronoun
+*******
+
+This module provides functions used to by :py:class:`pytest` to run tests against
+the following objects:
+
+- :py:class:`wwdtm.pronoun.Pronouns`
+
+test_pronoun_pronouns
+=====================
+
+.. automodule:: tests.pronoun.test_pronoun_pronouns
+    :members:
+    :undoc-members:

--- a/docs/wwdtm/index.rst
+++ b/docs/wwdtm/index.rst
@@ -17,6 +17,7 @@ The following is a list of modules provided in the library:
     host
     location
     panelist
+    pronoun
     scorekeeper
     show
     validation

--- a/docs/wwdtm/pronoun.rst
+++ b/docs/wwdtm/pronoun.rst
@@ -1,0 +1,20 @@
+.. module:: wwdtm.pronoun
+
+************
+Module: pronoun
+************
+
+This module provides objects used to retrieve pronouns information from
+a copy of the Wait Wait Don't Tell Me! Stats database.
+
+.. contents:: Contents
+    :depth: 1
+    :local:
+    :backlinks: none
+
+Pronouns
+========
+
+.. autoclass:: wwdtm.pronoun.Pronouns
+    :members:
+    :inherited-members:

--- a/tests/pronoun/test_pronoun_pronouns.py
+++ b/tests/pronoun/test_pronoun_pronouns.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2018-2024 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:class:`wwdtm.pronoun.Pronouns`."""
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from wwdtm.pronoun import Pronouns
+
+
+@pytest.mark.skip
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    """
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
+        config_dict = json.load(config_file)
+        if "database" in config_dict:
+            return config_dict["database"]
+
+
+def test_pronouns_retrieve_all():
+    """Testing for :py:meth:`wwdtm.pronoun.Pronouns.retrieve_all`."""
+    pn = Pronouns(connect_dict=get_connect_dict())
+    all_pronouns = pn.retrieve_all()
+
+    assert all_pronouns, "No pronouns could be retrieved"
+    assert "id" in all_pronouns[0], "'id' was not returned for the first list item"
+    assert (
+        "pronouns" in all_pronouns[0]
+    ), "'pronouns' was not returned for the first list item"
+
+
+def test_pronouns_retrieve_all_ids():
+    """Testing for :py:meth:`wwdtm.pronoun.Pronouns.retrieve_all_ids`."""
+    pn = Pronouns(connect_dict=get_connect_dict())
+    ids = pn.retrieve_all_ids()
+
+    assert ids, "No pronouns IDs could be retrieved"
+
+
+def test_pronouns_retrieve_all_as_dict():
+    """Testing for :py:meth:`wwdtm.pronoun.Pronouns.retrieve_all_as_dict`."""
+    pn = Pronouns(connect_dict=get_connect_dict())
+    all_pronouns = pn.retrieve_all_as_dict()
+
+    assert all_pronouns, "No pronouns could be retrieved"
+
+
+def test_pronouns_retrieve_all_pronouns():
+    """Testing for :py:meth:`wwdtm.pronoun.Pronouns.retrieve_all_pronouns`."""
+    pn = Pronouns(connect_dict=get_connect_dict())
+    all_pronouns = pn.retrieve_all_pronouns()
+
+    assert all_pronouns, "No pronouns strings could be retrieved"
+
+
+@pytest.mark.parametrize("pronouns_id", [1])
+def test_pronouns_retrieve_by_id(pronouns_id: int):
+    """Testing for :py:meth:`wwdtm.pronoun.Pronouns.retrieve_by_id`.
+
+    :param pronouns_id: Pronouns ID to test retrieving pronouns
+        information
+    """
+    pn = Pronouns(connect_dict=get_connect_dict())
+    info = pn.retrieve_by_id(pronouns_id)
+
+    assert info, f"Pronouns ID {pronouns_id} not found"
+    assert "id" in info, f"'id' was not returned for ID {pronouns_id}"
+    assert "pronouns" in info, f"'pronouns' was not returned for ID {pronouns_id}"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2018-2024 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing for object: :py:module:`wwdtm`."""
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from numpy import isin
+
+from wwdtm import database_version
+
+
+@pytest.mark.skip
+def get_connect_dict() -> dict[str, Any]:
+    """Retrieves database connection settings.
+
+    :return: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    """
+    file_path = Path.cwd() / "config.json"
+    with file_path.open(mode="r", encoding="utf-8") as config_file:
+        config_dict = json.load(config_file)
+        if "database" in config_dict:
+            return config_dict["database"]
+
+
+def test_database_version():
+    """Testing for :py:func:`wwdtm.database_version`."""
+    _database_version = database_version(connect_dict=get_connect_dict())
+
+    assert isinstance(
+        _database_version, tuple
+    ), "Invalid database version value type returned"
+
+    if isinstance(_database_version, tuple):
+        assert (
+            len(_database_version) == 2 or len(_database_version) == 3
+        ), "Invalid database version value returned"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -4,6 +4,11 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Explicitly listing all modules in this package."""
+from typing import Any
+
+from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
 
 from wwdtm import validation
 from wwdtm.guest import Guest, GuestAppearances, GuestUtility
@@ -21,3 +26,46 @@ from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUt
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
 VERSION = "2.9.1"
+
+
+def database_version(
+    connect_dict: dict[str, Any] = None,
+    database_connection: MySQLConnection | PooledMySQLConnection = None,
+) -> tuple[int] | None:
+    """Returns Stats Database version, if available.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
+    :return: A tuple containg major, minor and revision numbers if
+        available. If a version number is not available, None is
+        returned.
+    """
+    if connect_dict:
+        connect_dict = connect_dict
+        _database_connection = connect(**connect_dict)
+    elif database_connection:
+        _database_connection = database_connection
+        if not _database_connection.is_connected():
+            _database_connection.reconnect()
+
+    cursor = _database_connection.cursor(named_tuple=True)
+    query = """
+            SELECT keyname, value
+            FROM __metadata
+            WHERE keyname = 'database_version'
+            ORDER BY id DESC LIMIT 1;
+            """
+    cursor.execute(query)
+    result = cursor.fetchone()
+
+    if not result:
+        return None
+
+    version_info = str(result.value).split(".")
+    if len(version_info) == 3:
+        return int(version_info[0]), int(version_info[1]), int(version_info[2])
+    elif len(version_info) == 2:
+        return int(version_info[0]), int(version_info[1]), 0
+    else:
+        return None

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.9.1"
+VERSION = "2.10.0-beta.1"
 
 
 def database_version(

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -55,15 +55,17 @@ class Location:
             name, city, state and slug string
         """
         query = """
-            SELECT locationid AS id, city, state, venue, latitude,
-            longitude, locationslug AS slug
-            FROM ww_locations
+            SELECT l.locationid AS id, l.city, l.state,
+            pa.name AS state_name, l.venue, l.latitude, l.longitude,
+            l.locationslug AS slug
+            FROM ww_locations l
+            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state;
             """
 
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
+            query = query + "ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
         else:
-            query = query + "ORDER BY state ASC, city ASC, venue ASC;"
+            query = query + "ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
@@ -88,6 +90,7 @@ class Location:
                     "id": row.id,
                     "city": row.city,
                     "state": row.state,
+                    "state_name": row.state_name,
                     "venue": row.venue,
                     "coordinates": coordinates,
                     "slug": (
@@ -114,14 +117,16 @@ class Location:
             name, city, state, slug string and a list of recordings
         """
         query = """
-            SELECT locationid AS id, city, state, venue, latitude,
-            longitude, locationslug AS slug
-            FROM ww_locations
+            SELECT l.locationid AS id, l.city, l.state,
+            pa.name AS state_name, l.venue, l.latitude, l.longitude,
+            l.locationslug AS slug
+            FROM ww_locations l
+            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             """
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
+            query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
         else:
-            query = query + "ORDER BY state ASC, city ASC, venue ASC;"
+            query = query + " ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
         cursor = self.database_connection.cursor(named_tuple=True)
         cursor.execute(query)
@@ -146,6 +151,7 @@ class Location:
                     "id": row.id,
                     "city": row.city,
                     "state": row.state,
+                    "state_name": row.state_name,
                     "venue": row.venue,
                     "coordinates": coordinates,
                     "slug": (
@@ -171,11 +177,15 @@ class Location:
             list is sorted by venue first or by state and city first
         :return: A list of location IDs as integers
         """
-        query = "SELECT locationid FROM ww_locations "
+        query = """
+            SELECT l.locationid
+            FROM ww_locations l
+            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            """
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
+            query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
         else:
-            query = query + "ORDER BY state ASC, city ASC, venue ASC;"
+            query = query + " ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
         cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
@@ -194,11 +204,15 @@ class Location:
             list is sorted by venue first or by state and city first
         :return: A list of location slug strings
         """
-        query = "SELECT locationslug FROM ww_locations "
+        query = """
+            SELECT l.locationslug
+            FROM ww_locations l
+            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            """
         if sort_by_venue:
-            query = query + "ORDER BY venue ASC, city ASC, state ASC;"
+            query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
         else:
-            query = query + "ORDER BY state ASC, city ASC, venue ASC;"
+            query = query + " ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
         cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
@@ -221,10 +235,12 @@ class Location:
             return {}
 
         query = """
-            SELECT locationid AS id, city, state, venue, latitude,
-            longitude, locationslug AS slug
-            FROM ww_locations
-            WHERE locationid = %s
+            SELECT l.locationid AS id, l.city, l.state,
+            pa.name AS state_name, l.venue, l.latitude, l.longitude,
+            l.locationslug AS slug
+            FROM ww_locations l
+            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            WHERE l.locationid = %s
             LIMIT 1;
             """
         cursor = self.database_connection.cursor(named_tuple=True)
@@ -247,6 +263,7 @@ class Location:
             "id": result.id,
             "city": result.city,
             "state": result.state,
+            "state_name": result.state_name,
             "venue": result.venue,
             "coordinates": coordinates,
             "slug": (

--- a/wwdtm/pronoun/__init__.py
+++ b/wwdtm/pronoun/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) 2018-2024 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Stats: Pronouns module."""
+from .pronouns import Pronouns

--- a/wwdtm/pronoun/pronouns.py
+++ b/wwdtm/pronoun/pronouns.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2018-2024 Linh Pham
+# wwdtm is released under the terms of the Apache License 2.0
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Wait Wait Don't Tell Me! Stats Pronouns Data Retrieval Functions."""
+from typing import Any
+
+from mysql.connector import connect
+from mysql.connector.connection import MySQLConnection
+from mysql.connector.pooling import PooledMySQLConnection
+
+
+class Pronouns:
+    """Pronouns information retrieval class.
+
+    Contains methods used to retrieve available pronouns.
+
+    :param connect_dict: A dictionary containing database connection
+        settings as required by MySQL Connector/Python
+    :param database_connection: MySQL database connection object
+    """
+
+    def __init__(
+        self,
+        connect_dict: dict[str, Any] = None,
+        database_connection: MySQLConnection | PooledMySQLConnection = None,
+    ):
+        """Class initialization method."""
+        if connect_dict:
+            self.connect_dict = connect_dict
+            self.database_connection = connect(**connect_dict)
+        elif database_connection:
+            if not database_connection.is_connected():
+                database_connection.reconnect()
+
+            self.database_connection = database_connection
+
+    def retrieve_all(self) -> list[dict[int, str]]:
+        """Retrieves all pronouns.
+
+        :return: A list of dictionaries containing pronouns IDs and
+            corresponding pronouns
+        """
+        query = """
+            SELECT pronounsid, pronouns
+            FROM ww_pronouns
+            ORDER BY pronounsid ASC;
+            """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        pronouns = []
+        for row in results:
+            pronouns.append({"id": row.pronounsid, "pronouns": row.pronouns})
+
+        return pronouns
+
+    def retrieve_all_ids(self) -> list[int]:
+        """Retrieves all pronouns IDs, sorted by ID.
+
+        :return: A list of pronouns IDs as integers
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        query = """
+            SELECT pronounsid
+            FROM ww_pronouns
+            ORDER BY pronounsid ASC;
+        """
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        return [row.pronounsid for row in results]
+
+    def retrieve_all_as_dict(self) -> dict[int, str]:
+        """Retrieves all pronouns as a dictionary.
+
+        :return: A dictionary of pronouns IDs and pronoun strings,
+            ordered by pronouns ID
+        """
+        query = """
+            SELECT pronounsid, pronouns
+            FROM ww_pronouns
+            ORDER BY pronounsid ASC;
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return {}
+
+        return {row.pronounsid: row.pronouns for row in results}
+
+    def retrieve_all_pronouns(self) -> list[str]:
+        """Retrieves all pronouns names.
+
+        :return: A list of pronouns names, ordered by pronouns ID
+        """
+        query = """
+            SELECT pronouns
+            FROM ww_pronouns
+            ORDER BY pronounsid ASC;
+        """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        return [row.pronouns for row in results]
+
+    def retrieve_by_id(self, pronouns_id: int) -> dict[int, str]:
+        """Retrieves pronouns information.
+
+        :param pronouns_id: Pronouns ID
+        :return: A dictionary containing pronouns ID and corresponding
+            pronouns
+        """
+        query = """
+            SELECT pronounsid, pronouns
+            FROM ww_pronouns
+            WHERE pronounsid = %s
+            LIMIT 1;
+            """
+        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor.execute(query, (pronouns_id,))
+        result = cursor.fetchone()
+
+        if not result:
+            return {}
+
+        return {
+            "id": result.pronounsid,
+            "pronouns": result.pronouns,
+        }

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -182,8 +182,9 @@ class ShowInfo:
             SELECT s.showid AS show_id, s.showdate AS date,
             s.bestof AS best_of, s.repeatshowid AS repeat_show_id,
             s.showurl AS show_url,
-            l.locationid AS location_id, l.city, l.state, l.latitude,
-            l.longitude, l.venue, l.locationslug AS location_slug,
+            l.locationid AS location_id, l.city, l.state,
+            pa.name AS state_name, l.latitude, l.longitude, l.venue,
+            l.locationslug AS location_slug,
             h.hostid AS host_id, h.host, h.hostslug AS host_slug,
             hm.guest as host_guest, sk.scorekeeperid AS scorekeeper_id,
             sk.scorekeeper, sk.scorekeeperslug AS scorekeeper_slug,
@@ -194,6 +195,7 @@ class ShowInfo:
             FROM ww_shows s
             JOIN ww_showlocationmap lm ON lm.showid = s.showid
             JOIN ww_locations l ON l.locationid = lm.locationid
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             JOIN ww_showhostmap hm ON hm.showid = s.showid
             JOIN ww_hosts h ON h.hostid = hm.hostid
             JOIN ww_showskmap skm ON skm.showid = s.showid
@@ -224,6 +226,7 @@ class ShowInfo:
             "slug": result.location_slug,
             "city": result.city,
             "state": result.state,
+            "state_name": result.state_name,
             "venue": result.venue,
             "coordinates": coordinates if coordinates else None,
         }

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -281,7 +281,8 @@ class ShowInfoMultiple:
             s.bestof AS best_of, s.repeatshowid AS repeat_show_id,
             s.showurl AS show_url,
             l.locationid AS location_id, l.city, l.state,
-            l.venue, l.latitude, l.longitude, l.locationslug AS location_slug,
+            pa.name AS state_name, l.venue, l.latitude, l.longitude,
+            l.locationslug AS location_slug,
             h.hostid AS host_id, h.host, h.hostslug AS host_slug,
             hm.guest as host_guest,
             sk.scorekeeperid AS scorekeeper_id, sk.scorekeeper,
@@ -293,6 +294,7 @@ class ShowInfoMultiple:
             FROM ww_shows s
             JOIN ww_showlocationmap lm ON lm.showid = s.showid
             JOIN ww_locations l ON l.locationid = lm.locationid
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             JOIN ww_showhostmap hm ON hm.showid = s.showid
             JOIN ww_hosts h ON h.hostid = hm.hostid
             JOIN ww_showskmap skm ON skm.showid = s.showid
@@ -324,6 +326,7 @@ class ShowInfoMultiple:
                 "slug": show.location_slug,
                 "city": show.city,
                 "state": show.state,
+                "state_name": show.state_name,
                 "venue": show.venue,
                 "coordinates": coordinates,
             }
@@ -412,7 +415,8 @@ class ShowInfoMultiple:
             s.bestof AS best_of, s.repeatshowid AS repeat_show_id,
             s.showurl AS show_url,
             l.locationid AS location_id, l.city, l.state,
-            l.venue, l.latitude, l.longitude, l.locationslug AS location_slug,
+            pa.name AS state_name, l.venue, l.latitude, l.longitude,
+            l.locationslug AS location_slug,
             h.hostid AS host_id, h.host, h.hostslug AS host_slug,
             hm.guest as host_guest,
             sk.scorekeeperid AS scorekeeper_id, sk.scorekeeper,
@@ -424,6 +428,7 @@ class ShowInfoMultiple:
             FROM ww_shows s
             JOIN ww_showlocationmap lm ON lm.showid = s.showid
             JOIN ww_locations l ON l.locationid = lm.locationid
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             JOIN ww_showhostmap hm ON hm.showid = s.showid
             JOIN ww_hosts h ON h.hostid = hm.hostid
             JOIN ww_showskmap skm ON skm.showid = s.showid
@@ -457,6 +462,7 @@ class ShowInfoMultiple:
                 "slug": show.location_slug,
                 "city": show.city,
                 "state": show.state,
+                "state_name": show.state_name,
                 "venue": show.venue,
                 "coordinates": coordinates,
             }


### PR DESCRIPTION
## Application Changes

- Starting with version 2.10.0 of this library, the minimum required version of the Wait Wait Stats Database is 4.7
- Change handling of Host, Panelist and Scorekeeper pronouns to reflect the addition of corresponding pronouns mapping tables introduced with Wait Wait Stats Database version 4.7
- The ``pronouns`` property for Hosts, Panelists and Scorekeepers is now in the form of a list of pronouns strings
- Add ``Pronouns`` class that retrieves information from