### PR TITLE
Use Absolute Imports in Modules, Add Python 3.11 and 3.12 classifiers, Fix Header in Docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,20 @@
 Changes
 *******
 
+2.10.1
+======
+
+Application Changes
+-------------------
+
+* Use absolute imports in each of the module's respective ``__init__.py``
+
+Documentation Changes
+---------------------
+
+* Correct header formatting for ``wwdtm.pronoun.Pronouns``
+
+
 2.10.0
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,16 +5,16 @@ Changes
 2.10.1
 ======
 
-Application Changes
+Development Changes
 -------------------
 
+* Add Python 3.11 and 3.12 version classifiers in ``pyproject.toml``
 * Use absolute imports in each of the module's respective ``__init__.py``
 
 Documentation Changes
 ---------------------
 
 * Correct header formatting for ``wwdtm.pronoun.Pronouns``
-
 
 2.10.0
 ======

--- a/docs/wwdtm/pronoun.rst
+++ b/docs/wwdtm/pronoun.rst
@@ -1,8 +1,8 @@
 .. module:: wwdtm.pronoun
 
-************
+***************
 Module: pronoun
-************
+***************
 
 This module provides objects used to retrieve pronouns information from
 a copy of the Wait Wait Don't Tell Me! Stats database.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,8 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Software Development :: Libraries",
 ]
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.10.0"
+VERSION = "2.10.1"
 
 
 def database_version(

--- a/wwdtm/guest/__init__.py
+++ b/wwdtm/guest/__init__.py
@@ -4,6 +4,6 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Guest module."""
-from .appearances import GuestAppearances
-from .guest import Guest
-from .utility import GuestUtility
+from wwdtm.guest.appearances import GuestAppearances
+from wwdtm.guest.guest import Guest
+from wwdtm.guest.utility import GuestUtility

--- a/wwdtm/host/__init__.py
+++ b/wwdtm/host/__init__.py
@@ -4,6 +4,6 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Host module."""
-from .appearances import HostAppearances
-from .host import Host
-from .utility import HostUtility
+from wwdtm.host.appearances import HostAppearances
+from wwdtm.host.host import Host
+from wwdtm.host.utility import HostUtility

--- a/wwdtm/location/__init__.py
+++ b/wwdtm/location/__init__.py
@@ -4,6 +4,6 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Location module."""
-from .location import Location
-from .recordings import LocationRecordings
-from .utility import LocationUtility
+from wwdtm.location.location import Location
+from wwdtm.location.recordings import LocationRecordings
+from wwdtm.location.utility import LocationUtility

--- a/wwdtm/panelist/__init__.py
+++ b/wwdtm/panelist/__init__.py
@@ -4,9 +4,9 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Panelist module."""
-from .appearances import PanelistAppearances
-from .decimal_scores import PanelistDecimalScores
-from .panelist import Panelist
-from .scores import PanelistScores
-from .statistics import PanelistStatistics
-from .utility import PanelistUtility
+from wwdtm.panelist.appearances import PanelistAppearances
+from wwdtm.panelist.decimal_scores import PanelistDecimalScores
+from wwdtm.panelist.panelist import Panelist
+from wwdtm.panelist.scores import PanelistScores
+from wwdtm.panelist.statistics import PanelistStatistics
+from wwdtm.panelist.utility import PanelistUtility

--- a/wwdtm/pronoun/__init__.py
+++ b/wwdtm/pronoun/__init__.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Pronouns module."""
-from .pronouns import Pronouns
+from wwdtm.pronoun.pronouns import Pronouns

--- a/wwdtm/scorekeeper/__init__.py
+++ b/wwdtm/scorekeeper/__init__.py
@@ -4,6 +4,6 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Scorekeeper module."""
-from .appearances import ScorekeeperAppearances
-from .scorekeeper import Scorekeeper
-from .utility import ScorekeeperUtility
+from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
+from wwdtm.scorekeeper.scorekeeper import Scorekeeper
+from wwdtm.scorekeeper.utility import ScorekeeperUtility

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -4,7 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Show module."""
-from .info import ShowInfo
-from .info_multiple import ShowInfoMultiple
-from .show import Show
-from .utility import ShowUtility
+from wwdtm.show.info import ShowInfo
+from wwdtm.show.info_multiple import ShowInfoMultiple
+from wwdtm.show.show import Show
+from wwdtm.show.utility import ShowUtility


### PR DESCRIPTION
Development Changes
-------------------

* Add Python 3.11 and 3.12 version classifiers in ``pyproject.toml``
* Use absolute imports in each of the module's respective ``__init__.py``

Documentation Changes
---------------------

* Correct header formatting for ``wwdtm.pronoun.Pronouns``