### PR TITLE
Replace MySQL Connector/Python NamedTuple Cursors with Dictionary Cursors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,45 @@
 Changes
 *******
 
+2.12.0-beta
+===========
+
+Application Changes
+-------------------
+
+* Replace all references of ``named_tuple=`` in database cursors to ``dictionary=`` due to cursors using ``NamedTuple`` being marked for deprecation in future versions of MySQL Connector/Python
+* Update code that is impacted by the database cursor type change from ``NamedTuple`` to ``dict``
+* Additional code cleanup
+
+Compoennt Changes
+-----------------
+
+* Upgrade mysql-connector-python from 8.2.0 to 8.4.0
+* Upgrade numpy from 1.26.4 to 2.1.0
+* Upgrade python-slugify from 8.0.1 to 8.0.4
+* Upgrade pytz from 2024.1 to 2024.2
+
+Development Changes
+-------------------
+
+* Upgrade black from 24.4.2 to 24.8.0
+* Upgrade pytest from 8.1.2 to 8.3.3
+* Upgrade ruff from 0.6.7 to 0.6.8
+
+Document Changes
+----------------
+
+* Sync required package versions with main package requirements
+
 2.11.0
 ======
+
+Application Changes
+-------------------
+
+* Fix issues or add exceptions to Pylint errors and warnings
+* Remove an errant semicolon in ``wwdtm.location.location.retrieve_all``
+* Replace "Wait Wait Don't Tell Me! Stats" with "Wait Wait Stats" in docstrings
 
 Development Changes
 -------------------
@@ -15,13 +52,6 @@ Development Changes
 * Upgrade pytest from 8.1.1 to 8.1.2
 * Upgrade ruff from 0.3.6 to 0.6.7
 * Upgrade wheel from 0.43.0 to 0.44.0
-
-Application Changes
--------------------
-
-* Fix issues or add exceptions to Pylint errors and warnings
-* Remove an errant semicolon in ``wwdtm.location.location.retrieve_all``
-* Replace "Wait Wait Don't Tell Me! Stats" with "Wait Wait Stats" in docstrings
 
 Documentation Changes
 ---------------------

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,10 @@
-pytest==8.1.2
-black==24.4.2
+pytest==8.3.3
+black==24.8.0
 
-mysql-connector-python==8.2.0
-numpy==1.26.4
-python-slugify==8.0.1
-pytz==2024.1
+mysql-connector-python==8.4.0
+numpy==2.1.0
+python-slugify==8.0.4
+pytz==2024.2
 
 Sphinx==8.0.2
 sphinx-autobuild==2024.9.19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,10 +20,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "mysql-connector-python==8.2.0",
-    "numpy==1.26.4",
-    "python-slugify==8.0.1",
-    "pytz==2024.1",
+    "mysql-connector-python==8.4.0",
+    "numpy==2.1.0",
+    "python-slugify==8.0.4",
+    "pytz==2024.2",
 ]
 
 [project.urls]
@@ -41,7 +41,7 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "24.4.2"
+required-version = "24.8.0"
 target-version = ["py310", "py311", "py312"]
 line-length = 88
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-ruff==0.6.7
-black==24.4.2
-pytest==8.1.2
+ruff==0.6.8
+black==24.8.0
+pytest==8.3.3
 wheel==0.44.0
 build==1.2.2
 
-mysql-connector-python==8.2.0
-numpy==1.26.4
-python-slugify==8.0.1
-pytz==2024.1
+mysql-connector-python==8.4.0
+numpy==2.1.0
+python-slugify==8.0.4
+pytz==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mysql-connector-python==8.2.0
-numpy==1.26.4
-python-slugify==8.0.1
-pytz==2024.1
+mysql-connector-python==8.4.0
+numpy==2.1.0
+python-slugify==8.0.4
+pytz==2024.2

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.11.0"
+VERSION = "2.12.0-beta"
 
 
 def database_version(
@@ -49,7 +49,7 @@ def database_version(
         if not _database_connection.is_connected():
             _database_connection.reconnect()
 
-    cursor = _database_connection.cursor(named_tuple=True)
+    cursor = _database_connection.cursor(dictionary=True)
     query = """
             SELECT keyname, value
             FROM __metadata
@@ -62,7 +62,7 @@ def database_version(
     if not result:
         return None
 
-    version_info = str(result.value).split(".")
+    version_info = str(result["value"]).split(".")
     if len(version_info) == 3:
         return int(version_info[0]), int(version_info[1]), int(version_info[2])
     elif len(version_info) == 2:

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -63,7 +63,7 @@ class GuestAppearances:
             JOIN ww_shows s ON s.showid = gm.showid
             WHERE gm.guestid = %s ) AS all_shows;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -75,8 +75,8 @@ class GuestAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result.regular_shows,
-                "all_shows": result.all_shows,
+                "regular_shows": result["regular_shows"],
+                "all_shows": ["result.all_shows"],
             }
         else:
             appearance_counts = {
@@ -94,7 +94,7 @@ class GuestAppearances:
             WHERE gm.guestid = %s
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (guest_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -103,12 +103,12 @@ class GuestAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance.show_id,
-                    "date": appearance.date.isoformat(),
-                    "best_of": bool(appearance.best_of),
-                    "repeat_show": bool(appearance.repeat_show_id),
-                    "score": appearance.score,
-                    "score_exception": bool(appearance.score_exception),
+                    "show_id": appearance["show_id"],
+                    "date": appearance["date"].isoformat(),
+                    "best_of": bool(appearance["best_of"]),
+                    "repeat_show": bool(appearance["repeat_show_id"]),
+                    "score": appearance["score"],
+                    "score_exception": bool(appearance["score_exception"]),
                 }
                 appearances.append(info)
 

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -76,7 +76,7 @@ class GuestAppearances:
         if result:
             appearance_counts = {
                 "regular_shows": result["regular_shows"],
-                "all_shows": ["result.all_shows"],
+                "all_shows": result["all_shows"],
             }
         else:
             appearance_counts = {

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -59,7 +59,7 @@ class Guest:
             WHERE guestslug != 'none'
             ORDER BY guest ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -71,9 +71,9 @@ class Guest:
         for row in results:
             guests.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
                 }
             )
 
@@ -92,7 +92,7 @@ class Guest:
             WHERE guestslug != 'none'
             ORDER BY guest ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -104,10 +104,12 @@ class Guest:
         for row in results:
             guests.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "appearances": self.appearances.retrieve_appearances_by_id(
+                        row["id"]
+                    ),
                 }
             )
 
@@ -168,7 +170,7 @@ class Guest:
             WHERE guestid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (guest_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -177,9 +179,9 @@ class Guest:
             return {}
 
         return {
-            "id": result.id,
-            "name": result.name,
-            "slug": result.slug if result.slug else slugify(result.name),
+            "id": result["id"],
+            "name": result["name"],
+            "slug": result["slug"] if result["slug"] else slugify(result["name"]),
         }
 
     def retrieve_by_slug(self, guest_slug: str) -> dict[str, int | str]:

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -62,7 +62,7 @@ class HostAppearances:
             JOIN ww_shows s ON s.showid = hm.showid
             WHERE hm.hostid = %s ) AS all_shows;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -74,8 +74,8 @@ class HostAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result.regular_shows,
-                "all_shows": result.all_shows,
+                "regular_shows": result["regular_shows"],
+                "all_shows": result["all_shows"],
             }
         else:
             appearance_counts = {
@@ -100,11 +100,11 @@ class HostAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance.show_id,
-                    "date": appearance.date.isoformat(),
-                    "best_of": bool(appearance.best_of),
-                    "repeat_show": bool(appearance.repeat_show_id),
-                    "guest": bool(appearance.guest),
+                    "show_id": appearance["show_id"],
+                    "date": appearance["date"].isoformat(),
+                    "best_of": bool(appearance["best_of"]),
+                    "repeat_show": bool(appearance["repeat_show_id"]),
+                    "guest": bool(appearance["guest"]),
                 }
                 appearances.append(info)
 

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -57,7 +57,7 @@ class Host:
             FROM ww_hosts h
             ORDER BY host ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -67,7 +67,7 @@ class Host:
 
         hosts = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -76,17 +76,19 @@ class Host:
                 WHERE hpm.hostid = %s
                 ORDER BY hpm.hostpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
 
             hosts.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
                 }
             )
@@ -108,7 +110,7 @@ class Host:
             FROM ww_hosts h
             ORDER BY host ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -118,7 +120,7 @@ class Host:
 
         hosts = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -127,19 +129,23 @@ class Host:
                 WHERE hpm.hostid = %s
                 ORDER BY hpm.hostpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
 
             hosts.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
-                    "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+                    "appearances": self.appearances.retrieve_appearances_by_id(
+                        row["id"]
+                    ),
                 }
             )
 
@@ -197,7 +203,7 @@ class Host:
             WHERE h.hostid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (host_id,))
         result = cursor.fetchone()
 
@@ -211,17 +217,17 @@ class Host:
             WHERE hpm.hostid = %s
             ORDER BY hpm.hostpronounsmapid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (host_id,))
         results = cursor.fetchall()
         cursor.close()
 
         return {
-            "id": result.id,
-            "name": result.name,
-            "slug": result.slug if result.slug else slugify(result.name),
-            "gender": result.gender,
-            "pronouns": [result.pronouns for result in results] if results else [],
+            "id": result["id"],
+            "name": result["name"],
+            "slug": result["slug"] if result["slug"] else slugify(result["name"]),
+            "gender": result["gender"],
+            "pronouns": [result["pronouns"] for result in results] if results else [],
         }
 
     def retrieve_by_slug(self, host_slug: str) -> dict[str, Any]:

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -67,7 +67,7 @@ class Location:
         else:
             query = query + "ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -77,30 +77,30 @@ class Location:
 
         locations = []
         for row in results:
-            if not row.latitude and not row.longitude:
+            if not row["latitude"] and not row["longitude"]:
                 coordinates = None
             else:
                 coordinates = {
-                    "latitude": row.latitude if row.latitude else None,
-                    "longitude": row.longitude if row.longitude else None,
+                    "latitude": row["latitude"] if row["latitude"] else None,
+                    "longitude": row["longitude"] if row["longitude"] else None,
                 }
 
             locations.append(
                 {
-                    "id": row.id,
-                    "city": row.city,
-                    "state": row.state,
-                    "state_name": row.state_name,
-                    "venue": row.venue,
+                    "id": row["id"],
+                    "city": row["city"],
+                    "state": row["state"],
+                    "state_name": row["state_name"],
+                    "venue": row["venue"],
                     "coordinates": coordinates,
                     "slug": (
-                        row.slug
-                        if row.slug
+                        row["slug"]
+                        if row["slug"]
                         else self.utility.slugify_location(
-                            location_id=row.id,
-                            venue=row.venue,
-                            city=row.city,
-                            state=row.state,
+                            location_id=row["id"],
+                            venue=row["venue"],
+                            city=row["city"],
+                            state=row["state"],
                         )
                     ),
                 }
@@ -128,7 +128,7 @@ class Location:
         else:
             query = query + " ORDER BY pa.name ASC, l.city ASC, l.venue ASC;"
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -138,33 +138,33 @@ class Location:
 
         locations = []
         for row in results:
-            if not row.latitude and not row.longitude:
+            if not row["latitude"] and not row["longitude"]:
                 coordinates = None
             else:
                 coordinates = {
-                    "latitude": row.latitude if row.latitude else None,
-                    "longitude": row.longitude if row.longitude else None,
+                    "latitude": row["latitude"] if row["latitude"] else None,
+                    "longitude": row["longitude"] if row["longitude"] else None,
                 }
 
             locations.append(
                 {
-                    "id": row.id,
-                    "city": row.city,
-                    "state": row.state,
-                    "state_name": row.state_name,
-                    "venue": row.venue,
+                    "id": row["id"],
+                    "city": row["city"],
+                    "state": row["state"],
+                    "state_name": row["state_name"],
+                    "venue": row["venue"],
                     "coordinates": coordinates,
                     "slug": (
-                        row.slug
-                        if row.slug
+                        row["slug"]
+                        if row["slug"]
                         else self.utility.slugify_location(
-                            location_id=row.id,
-                            venue=row.venue,
-                            city=row.city,
-                            state=row.state,
+                            location_id=row["id"],
+                            venue=row["venue"],
+                            city=row["city"],
+                            state=row["state"],
                         )
                     ),
-                    "recordings": self.recordings.retrieve_recordings_by_id(row.id),
+                    "recordings": self.recordings.retrieve_recordings_by_id(row["id"]),
                 }
             )
 
@@ -243,7 +243,7 @@ class Location:
             WHERE l.locationid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (location_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -251,29 +251,29 @@ class Location:
         if not result:
             return {}
 
-        if not result.latitude and not result.longitude:
+        if not result["latitude"] and not result["longitude"]:
             coordinates = None
         else:
             coordinates = {
-                "latitude": result.latitude if result.latitude else None,
-                "longitude": result.longitude if result.longitude else None,
+                "latitude": result["latitude"] if result["latitude"] else None,
+                "longitude": result["longitude"] if result["longitude"] else None,
             }
 
         return {
-            "id": result.id,
-            "city": result.city,
-            "state": result.state,
-            "state_name": result.state_name,
-            "venue": result.venue,
+            "id": result["id"],
+            "city": result["city"],
+            "state": result["state"],
+            "state_name": result["state_name"],
+            "venue": result["venue"],
             "coordinates": coordinates,
             "slug": (
-                result.slug
-                if result.slug
+                result["slug"]
+                if result["slug"]
                 else self.utility.slugify_location(
-                    location_id=result.id,
-                    venue=result.venue,
-                    city=result.city,
-                    state=result.state,
+                    location_id=result["id"],
+                    venue=result["venue"],
+                    city=result["city"],
+                    state=result["state"],
                 )
             ),
         }

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -65,7 +65,7 @@ class LocationRecordings:
             JOIN ww_shows s ON s.showid = lm.showid
             WHERE lm.locationid = %s ) AS all_shows;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -76,8 +76,8 @@ class LocationRecordings:
         result = cursor.fetchone()
 
         recording_counts = {
-            "regular_shows": result.regular_shows,
-            "all_shows": result.all_shows,
+            "regular_shows": result["regular_shows"],
+            "all_shows": result["all_shows"],
         }
 
         query = """
@@ -96,10 +96,10 @@ class LocationRecordings:
             recordings = []
             for recording in results:
                 info = {
-                    "show_id": recording.show_id,
-                    "date": recording.date.isoformat(),
-                    "best_of": bool(recording.best_of),
-                    "repeat_show": bool(recording.repeat_show_id),
+                    "show_id": recording["show_id"],
+                    "date": recording["date"].isoformat(),
+                    "best_of": bool(recording["best_of"]),
+                    "repeat_show": bool(recording["repeat_show_id"]),
                 }
                 recordings.append(info)
 

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -72,7 +72,7 @@ class PanelistAppearances:
             AND pm.panelistscore IS NOT NULL )
             AS shows_with_scores;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -85,9 +85,9 @@ class PanelistAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result.regular_shows,
-                "all_shows": result.all_shows,
-                "shows_with_scores": result.shows_with_scores,
+                "regular_shows": result["regular_shows"],
+                "all_shows": result["all_shows"],
+                "shows_with_scores": result["shows_with_scores"],
             }
         else:
             appearance_counts = {
@@ -108,15 +108,15 @@ class PanelistAppearances:
         cursor.execute(query, (panelist_id,))
         result = cursor.fetchone()
 
-        if result and result.first_id:
+        if result and result["first_id"]:
             first = {
-                "show_id": result.first_id,
-                "show_date": result.first.isoformat(),
+                "show_id": result["first_id"],
+                "show_date": result["first"].isoformat(),
             }
 
             most_recent = {
-                "show_id": result.most_recent_id,
-                "show_date": result.most_recent.isoformat(),
+                "show_id": result["most_recent_id"],
+                "show_date": result["most_recent"].isoformat(),
             }
 
             milestones = {
@@ -170,31 +170,21 @@ class PanelistAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance.show_id,
-                    "date": appearance.date.isoformat(),
-                    "best_of": bool(appearance.best_of),
-                    "repeat_show": bool(appearance.repeat_show_id),
-                    "lightning_round_start": appearance.start,
-                    "lightning_round_start_decimal": (
-                        appearance.start_decimal
-                        if "start_decimal" in appearance._fields
-                        else None
+                    "show_id": appearance["show_id"],
+                    "date": appearance["date"].isoformat(),
+                    "best_of": bool(appearance["best_of"]),
+                    "repeat_show": bool(appearance["repeat_show_id"]),
+                    "lightning_round_start": appearance["start"],
+                    "lightning_round_start_decimal": appearance.get(
+                        "start_decimal", None
                     ),
-                    "lightning_round_correct": appearance.correct,
-                    "lightning_round_correct_decimal": (
-                        appearance.correct_decimal
-                        if "correct_decimal" in appearance._fields
-                        else None
+                    "lightning_round_correct": appearance["correct"],
+                    "lightning_round_correct_decimal": appearance.get(
+                        "correct_decimal", None
                     ),
-                    "score": appearance.score,
-                    "score_decimal": (
-                        appearance.score_decimal
-                        if "score_decimal" in appearance._fields
-                        else None
-                    ),
-                    "rank": (
-                        appearance.pnl_rank if appearance.pnl_rank is not None else None
-                    ),
+                    "score": appearance["score"],
+                    "score_decimal": appearance.get("score_decimal", None),
+                    "rank": appearance.get("pnl_rank", None),
                 }
                 appearances.append(info)
 
@@ -240,7 +230,7 @@ class PanelistAppearances:
             FROM ww_shows s
             ORDER BY YEAR(s.showdate) ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
 
@@ -249,7 +239,7 @@ class PanelistAppearances:
 
         years = {}
         for row in results:
-            years[row.year] = 0
+            years[row["year"]] = 0
 
         query = """
             SELECT YEAR(s.showdate) AS year,
@@ -270,7 +260,7 @@ class PanelistAppearances:
             return {}
 
         for row in results:
-            years[row.year] = row.count
+            years[row["year"]] = row["count"]
 
         return years
 

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -54,7 +54,7 @@ class PanelistDecimalScores:
             return []
 
         scores = []
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         query = """
             SELECT pm.panelistscore_decimal AS score
             FROM ww_showpnlmap pm
@@ -71,8 +71,8 @@ class PanelistDecimalScores:
             return []
 
         for appearance in result:
-            if appearance.score:
-                scores.append(appearance.score)
+            if appearance["score"]:
+                scores.append(appearance["score"])
 
         return scores
 
@@ -100,7 +100,7 @@ class PanelistDecimalScores:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         query = """
             SELECT MIN(pm.panelistscore_decimal) AS min,
             MAX(pm.panelistscore_decimal) AS max
@@ -113,8 +113,8 @@ class PanelistDecimalScores:
         if not result:
             return {}
 
-        min_score = result.min
-        max_score = result.max
+        min_score = result["min"]
+        max_score = result["max"]
 
         scores = {}
         for score in range(floor(min_score), floor(max_score) + 1):
@@ -142,7 +142,7 @@ class PanelistDecimalScores:
             return {}
 
         for row in results:
-            scores[f"{Decimal(row.score).normalize():f}"] = row.score_count
+            scores[f"{Decimal(row["score"]).normalize():f}"] = row["score_count"]
 
         return {
             "score": list(scores.keys()),
@@ -176,7 +176,7 @@ class PanelistDecimalScores:
         if not valid_int_id(panelist_id):
             return []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         query = """
             SELECT MIN(pm.panelistscore_decimal) AS min,
             MAX(pm.panelistscore_decimal) AS max
@@ -188,8 +188,8 @@ class PanelistDecimalScores:
         if not result:
             return []
 
-        min_score = result.min
-        max_score = result.max
+        min_score = result["min"]
+        max_score = result["max"]
 
         scores = {}
         for score in range(floor(min_score), floor(max_score) + 1):
@@ -217,7 +217,7 @@ class PanelistDecimalScores:
             return []
 
         for row in results:
-            scores[f"{Decimal(row.score).normalize():f}"] = row.score_count
+            scores[f"{Decimal(row["score"]).normalize():f}"] = row["score_count"]
 
         return list(scores.items())
 
@@ -250,7 +250,7 @@ class PanelistDecimalScores:
         if not valid_int_id(panelist_id):
             return {}
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         query = """
             SELECT s.showdate AS date, pm.panelistscore_decimal AS score
             FROM ww_showpnlmap pm
@@ -270,8 +270,8 @@ class PanelistDecimalScores:
         show_list = []
         score_list = []
         for shows in results:
-            show_list.append(shows.date.isoformat())
-            score_list.append(shows.score)
+            show_list.append(shows["date"].isoformat())
+            score_list.append(shows["score"])
 
         return {
             "shows": show_list,
@@ -306,7 +306,7 @@ class PanelistDecimalScores:
         if not valid_int_id(panelist_id):
             return []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         query = """
             SELECT s.showdate AS date, pm.panelistscore_decimal AS score
             FROM ww_showpnlmap pm
@@ -325,8 +325,8 @@ class PanelistDecimalScores:
 
         scores = []
         for show in results:
-            show_date = show.date.isoformat()
-            score = show.score
+            show_date = show["date"].isoformat()
+            score = show["score"]
             scores.append((show_date, score))
 
         return scores

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -64,7 +64,7 @@ class Panelist:
             WHERE panelistslug != 'multiple'
             ORDER BY panelist ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -74,7 +74,7 @@ class Panelist:
 
         panelists = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -83,17 +83,19 @@ class Panelist:
                 WHERE ppm.panelistid = %s
                 ORDER BY ppm.panelistpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
 
             panelists.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
                 }
             )
@@ -118,7 +120,7 @@ class Panelist:
             WHERE panelistslug != 'multiple'
             ORDER BY panelist ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -128,7 +130,7 @@ class Panelist:
 
         panelists = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -137,23 +139,25 @@ class Panelist:
                 WHERE ppm.panelistid = %s
                 ORDER BY ppm.panelistpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
             panelists.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
                     "statistics": self.statistics.retrieve_statistics_by_id(
-                        row.id, include_decimal_scores=use_decimal_scores
+                        row["id"], include_decimal_scores=use_decimal_scores
                     ),
-                    "bluffs": self.statistics.retrieve_bluffs_by_id(row.id),
+                    "bluffs": self.statistics.retrieve_bluffs_by_id(row["id"]),
                     "appearances": self.appearances.retrieve_appearances_by_id(
-                        row.id, use_decimal_scores=use_decimal_scores
+                        row["id"], use_decimal_scores=use_decimal_scores
                     ),
                 }
             )
@@ -217,7 +221,7 @@ class Panelist:
             WHERE p.panelistid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (panelist_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -232,17 +236,17 @@ class Panelist:
             WHERE ppm.panelistid = %s
             ORDER BY ppm.panelistpronounsmapid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
 
         return {
-            "id": result.id,
-            "name": result.name,
-            "slug": result.slug if result.slug else slugify(result.name),
-            "gender": result.gender,
-            "pronouns": [result.pronouns for result in results] if results else [],
+            "id": result["id"],
+            "name": result["name"],
+            "slug": result["slug"] if result["slug"] else slugify(result["name"]),
+            "gender": result["gender"],
+            "pronouns": [result["pronouns"] for result in results] if results else [],
         }
 
     def retrieve_by_slug(self, panelist_slug: str) -> dict[str, Any]:

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -59,7 +59,7 @@ class PanelistScores:
             AND s.bestof = 0 and s.repeatshowid IS NULL
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (panelist_id,))
         result = cursor.fetchall()
         cursor.close()
@@ -69,8 +69,8 @@ class PanelistScores:
 
         scores = []
         for appearance in result:
-            if appearance.score:
-                scores.append(appearance.score)
+            if appearance["score"]:
+                scores.append(appearance["score"])
 
         return scores
 
@@ -104,15 +104,15 @@ class PanelistScores:
             FROM ww_showpnlmap pm
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         result = cursor.fetchone()
 
         if not result:
             return {}
 
-        min_score = result.min
-        max_score = result.max
+        min_score = result["min"]
+        max_score = result["max"]
 
         scores = {}
         for score in range(min_score, max_score + 1):
@@ -137,7 +137,7 @@ class PanelistScores:
             return {}
 
         for row in results:
-            scores[row.score] = row.score_count
+            scores[row["score"]] = row["score_count"]
 
         return {
             "score": list(scores.keys()),
@@ -175,15 +175,15 @@ class PanelistScores:
             MAX(pm.panelistscore) AS max
             FROM ww_showpnlmap pm;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         result = cursor.fetchone()
 
         if not result:
             return []
 
-        min_score = result.min
-        max_score = result.max
+        min_score = result["min"]
+        max_score = result["max"]
 
         scores = {}
         for score in range(min_score, max_score + 1):
@@ -208,7 +208,7 @@ class PanelistScores:
             return []
 
         for row in results:
-            scores[row.score] = row.score_count
+            scores[row["score"]] = row["score_count"]
 
         return list(scores.items())
 
@@ -249,7 +249,7 @@ class PanelistScores:
             AND pm.panelistscore IS NOT NULL
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -260,8 +260,8 @@ class PanelistScores:
         show_list = []
         score_list = []
         for shows in results:
-            show_list.append(shows.date.isoformat())
-            score_list.append(shows.score)
+            show_list.append(shows["date"].isoformat())
+            score_list.append(shows["score"])
 
         return {
             "shows": show_list,
@@ -304,7 +304,7 @@ class PanelistScores:
             AND pm.panelistscore IS NOT NULL
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (panelist_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -314,8 +314,8 @@ class PanelistScores:
 
         scores = []
         for show in results:
-            show_date = show.date.isoformat()
-            score = show.score
+            show_date = show["date"].isoformat()
+            score = show["score"]
             scores.append((show_date, score))
 
         return scores

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -69,7 +69,7 @@ class PanelistStatistics:
             WHERE s.repeatshowid IS NULL AND blm.correctbluffpnlid = %s
             ) AS correct;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -84,8 +84,8 @@ class PanelistStatistics:
             return {}
 
         return {
-            "chosen": result.chosen,
-            "correct": result.correct,
+            "chosen": result["chosen"],
+            "correct": result["correct"],
         }
 
     def retrieve_bluffs_by_slug(self, panelist_slug: str) -> dict[str, int]:
@@ -136,7 +136,7 @@ class PanelistStatistics:
             s.bestof = 0 and s.repeatshowid IS NULL
             ) as 'third';
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -154,11 +154,11 @@ class PanelistStatistics:
             return {}
 
         return {
-            "first": result.first,
-            "first_tied": result.first_tied,
-            "second": result.second,
-            "second_tied": result.second_tied,
-            "third": result.third,
+            "first": result["first"],
+            "first_tied": result["first_tied"],
+            "second": result["second"],
+            "second_tied": result["second_tied"],
+            "third": result["third"],
         }
 
     def retrieve_rank_info_by_slug(self, panelist_slug: str) -> dict[str, int]:

--- a/wwdtm/pronoun/pronouns.py
+++ b/wwdtm/pronoun/pronouns.py
@@ -47,7 +47,7 @@ class Pronouns:
             FROM ww_pronouns
             ORDER BY pronounsid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -57,7 +57,12 @@ class Pronouns:
 
         pronouns = []
         for row in results:
-            pronouns.append({"id": row.pronounsid, "pronouns": row.pronouns})
+            pronouns.append(
+                {
+                    "id": row["pronounsid"],
+                    "pronouns": row["pronouns"],
+                }
+            )
 
         return pronouns
 
@@ -66,7 +71,7 @@ class Pronouns:
 
         :return: A list of pronouns IDs as integers
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=False)
         query = """
             SELECT pronounsid
             FROM ww_pronouns
@@ -79,7 +84,7 @@ class Pronouns:
         if not results:
             return []
 
-        return [row.pronounsid for row in results]
+        return [row[0] for row in results]
 
     def retrieve_all_as_dict(self) -> dict[int, str]:
         """Retrieves all pronouns as a dictionary.
@@ -92,7 +97,7 @@ class Pronouns:
             FROM ww_pronouns
             ORDER BY pronounsid ASC;
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -100,7 +105,7 @@ class Pronouns:
         if not results:
             return {}
 
-        return {row.pronounsid: row.pronouns for row in results}
+        return {row["pronounsid"]: row["pronouns"] for row in results}
 
     def retrieve_all_pronouns(self) -> list[str]:
         """Retrieves all pronouns names.
@@ -112,7 +117,7 @@ class Pronouns:
             FROM ww_pronouns
             ORDER BY pronounsid ASC;
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -120,7 +125,7 @@ class Pronouns:
         if not results:
             return []
 
-        return [row.pronouns for row in results]
+        return [row[0] for row in results]
 
     def retrieve_by_id(self, pronouns_id: int) -> dict[int, str]:
         """Retrieves pronouns information.
@@ -135,7 +140,7 @@ class Pronouns:
             WHERE pronounsid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (pronouns_id,))
         result = cursor.fetchone()
 
@@ -143,6 +148,6 @@ class Pronouns:
             return {}
 
         return {
-            "id": result.pronounsid,
-            "pronouns": result.pronouns,
+            "id": result["pronounsid"],
+            "pronouns": result["pronouns"],
         }

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -62,7 +62,7 @@ class ScorekeeperAppearances:
             JOIN ww_shows s ON s.showid = skm.showid
             WHERE skm.scorekeeperid = %s ) AS all_shows;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(
             query,
             (
@@ -74,8 +74,8 @@ class ScorekeeperAppearances:
 
         if result:
             appearance_counts = {
-                "regular_shows": result.regular_shows,
-                "all_shows": result.all_shows,
+                "regular_shows": result["regular_shows"],
+                "all_shows": result["all_shows"],
             }
         else:
             appearance_counts = {
@@ -101,12 +101,12 @@ class ScorekeeperAppearances:
             appearances = []
             for appearance in results:
                 info = {
-                    "show_id": appearance.show_id,
-                    "date": appearance.date.isoformat(),
-                    "best_of": bool(appearance.best_of),
-                    "repeat_show": bool(appearance.repeat_show_id),
-                    "guest": bool(appearance.guest),
-                    "description": appearance.description,
+                    "show_id": appearance["show_id"],
+                    "date": appearance["date"].isoformat(),
+                    "best_of": bool(appearance["best_of"]),
+                    "repeat_show": bool(appearance["repeat_show_id"]),
+                    "guest": bool(appearance["guest"]),
+                    "description": appearance["description"],
                 }
                 appearances.append(info)
 

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -59,7 +59,7 @@ class Scorekeeper:
             FROM ww_scorekeepers sk
             ORDER BY scorekeeper ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -69,7 +69,7 @@ class Scorekeeper:
 
         scorekeepers = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -78,17 +78,19 @@ class Scorekeeper:
                 WHERE spm.scorekeeperid = %s
                 ORDER BY spm.skpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
 
             scorekeepers.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
                 }
             )
@@ -108,7 +110,7 @@ class Scorekeeper:
             FROM ww_scorekeepers sk
             ORDER BY scorekeeper ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -118,7 +120,7 @@ class Scorekeeper:
 
         scorekeepers = []
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         for row in results:
             query = """
                 SELECT pn.pronouns
@@ -127,19 +129,23 @@ class Scorekeeper:
                 WHERE spm.scorekeeperid = %s
                 ORDER BY spm.skpronounsmapid ASC;
                 """
-            cursor.execute(query, (row.id,))
+            cursor.execute(query, (row["id"],))
             pn_results = cursor.fetchall()
 
             scorekeepers.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "gender": row.gender,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "gender": row["gender"],
                     "pronouns": (
-                        [result.pronouns for result in pn_results] if pn_results else []
+                        [result["pronouns"] for result in pn_results]
+                        if pn_results
+                        else []
                     ),
-                    "appearances": self.appearances.retrieve_appearances_by_id(row.id),
+                    "appearances": self.appearances.retrieve_appearances_by_id(
+                        row["id"]
+                    ),
                 }
             )
 
@@ -198,7 +204,7 @@ class Scorekeeper:
             WHERE sk.scorekeeperid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (scorekeeper_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -213,17 +219,17 @@ class Scorekeeper:
             WHERE spm.scorekeeperid = %s
             ORDER BY spm.skpronounsmapid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (scorekeeper_id,))
         results = cursor.fetchall()
         cursor.close()
 
         return {
-            "id": result.id,
-            "name": result.name,
-            "slug": result.slug if result.slug else slugify(result.name),
-            "gender": result.gender,
-            "pronouns": [result.pronouns for result in results] if results else [],
+            "id": result["id"],
+            "name": result["name"],
+            "slug": result["slug"] if result["slug"] else slugify(result["name"]),
+            "gender": result["gender"],
+            "pronouns": [result["pronouns"] for result in results] if results else [],
         }
 
     def retrieve_by_slug(self, scorekeeper_slug: str) -> dict[str, Any]:

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -57,7 +57,7 @@ class ShowInfo:
             FROM ww_panelists
             ORDER BY panelistid ASC;
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -67,9 +67,9 @@ class ShowInfo:
 
         panelists = {}
         for row in results:
-            panelists[row.panelistid] = {
-                "name": row.panelist,
-                "slug": row.panelistslug,
+            panelists[row["panelistid"]] = {
+                "name": row["panelist"],
+                "slug": row["panelistslug"],
             }
 
         return panelists
@@ -92,7 +92,7 @@ class ShowInfo:
             WHERE showid = %s
             ORDER BY segment ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (show_id,))
         result = cursor.fetchall()
 
@@ -101,42 +101,42 @@ class ShowInfo:
 
         bluffs = []
         for row in result:
-            if not row.chosen_id and not row.correct_id:
+            if not row["chosen_id"] and not row["correct_id"]:
                 bluffs.append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": None,
                     }
                 )
-            elif row.chosen_id and not row.correct_id:
+            elif row["chosen_id"] and not row["correct_id"]:
                 bluffs.append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": None,
                     }
                 )
-            elif row.correct_id and not row.chosen_id:
+            elif row["correct_id"] and not row["chosen_id"]:
                 bluffs.append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
@@ -144,23 +144,23 @@ class ShowInfo:
             else:
                 bluffs.append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
@@ -205,7 +205,7 @@ class ShowInfo:
             WHERE s.showid = %s
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (show_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -213,70 +213,72 @@ class ShowInfo:
         if not result:
             return {}
 
-        if not result.latitude and not result.longitude:
+        if not result["latitude"] and not result["longitude"]:
             coordinates = None
         else:
             coordinates = {
-                "latitude": result.latitude if result.latitude else None,
-                "longitude": result.longitude if result.longitude else None,
+                "latitude": result["latitude"] if result["latitude"] else None,
+                "longitude": result["longitude"] if result["longitude"] else None,
             }
 
         location_info = {
-            "id": result.location_id,
-            "slug": result.location_slug,
-            "city": result.city,
-            "state": result.state,
-            "state_name": result.state_name,
-            "venue": result.venue,
+            "id": result["location_id"],
+            "slug": result["location_slug"],
+            "city": result["city"],
+            "state": result["state"],
+            "state_name": result["state_name"],
+            "venue": result["venue"],
             "coordinates": coordinates if coordinates else None,
         }
 
-        if not result.location_slug:
+        if not result["location_slug"]:
             location_info["slug"] = self.loc_util.slugify_location(
-                location_id=result.location_id,
-                venue=result.venue,
-                city=result.city,
-                state=result.state,
+                location_id=result["location_id"],
+                venue=result["venue"],
+                city=result["city"],
+                state=result["state"],
             )
 
         host_info = {
-            "id": result.host_id,
-            "name": result.host,
-            "slug": result.host_slug if result.host_slug else slugify(result.host),
-            "guest": bool(result.host_guest),
+            "id": result["host_id"],
+            "name": result["host"],
+            "slug": (
+                result["host_slug"] if result["host_slug"] else slugify(result["host"])
+            ),
+            "guest": bool(result["host_guest"]),
         }
 
         scorekeeper_info = {
-            "id": result.scorekeeper_id,
-            "name": result.scorekeeper,
+            "id": result["scorekeeper_id"],
+            "name": result["scorekeeper"],
             "slug": (
-                result.scorekeeper_slug
-                if result.scorekeeper_slug
-                else slugify(result.scorekeeper)
+                result["scorekeeper_slug"]
+                if result["scorekeeper_slug"]
+                else slugify(result["scorekeeper"])
             ),
-            "guest": bool(result.scorekeeper_guest),
+            "guest": bool(result["scorekeeper_guest"]),
             "description": (
-                result.scorekeeper_description
-                if result.scorekeeper_description
+                result["scorekeeper_description"]
+                if result["scorekeeper_description"]
                 else None
             ),
         }
 
-        if result.show_description:
-            description = str(result.show_description).strip()
+        if result["show_description"]:
+            description = str(result["show_description"]).strip()
         else:
             description = None
 
-        notes = str(result.show_notes).strip() if result.show_notes else None
+        notes = str(result["show_notes"]).strip() if result["show_notes"] else None
 
         show_info = {
-            "id": result.show_id,
-            "date": result.date.isoformat(),
-            "best_of": bool(result.best_of),
-            "repeat_show": bool(result.repeat_show_id),
+            "id": result["show_id"],
+            "date": result["date"].isoformat(),
+            "best_of": bool(result["best_of"]),
+            "repeat_show": bool(result["repeat_show_id"]),
             "original_show_id": None,
             "original_show_date": None,
-            "show_url": result.show_url,
+            "show_url": result["show_url"],
             "description": description,
             "notes": notes,
             "location": location_info,
@@ -284,7 +286,7 @@ class ShowInfo:
             "scorekeeper": scorekeeper_info,
         }
 
-        repeat_show_id = result.repeat_show_id
+        repeat_show_id = result["repeat_show_id"]
         if repeat_show_id:
             original_date = self.utility.convert_id_to_date(repeat_show_id)
             show_info["original_show_id"] = repeat_show_id
@@ -315,7 +317,7 @@ class ShowInfo:
             WHERE gm.showid = %s
             ORDER by gm.showguestmapid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (show_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -327,11 +329,11 @@ class ShowInfo:
         for guest in results:
             guests.append(
                 {
-                    "id": guest.id,
-                    "name": guest.name,
-                    "slug": guest.slug if guest.slug else slugify(guest.name),
-                    "score": guest.score,
-                    "score_exception": bool(guest.score_exception),
+                    "id": guest["id"],
+                    "name": guest["name"],
+                    "slug": guest["slug"] if guest["slug"] else slugify(guest["name"]),
+                    "score": guest["score"],
+                    "score_exception": bool(guest["score_exception"]),
                 }
             )
 
@@ -381,7 +383,7 @@ class ShowInfo:
                 ORDER by pm.panelistscore DESC, pm.showpnlmapid ASC;
                 """
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (show_id,))
         results = cursor.fetchall()
         cursor.close()
@@ -393,24 +395,16 @@ class ShowInfo:
         for row in results:
             panelists.append(
                 {
-                    "id": row.id,
-                    "name": row.name,
-                    "slug": row.slug if row.slug else slugify(row.name),
-                    "lightning_round_start": row.start,
-                    "lightning_round_start_decimal": (
-                        row.start_decimal if "start_decimal" in row._fields else None
-                    ),
-                    "lightning_round_correct": row.correct,
-                    "lightning_round_correct_decimal": (
-                        row.correct_decimal
-                        if "correct_decimal" in row._fields
-                        else None
-                    ),
-                    "score": row.score,
-                    "score_decimal": (
-                        row.score_decimal if "score_decimal" in row._fields else None
-                    ),
-                    "rank": row.pnl_rank if row.pnl_rank else None,
+                    "id": row["id"],
+                    "name": row["name"],
+                    "slug": row["slug"] if row["slug"] else slugify(row["name"]),
+                    "lightning_round_start": row["start"],
+                    "lightning_round_start_decimal": row.get("start_decimal", None),
+                    "lightning_round_correct": row["correct"],
+                    "lightning_round_correct_decimal": row.get("correct_decimal", None),
+                    "score": row["score"],
+                    "score_decimal": row.get("score_decimal", None),
+                    "rank": row["pnl_rank"] if row["pnl_rank"] else None,
                 }
             )
 

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -58,7 +58,7 @@ class ShowInfoMultiple:
             FROM ww_panelists
             ORDER BY panelistid ASC;
         """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -68,9 +68,9 @@ class ShowInfoMultiple:
 
         panelists = {}
         for row in results:
-            panelists[row.panelistid] = {
-                "name": row.panelist,
-                "slug": row.panelistslug,
+            panelists[row["panelistid"]] = {
+                "name": row["panelist"],
+                "slug": row["panelistslug"],
             }
 
         return panelists
@@ -89,7 +89,7 @@ class ShowInfoMultiple:
             JOIN ww_shows s on s.showid = blm.showid
             ORDER BY s.showid ASC, blm.segment ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -99,69 +99,69 @@ class ShowInfoMultiple:
 
         bluff_info = {}
         for row in results:
-            if row.showid not in bluff_info:
-                bluff_info[row.showid] = []
+            if row["showid"] not in bluff_info:
+                bluff_info[row["showid"]] = []
 
-            if not row.chosen_id and not row.correct_id:
-                bluff_info[row.showid].append(
+            if not row["chosen_id"] and not row["correct_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": None,
                     }
                 )
-            elif row.chosen_id and not row.correct_id:
-                bluff_info[row.showid].append(
+            elif row["chosen_id"] and not row["correct_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": None,
                     }
                 )
-            elif row.correct_id and not row.chosen_id:
-                bluff_info[row.showid].append(
+            elif row["correct_id"] and not row["chosen_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
                 )
             else:
-                bluff_info[row.showid].append(
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
@@ -191,7 +191,7 @@ class ShowInfoMultiple:
             ORDER BY showid ASC, segment ASC;""".format(
             ids=", ".join(str(v) for v in show_ids)
         )
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -201,69 +201,69 @@ class ShowInfoMultiple:
 
         bluff_info = {}
         for row in results:
-            if row.showid not in bluff_info:
-                bluff_info[row.showid] = []
+            if row["showid"] not in bluff_info:
+                bluff_info[row["showid"]] = []
 
-            if not row.chosen_id and not row.correct_id:
-                bluff_info[row.showid].append(
+            if not row["chosen_id"] and not row["correct_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": None,
                     }
                 )
-            elif row.chosen_id and not row.correct_id:
-                bluff_info[row.showid].append(
+            elif row["chosen_id"] and not row["correct_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": None,
                     }
                 )
-            elif row.correct_id and not row.chosen_id:
-                bluff_info[row.showid].append(
+            elif row["correct_id"] and not row["chosen_id"]:
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": None,
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
                 )
             else:
-                bluff_info[row.showid].append(
+                bluff_info[row["showid"]].append(
                     {
-                        "segment": row.segment,
+                        "segment": row["segment"],
                         "chosen_panelist": {
-                            "id": row.chosen_id,
-                            "name": self.panelists[row.chosen_id]["name"],
+                            "id": row["chosen_id"],
+                            "name": self.panelists[row["chosen_id"]]["name"],
                             "slug": (
-                                self.panelists[row.chosen_id]["slug"]
-                                if self.panelists[row.chosen_id]["slug"]
-                                else slugify(self.panelists[row.chosen_id]["name"])
+                                self.panelists[row["chosen_id"]]["slug"]
+                                if self.panelists[row["chosen_id"]]["slug"]
+                                else slugify(self.panelists[row["chosen_id"]]["name"])
                             ),
                         },
                         "correct_panelist": {
-                            "id": row.correct_id,
-                            "name": self.panelists[row.correct_id]["name"],
+                            "id": row["correct_id"],
+                            "name": self.panelists[row["correct_id"]]["name"],
                             "slug": (
-                                self.panelists[row.correct_id]["slug"]
-                                if self.panelists[row.correct_id]["slug"]
-                                else slugify(self.panelists[row.correct_id]["name"])
+                                self.panelists[row["correct_id"]]["slug"]
+                                if self.panelists[row["correct_id"]]["slug"]
+                                else slugify(self.panelists[row["correct_id"]]["name"])
                             ),
                         },
                     }
@@ -304,7 +304,7 @@ class ShowInfoMultiple:
             JOIN ww_shownotes sn ON sn.showid = s.showid
             ORDER BY s.showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -314,70 +314,72 @@ class ShowInfoMultiple:
 
         shows = {}
         for show in results:
-            if not show.latitude and not show.longitude:
+            if not show["latitude"] and not show["longitude"]:
                 coordinates = None
             else:
                 coordinates = {
-                    "latitude": show.latitude if show.latitude else None,
-                    "longitude": show.longitude if show.longitude else None,
+                    "latitude": show["latitude"] if show["latitude"] else None,
+                    "longitude": show["longitude"] if show["longitude"] else None,
                 }
 
             location_info = {
-                "id": show.location_id,
-                "slug": show.location_slug,
-                "city": show.city,
-                "state": show.state,
-                "state_name": show.state_name,
-                "venue": show.venue,
+                "id": show["location_id"],
+                "slug": show["location_slug"],
+                "city": show["city"],
+                "state": show["state"],
+                "state_name": show["state_name"],
+                "venue": show["venue"],
                 "coordinates": coordinates,
             }
 
-            if not show.location_slug:
+            if not show["location_slug"]:
                 location_info["slug"] = self.loc_util.slugify_location(
-                    location_id=show.location_id,
-                    venue=show.venue,
-                    city=show.city,
-                    state=show.state,
+                    location_id=show["location_id"],
+                    venue=show["venue"],
+                    city=show["city"],
+                    state=show["state"],
                 )
 
             host_info = {
-                "id": show.host_id,
-                "name": show.host,
-                "slug": show.host_slug if show.host_slug else slugify(show.host),
-                "guest": bool(show.host_guest),
+                "id": show["host_id"],
+                "name": show["host"],
+                "slug": (
+                    show["host_slug"] if show["host_slug"] else slugify(show["host"])
+                ),
+                "guest": bool(show["host_guest"]),
             }
 
             scorekeeper_info = {
-                "id": show.scorekeeper_id,
-                "name": show.scorekeeper,
+                "id": show["scorekeeper_id"],
+                "name": show["scorekeeper"],
                 "slug": (
-                    show.scorekeeper_slug
-                    if show.scorekeeper_slug
-                    else slugify(show.scorekeeper)
+                    show["scorekeeper_slug"]
+                    if show["scorekeeper_slug"]
+                    else slugify(show["scorekeeper"])
                 ),
-                "guest": bool(show.scorekeeper_guest),
+                "guest": bool(show["scorekeeper_guest"]),
                 "description": (
-                    show.scorekeeper_description
-                    if show.scorekeeper_description
+                    show["scorekeeper_description"]
+                    if show["scorekeeper_description"]
                     else None
                 ),
             }
 
-            if show.show_description:
-                description = str(show.show_description).strip()
+            if show["show_description"]:
+                description = str(show["show_description"]).strip()
             else:
                 description = None
 
-            notes = str(show.show_notes).strip() if show.show_notes else None
+            notes = str(show["show_notes"]).strip() if show["show_notes"] else None
 
             show_info = {
-                "id": show.show_id,
-                "date": show.date.isoformat(),
-                "best_of": bool(show.best_of),
-                "repeat_show": bool(show.repeat_show_id),
+                "id": show["show_id"],
+                "date": show["date"].isoformat(),
+                "best_of": bool(show["best_of"]),
+                "repeat_show": bool(show["repeat_show_id"]),
                 "original_show_id": None,
                 "original_show_date": None,
-                "show_url": show.show_url,
+                "show_url": show["show_url"],
                 "description": description,
                 "notes": notes,
                 "location": location_info,
@@ -385,7 +387,7 @@ class ShowInfoMultiple:
                 "scorekeeper": scorekeeper_info,
             }
 
-            repeat_show_id = show.repeat_show_id
+            repeat_show_id = show["repeat_show_id"]
             if repeat_show_id:
                 original_date = self.utility.convert_id_to_date(repeat_show_id)
                 show_info["original_show_id"] = repeat_show_id
@@ -394,7 +396,7 @@ class ShowInfoMultiple:
                 show_info.pop("original_show_id", None)
                 show_info.pop("original_show_date", None)
 
-            shows[show.show_id] = show_info
+            shows[show["show_id"]] = show_info
 
         return shows
 
@@ -440,7 +442,7 @@ class ShowInfoMultiple:
             ORDER BY s.showdate ASC;""".format(
             ids=", ".join(str(v) for v in show_ids)
         )
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -450,70 +452,72 @@ class ShowInfoMultiple:
 
         shows = {}
         for show in results:
-            if not show.latitude and not show.longitude:
+            if not show["latitude"] and not show["longitude"]:
                 coordinates = None
             else:
                 coordinates = {
-                    "latitude": show.latitude if show.latitude else None,
-                    "longitude": show.longitude if show.longitude else None,
+                    "latitude": show["latitude"] if show["latitude"] else None,
+                    "longitude": show["longitude"] if show["longitude"] else None,
                 }
 
             location_info = {
-                "id": show.location_id,
-                "slug": show.location_slug,
-                "city": show.city,
-                "state": show.state,
-                "state_name": show.state_name,
-                "venue": show.venue,
+                "id": show["location_id"],
+                "slug": show["location_slug"],
+                "city": show["city"],
+                "state": show["state"],
+                "state_name": show["state_name"],
+                "venue": show["venue"],
                 "coordinates": coordinates,
             }
 
-            if not show.location_slug:
+            if not show["location_slug"]:
                 location_info["slug"] = self.loc_util.slugify_location(
-                    location_id=show.location_id,
-                    venue=show.venue,
-                    city=show.city,
-                    state=show.state,
+                    location_id=show["location_id"],
+                    venue=show["venue"],
+                    city=show["city"],
+                    state=show["state"],
                 )
 
             host_info = {
-                "id": show.host_id,
-                "name": show.host,
-                "slug": show.host_slug if show.host_slug else slugify(show.host),
-                "guest": bool(show.host_guest),
+                "id": show["host_id"],
+                "name": show["host"],
+                "slug": (
+                    show["host_slug"] if show["host_slug"] else slugify(show["host"])
+                ),
+                "guest": bool(show["host_guest"]),
             }
 
             scorekeeper_info = {
-                "id": show.scorekeeper_id,
-                "name": show.scorekeeper,
+                "id": show["scorekeeper_id"],
+                "name": show["scorekeeper"],
                 "slug": (
-                    show.scorekeeper_slug
-                    if show.scorekeeper_slug
-                    else slugify(show.scorekeeper)
+                    show["scorekeeper_slug"]
+                    if show["scorekeeper_slug"]
+                    else slugify(show["scorekeeper"])
                 ),
-                "guest": bool(show.scorekeeper_guest),
+                "guest": bool(show["scorekeeper_guest"]),
                 "description": (
-                    show.scorekeeper_description
-                    if show.scorekeeper_description
+                    show["scorekeeper_description"]
+                    if show["scorekeeper_description"]
                     else None
                 ),
             }
 
-            if show.show_description:
-                description = str(show.show_description).strip()
+            if show["show_description"]:
+                description = str(show["show_description"]).strip()
             else:
                 description = None
 
-            notes = str(show.show_notes).strip() if show.show_notes else None
+            notes = str(show["show_notes"]).strip() if show["show_notes"] else None
 
             show_info = {
-                "id": show.show_id,
-                "date": show.date.isoformat(),
-                "best_of": bool(show.best_of),
-                "repeat_show": bool(show.repeat_show_id),
+                "id": show["show_id"],
+                "date": show["date"].isoformat(),
+                "best_of": bool(show["best_of"]),
+                "repeat_show": bool(show["repeat_show_id"]),
                 "original_show_id": None,
                 "original_show_date": None,
-                "show_url": show.show_url,
+                "show_url": show["show_url"],
                 "description": description,
                 "notes": notes,
                 "location": location_info,
@@ -521,7 +525,7 @@ class ShowInfoMultiple:
                 "scorekeeper": scorekeeper_info,
             }
 
-            repeat_show_id = show.repeat_show_id
+            repeat_show_id = show["repeat_show_id"]
             if repeat_show_id:
                 original_date = self.utility.convert_id_to_date(repeat_show_id)
                 show_info["original_show_id"] = repeat_show_id
@@ -530,7 +534,7 @@ class ShowInfoMultiple:
                 show_info.pop("original_show_id", None)
                 show_info.pop("original_show_date", None)
 
-            shows[show.show_id] = show_info
+            shows[show["show_id"]] = show_info
 
         return shows
 
@@ -549,7 +553,7 @@ class ShowInfoMultiple:
             JOIN ww_shows s ON s.showid = gm.showid
             ORDER BY s.showdate ASC, gm.showguestmapid ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -559,16 +563,16 @@ class ShowInfoMultiple:
 
         shows = {}
         for guest in results:
-            if guest.show_id not in shows:
-                shows[guest.show_id] = []
+            if guest["show_id"] not in shows:
+                shows[guest["show_id"]] = []
 
-            shows[guest.show_id].append(
+            shows[guest["show_id"]].append(
                 {
-                    "id": guest.guest_id,
-                    "name": guest.name,
-                    "slug": guest.slug if guest.slug else slugify(guest.name),
-                    "score": guest.score,
-                    "score_exception": bool(guest.score_exception),
+                    "id": guest["guest_id"],
+                    "name": guest["name"],
+                    "slug": guest["slug"] if guest["slug"] else slugify(guest["name"]),
+                    "score": guest["score"],
+                    "score_exception": bool(guest["score_exception"]),
                 }
             )
 
@@ -599,7 +603,7 @@ class ShowInfoMultiple:
             gm.showguestmapid ASC;""".format(
             ids=", ".join(str(v) for v in show_ids)
         )
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -609,16 +613,16 @@ class ShowInfoMultiple:
 
         shows = {}
         for guest in results:
-            if guest.show_id not in shows:
-                shows[guest.show_id] = []
+            if guest["show_id"] not in shows:
+                shows[guest["show_id"]] = []
 
-            shows[guest.show_id].append(
+            shows[guest["show_id"]].append(
                 {
-                    "id": guest.guest_id,
-                    "name": guest.name,
-                    "slug": guest.slug if guest.slug else slugify(guest.name),
-                    "score": guest.score,
-                    "score_exception": bool(guest.score_exception),
+                    "id": guest["guest_id"],
+                    "name": guest["name"],
+                    "slug": guest["slug"] if guest["slug"] else slugify(guest["name"]),
+                    "score": guest["score"],
+                    "score_exception": bool(guest["score_exception"]),
                 }
             )
 
@@ -665,7 +669,7 @@ class ShowInfoMultiple:
                 ORDER by s.showdate ASC, pm.panelistscore DESC,
                 pm.showpnlmapid ASC;
                 """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -675,33 +679,29 @@ class ShowInfoMultiple:
 
         panelists = {}
         for panelist in results:
-            if panelist.show_id not in panelists:
-                panelists[panelist.show_id] = []
+            if panelist["show_id"] not in panelists:
+                panelists[panelist["show_id"]] = []
 
-            panelists[panelist.show_id].append(
+            panelists[panelist["show_id"]].append(
                 {
-                    "id": panelist.panelist_id,
-                    "name": panelist.name,
-                    "slug": panelist.slug if panelist.slug else slugify(panelist.name),
-                    "lightning_round_start": panelist.start,
-                    "lightning_round_start_decimal": (
-                        panelist.start_decimal
-                        if "start_decimal" in panelist._fields
-                        else None
+                    "id": panelist["panelist_id"],
+                    "name": panelist["name"],
+                    "slug": (
+                        panelist["slug"]
+                        if panelist["slug"]
+                        else slugify(panelist["name"])
                     ),
-                    "lightning_round_correct": panelist.correct,
-                    "lightning_round_correct_decimal": (
-                        panelist.correct_decimal
-                        if "correct_decimal" in panelist._fields
-                        else None
+                    "lightning_round_start": panelist["start"],
+                    "lightning_round_start_decimal": panelist.get(
+                        "start_decimal", None
                     ),
-                    "score": panelist.score,
-                    "score_decimal": (
-                        panelist.score_decimal
-                        if "score_decimal" in panelist._fields
-                        else None
+                    "lightning_round_correct": panelist["correct"],
+                    "lightning_round_correct_decimal": panelist.get(
+                        "correct_decimal", None
                     ),
-                    "rank": panelist.pnl_rank if panelist.pnl_rank else None,
+                    "score": panelist["score"],
+                    "score_decimal": panelist.get("score_decimal", None),
+                    "rank": panelist["pnl_rank"] if panelist["pnl_rank"] else None,
                 }
             )
 
@@ -757,7 +757,7 @@ class ShowInfoMultiple:
                 ids=", ".join(str(v) for v in show_ids)
             )
 
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -767,35 +767,33 @@ class ShowInfoMultiple:
 
         panelists = {}
         for panelist in results:
-            if panelist.show_id not in panelists:
-                panelists[panelist.show_id] = []
+            if panelist["show_id"] not in panelists:
+                panelists[panelist["show_id"]] = []
 
-            panelists[panelist.show_id].append(
+            panelists[panelist["show_id"]].append(
                 {
-                    "id": panelist.panelist_id,
-                    "name": panelist.name,
-                    "slug": panelist.slug if panelist.slug else slugify(panelist.name),
-                    "lightning_round_start": panelist.start if panelist.start else None,
-                    "lightning_round_start_decimal": (
-                        panelist.start_decimal
-                        if "start_decimal" in panelist._fields
-                        else None
+                    "id": panelist["panelist_id"],
+                    "name": panelist["name"],
+                    "slug": (
+                        panelist["slug"]
+                        if panelist["slug"]
+                        else slugify(panelist["name"])
+                    ),
+                    "lightning_round_start": (
+                        panelist["start"] if panelist["start"] else None
+                    ),
+                    "lightning_round_start_decimal": panelist.get(
+                        "start_decimal", None
                     ),
                     "lightning_round_correct": (
-                        panelist.correct if panelist.correct else None
+                        panelist["correct"] if panelist["correct"] else None
                     ),
-                    "lightning_round_correct_decimal": (
-                        panelist.correct_decimal
-                        if "correct_decimal" in panelist._fields
-                        else None
+                    "lightning_round_correct_decimal": panelist.get(
+                        "correct_decimal", None
                     ),
-                    "score": panelist.score,
-                    "score_decimal": (
-                        panelist.score_decimal
-                        if "score_decimal" in panelist._fields
-                        else None
-                    ),
-                    "rank": panelist.pnl_rank if panelist.pnl_rank else None,
+                    "score": panelist["score"],
+                    "score_decimal": panelist.get("score_decimal", None),
+                    "rank": panelist["pnl_rank"] if panelist["pnl_rank"] else None,
                 }
             )
 

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -66,7 +66,7 @@ class Show:
             FROM ww_shows
             ORDER BY showdate ASC;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
         cursor.close()
@@ -77,17 +77,17 @@ class Show:
         shows = []
         for row in results:
             show = {
-                "id": row.id,
-                "date": row.date.isoformat(),
-                "best_of": bool(row.best_of),
-                "repeat_show": bool(row.repeat_show_id),
-                "show_url": row.show_url,
+                "id": row["id"],
+                "date": row["date"].isoformat(),
+                "best_of": bool(row["best_of"]),
+                "repeat_show": bool(row["repeat_show_id"]),
+                "show_url": row["show_url"],
             }
 
-            if row.repeat_show_id:
-                show["original_show_id"] = row.repeat_show_id
+            if row["repeat_show_id"]:
+                show["original_show_id"] = row["repeat_show_id"]
                 show["original_show_date"] = self.utility.convert_id_to_date(
-                    row.repeat_show_id
+                    row["repeat_show_id"]
                 )
 
             shows.append(show)
@@ -277,7 +277,7 @@ class Show:
             WHERE showid = %s
             LIMIT 1;
             """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (show_id,))
         result = cursor.fetchone()
         cursor.close()
@@ -286,17 +286,17 @@ class Show:
             return {}
 
         info = {
-            "id": result.id,
-            "date": result.date.isoformat(),
-            "best_of": bool(result.best_of),
-            "repeat_show": bool(result.repeat_show_id),
-            "show_url": result.show_url,
+            "id": result["id"],
+            "date": result["date"].isoformat(),
+            "best_of": bool(result["best_of"]),
+            "repeat_show": bool(result["repeat_show_id"]),
+            "show_url": result["show_url"],
         }
 
-        if result.repeat_show_id:
-            info["original_show_id"] = result.repeat_show_id
+        if result["repeat_show_id"]:
+            info["original_show_id"] = result["repeat_show_id"]
             info["original_show_date"] = self.utility.convert_id_to_date(
-                result.repeat_show_id
+                result["repeat_show_id"]
             )
 
         return info
@@ -823,7 +823,7 @@ class Show:
                 AND YEAR(s.showdate) = %s
                 ORDER BY s.showdate ASC, pm.panelistscore ASC;
                 """
-        cursor = self.database_connection.cursor(named_tuple=True)
+        cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query, (year,))
         results = cursor.fetchall()
         cursor.close()
@@ -833,11 +833,11 @@ class Show:
 
         shows = {}
         for row in results:
-            date = row.date.isoformat()
+            date = row["date"].isoformat()
             if date not in shows:
                 shows[date] = []
 
-            shows[date].append(row.score)
+            shows[date].append(row["score"])
 
         show_scores = []
         for show in shows:


### PR DESCRIPTION
Application Changes
-------------------

* Replace all references of `named_tuple=` in database cursors to `dictionary=` due to cursors using `NamedTuple` being marked for deprecation in future versions of MySQL Connector/Python
* Update code that is impacted by the database cursor type change from `NamedTuple` to `dict`
* Additional code cleanup

Compoennt Changes
-----------------

* Upgrade mysql-connector-python from 8.2.0 to 8.4.0
* Upgrade numpy from 1.26.4 to 2.1.0
* Upgrade python-slugify from 8.0.1 to 8.0.4
* Upgrade pytz from 2024.1 to 2024.2

Development Changes
-------------------

* Upgrade black from 24.4.2 to 24.8.0
* Upgrade pytest from 8.1.2 to 8.3.3
* Upgrade ruff from 0.6.7 to 0.6.8

Document Changes
----------------

* Sync required package versions with main package requirements