### PR TITLE
Adding Best Of, Best Of Repeat and Repeat Show Retrieval Methods, Sphinx Doc Theme Change, Update Dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,45 @@
 Changes
 *******
 
+2.13.0
+======
+
+Application Changes
+-------------------
+
+* Add methods to ``show.show`` to retrieve information and details for Best Of, Repeat and Repeat Best Of shows
+* Initial Python 3.13 support
+
+Component Changes
+-----------------
+
+* Upgrade mysql-connector from 8.4.0 to 9.1.0
+* Upgrade numpy from 2.1.0 to 2.1.2
+
+Development Changes
+-------------------
+
+* Upgrade black from 24.8.0 to 24.10.0
+* Upgrade ruff from 0.6.9 to 0.7.0
+* Upgrade build from 1.2.2 to 1.2.2.post1
+* Increase minimum pytest version from 8.0 to 8.3 in ``pyproject.toml``
+* Add ``py313`` to ``tool.black.target-version``
+
+Documentation Changes
+---------------------
+
+* Theme Updates
+
+  * Replace Pallets-Sphinx-Themes/Flask theme with Furo version 2024.8.6
+  * Change body text from IBM Plex Serif to IBM Plex Sans
+
+* Sync required package versions with main package requirements
+* Upgrade Sphinx from 8.0.2 to 8.1.3
+* Upgrade sphinx-autobuild from 2024.9.19 to 2024.10.3
+* Upgrade sphinx-autodoc-typehints from 2.4.4 to 2.5.0
+* Upgrade sphinx-toolbox from 3.8.0 to 3.8.1
+* Adding sphinxext-opengraph version 0.9.1
+
 2.12.1-post0
 ============
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -21,4 +21,4 @@ github:
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile
-	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) -v $(O)

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -1,41 +1,50 @@
-/* @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap'); */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Serif:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap');
-
 @media all {
     body, input, div.sphinxsidebar input {
-        /* font-family: "IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"; */
-        font-family: "IBM Plex Serif", Georgia, Cambria, "Times New Roman", serif;
         font-size: 1.05rem;
     }
 
-    h1, h2, h3, h4, h5, h6 {
-        font-family: "IBM Plex Serif", Georgia, Cambria, "Times New Roman", serif;
-    }
-
     code, kbd, pre, textarea {
-        font-family: "IBM Plex Mono", Menlo, Consolas, Monaco, "Liberation Mono", "Lucida Console", monospace;
         font-size: 1rem;
-    }
-
-    div.sphinxsidebar {
-        font-size: 1rem;
-    }
-
-    nav#contents {
-        margin-left: 1em;
-        padding-bottom: 1em;
-        padding-left: 1em;
-        width: 90%;
     }
 
     p.caption, .caption-text {
         font-weight: bold;
     }
 
+    span.pre {
+        font-family: var(--font-stack--monospace);
+    }
+
+    code.literal {
+        font-size: 1rem;
+    }
+
+    .toc-title {
+        font-weight: bold;
+    }
+
+    .toc-tree code.literal {
+        font-size: 0.9rem;
+    }
+
+    div.highlight {
+        border: 1px solid;
+    }
+
     .bolditalic {
         font-style: italic;
         font-weight: bold;
+    }
+
+    ul.simple {
+        margin-bottom: 1rem;
+        margin-top: 0;
+    }
+
+    footer, .page-info .context, .bottom-of-page .left-details, .bottom-of-page .right-details {
+        font-size: unset;
     }
 
     /* Hide "On GitHub" section from versions menu */

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,9 +4,8 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 import sys
+from email.mime import base
 from pathlib import Path
-
-from pallets_sphinx_themes import ProjectLink  # type: ignore[report-missing-imports]
 
 current_path = Path.cwd()
 sys.path.insert(0, str(current_path.parent))
@@ -16,11 +15,11 @@ copyright = "2018-2024 Linh Pham. All Rights Reserved"
 author = "Linh Pham"
 
 extensions = [
-    "pallets_sphinx_themes",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",
+    "sphinxext.opengraph",
 ]
 
 templates_path = [
@@ -35,33 +34,9 @@ exclude_patterns = [
     "venv",
 ]
 
-html_theme = "flask"
+html_theme = "furo"
 
-html_context = {
-    "project_links": [
-        ProjectLink("Source Code", "https://github.com/questionlp/wwdtm"),
-        ProjectLink("PyPI", "https://pypi.org/project/wwdtm/"),
-        ProjectLink("Stats API", "https://api.wwdt.me/"),
-        ProjectLink("Stats Page", "https://stats.wwdt.me/"),
-        ProjectLink("Graphs Site", "https://graphs.wwdt.me/"),
-        ProjectLink("Reports Site", "https://reports.wwdt.me/"),
-    ]
-}
-
-html_sidebars = {
-    "index": [
-        "globaltoc.html",
-        "project.html",
-        "searchbox.html",
-    ],
-    "**": [
-        "globaltoc.html",
-        # "localtoc.html",
-        "relations.html",
-        "project.html",
-        "searchbox.html",
-    ],
-}
+html_title = "Wait Wait Stats Library"
 
 html_static_path = [
     "_static",
@@ -72,6 +47,58 @@ html_css_files = [
 ]
 
 html_show_sourcelink = False
+smartquotes = False
+
+base_fonts = '"IBM Plex Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";'
+monospace_fonts = '"IBM Plex Mono", Menlo, Consolas, Monaco, "Liberation Mono", "Lucida Console", monospace;'
+
+html_theme_options = {
+    "light_css_variables": {
+        "font-stack": base_fonts,
+        "font-stack--monospace": monospace_fonts,
+        "color-foreground-primary": "#000000",
+        "color-foreground-secondary": "#161616",
+        "color-foreground-muted": "#21272a",
+        "color-brand-content": "#0043ce",
+        "color-background-primary": "#ffffff",
+        "color-sidebar-background": "#f2f4f8",
+        "color-sidebar-link-text--top-level": "#0043ce",
+        "color-api-name": "#520408",
+        "color-api-pre-name": "#da1e28",
+        "color-highlight-on-target": "#f2f4f8",
+        "color-sidebar-search-foreground": "#000000",
+        "sidebar-item-font-size": "1rem",
+        "toc-font-size": "0.95rem",
+        "toc-title-font-size": "1rem",
+        "color-toc-item-text": "var(--color-foreground-primary);",
+        "color-toc-title-text": "var(--color-foreground-primary);",
+        "code-font-size": "1rem",
+    },
+    "dark_css_variables": {
+        "font-stack": base_fonts,
+        "font-stack--monospace": monospace_fonts,
+        "color-foreground-primary": "#ffffff",
+        "color-foreground-secondary": "#f4f4f4",
+        "color-foreground-muted": "#dde1e6",
+        "color-brand-content": "#78a9ff",
+        "color-background-primary": "#161616",
+        "color-sidebar-background": "#21272a",
+        "color-sidebar-link-text--top-level": "#78a9ff",
+        "color-api-name": "#fa4d56",
+        "color-api-pre-name": "#ffb3b8",
+        "color-highlight-on-target": "#21272a",
+        "color-sidebar-search-foreground": "#ffffff",
+        "sidebar-item-font-size": "1rem",
+        "toc-font-size": "0.95rem",
+        "toc-title-font-size": "1rem",
+        "color-toc-item-text": "var(--color-foreground-primary);",
+        "color-toc-title-text": "var(--color-foreground-primary);",
+        "code-font-size": "1rem",
+    },
+}
+
+pygments_style = "sas"
+pygments_dark_style = "rrt"
 
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -40,11 +40,28 @@ Table of Contents
     migrating/index
     changes/index
 
+
+Project Links
+=============
+
+* `Source Code`_
+* `PyPI`_
+* `Wait Wait Stats API`_
+* `Wait Wait Stats Page`_
+* `Wait Wait Graphs`_
+* `Wait Wait Reports`_
+
+
 Indices and tables
 ==================
 
 * :ref:`genindex`
 * :ref:`modindex`
-* :ref:`search`
+
 
 .. _PyPI: https://pypi.org/project/wwdtm/
+.. _Source Code: https://github.com/questionlp/wwdtm/
+.. _Wait Wait Stats API: https://api.stats.wwdt.me/
+.. _Wait Wait Stats Page: https://stats.wwdt.me/
+.. _Wait Wait Graphs: https://graphs.wwdt.me/
+.. _Wait Wait Reports: https://reports.wwdt.me/

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,15 @@
 pytest==8.3.3
-black==24.8.0
+black==24.10.0
 
-mysql-connector-python==8.4.0
-numpy==2.1.0
+mysql-connector-python==9.1.0
+numpy==2.1.2
 python-slugify==8.0.4
 pytz==2024.2
 
-Sphinx==8.0.2
-sphinx-autobuild==2024.9.19
-sphinx-autodoc-typehints==2.4.4
+Sphinx==8.1.3
+sphinx-autobuild==2024.10.3
+sphinx-autodoc-typehints==2.5.0
 sphinx-copybutton==0.5.2
-sphinx-toolbox==3.8.0
-Pallets-Sphinx-Themes==2.1.3
+sphinx-toolbox==3.8.1
+sphinxext-opengraph==0.9.1
+furo==2024.8.6

--- a/docs/wwdtm/guest.rst
+++ b/docs/wwdtm/guest.rst
@@ -7,11 +7,6 @@ Module: guest
 This module provides objects used to retrieve guests, guest information and
 guest details from a copy of the Wait Wait Don't Tell Me! Stats database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Guest
 =====
 

--- a/docs/wwdtm/host.rst
+++ b/docs/wwdtm/host.rst
@@ -7,11 +7,6 @@ Module: host
 This module provides objects used to retrieve hosts, host information and host
 details from a copy of the Wait Wait Don't Tell Me! Stats database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Host
 ====
 

--- a/docs/wwdtm/location.rst
+++ b/docs/wwdtm/location.rst
@@ -8,11 +8,6 @@ This module provides objects that are used to retrieve locations, location
 information and location recordings from a copy of the Wait Wait Don't Tell Me!
 Stats database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Location
 ========
 

--- a/docs/wwdtm/panelist.rst
+++ b/docs/wwdtm/panelist.rst
@@ -8,11 +8,6 @@ This module provides objects used to retrieve panelists, panelist information
 and panelist details from a copy of the Wait Wait Don't Tell Me! Stats
 database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Panelist
 ========
 

--- a/docs/wwdtm/pronoun.rst
+++ b/docs/wwdtm/pronoun.rst
@@ -7,11 +7,6 @@ Module: pronoun
 This module provides objects used to retrieve pronouns information from
 a copy of the Wait Wait Don't Tell Me! Stats database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Pronouns
 ========
 

--- a/docs/wwdtm/scorekeeper.rst
+++ b/docs/wwdtm/scorekeeper.rst
@@ -8,11 +8,6 @@ This module provides objects used to retrieve scorekeepers, scorekeeper
 information and scorekeeper details from a copy of the Wait Wait Don't Tell Me!
 Stats database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Scorekeeper
 ===========
 

--- a/docs/wwdtm/show.rst
+++ b/docs/wwdtm/show.rst
@@ -8,11 +8,6 @@ This module provides objects used to retrieve shows, show information,
 and show details from a copy of the Wait Wait Don't Tell Me! Stats
 database.
 
-.. contents:: Contents
-    :depth: 1
-    :local:
-    :backlinks: none
-
 Show
 ====
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,13 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 
 dependencies = [
-    "mysql-connector-python==8.4.0",
-    "numpy==2.1.0",
+    "mysql-connector-python==9.1.0",
+    "numpy==2.1.2",
     "python-slugify==8.0.4",
     "pytz==2024.2",
 ]
@@ -41,12 +42,12 @@ requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.black]
-required-version = "24.8.0"
-target-version = ["py310", "py311", "py312"]
+required-version = "24.10.0"
+target-version = ["py310", "py311", "py312", "py313"]
 line-length = 88
 
 [tool.pytest.ini_options]
-minversion = "8.0"
+minversion = "8.3"
 filterwarnings = [
     "ignore::DeprecationWarning:mysql.*:",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,11 +1,11 @@
-ruff==0.6.9
-black==24.8.0
+ruff==0.7.0
+black==24.10.0
 pytest==8.3.3
 pytest-cov==5.0.0
 wheel==0.44.0
-build==1.2.2
+build==1.2.2.post1
 
-mysql-connector-python==8.4.0
-numpy==2.1.0
+mysql-connector-python==9.1.0
+numpy==2.1.2
 python-slugify==8.0.4
 pytz==2024.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mysql-connector-python==8.4.0
-numpy==2.1.0
+mysql-connector-python==9.1.0
+numpy==2.1.2
 python-slugify==8.0.4
 pytz==2024.2

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -36,6 +36,84 @@ def test_show_retrieve_all():
     assert "id" in shows[0], "No Show ID returned for the first list item"
 
 
+def test_show_retrieve_all_best_ofs():
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_best_ofs`."""
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_best_ofs()
+
+    assert shows, "No shows could be retrieved"
+    assert "id" in shows[0], "No Show ID returned for the first list item"
+
+
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_best_ofs_details(include_decimal_scores: bool):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_best_ofs_details`.
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_best_ofs_details(
+        include_decimal_scores=include_decimal_scores
+    )
+
+    assert shows, "No shows could be retrieved"
+    assert "date" in shows[0], "'date' was not returned for the first list item"
+    assert "host" in shows[0], "'host' was not returned for first list item"
+
+
+def test_show_retrieve_all_repeats():
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_repeats`."""
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_repeats()
+
+    assert shows, "No shows could be retrieved"
+    assert "id" in shows[0], "No Show ID returned for the first list item"
+
+
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_repeat_details(include_decimal_scores: bool):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_repeat_details`.
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_repeats_details(
+        include_decimal_scores=include_decimal_scores
+    )
+
+    assert shows, "No shows could be retrieved"
+    assert "date" in shows[0], "'date' was not returned for the first list item"
+    assert "host" in shows[0], "'host' was not returned for first list item"
+
+
+def test_show_retrieve_all_best_of_repeats():
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats`."""
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_best_of_repeats()
+
+    assert shows, "No shows could be retrieved"
+    assert "id" in shows[0], "No Show ID returned for the first list item"
+
+
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_best_of_repeats_details(include_decimal_scores: bool):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats_details`.
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_best_of_repeats_details(
+        include_decimal_scores=include_decimal_scores
+    )
+
+    assert shows, "No shows could be retrieved"
+    assert "date" in shows[0], "'date' was not returned for the first list item"
+    assert "host" in shows[0], "'host' was not returned for first list item"
+
+
 @pytest.mark.parametrize("include_decimal_scores", [True, False])
 def test_show_retrieve_all_details(include_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_details`.

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -17,10 +17,15 @@ def test_validation_valid_int_id(test_id: int):
     assert valid_int_id(test_id), f"Provided ID {test_id} was not valid"
 
 
-@pytest.mark.parametrize("test_id", [-54, 2**32])
+@pytest.mark.parametrize("test_id", [-54, 2**32, "hello", False])
 def test_validation_invalid_int_id(test_id: int):
     """Negative testing for :py:meth:`wwdtm.validation.valid_int_id`.
 
     :param test_id: ID to test failing ID validation
     """
     assert not valid_int_id(test_id), f"Provided ID {test_id} was valid"
+
+
+def test_validation_no_id():
+    """Negative testing for :py:meth:`wwdtm.validation.valid_int_id`."""
+    assert not valid_int_id(None), "Provided ID 'None' was valid"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.12.1-post0"
+VERSION = "2.13.0-beta1"
 
 
 def database_version(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.13.0-beta1"
+VERSION = "2.13.0"
 
 
 def database_version(

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -94,6 +94,279 @@ class Show:
 
         return shows
 
+    def retrieve_all_best_ofs(self) -> list[dict[str, Any]]:
+        """Retrieves basic show information for all Best Of shows.
+
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable) and show
+            URL at NPR.org
+        """
+        query = """
+            SELECT showid AS id, showdate AS date,
+            bestof AS best_of, repeatshowid AS repeat_show_id,
+            showurl AS show_url
+            FROM ww_shows
+            WHERE bestof = 1
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        shows = []
+        for row in results:
+            show = {
+                "id": row["id"],
+                "date": row["date"].isoformat(),
+                "best_of": bool(row["best_of"]),
+                "repeat_show": bool(row["repeat_show_id"]),
+                "show_url": row["show_url"],
+            }
+
+            if row["repeat_show_id"]:
+                show["original_show_id"] = row["repeat_show_id"]
+                show["original_show_date"] = self.utility.convert_id_to_date(
+                    row["repeat_show_id"]
+                )
+
+            shows.append(show)
+
+        return shows
+
+    def retrieve_all_best_ofs_details(
+        self, include_decimal_scores: bool = False
+    ) -> list[dict[str, Any]]:
+        """Retrieves detailed show information for all Best Of shows.
+
+        :param include_decimal_scores: A boolean to determine if decimal
+            scores should be included
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable), show URL
+            at NPR.org, host, scorekeeper, location, panelists and
+            guests
+        """
+        query = """
+            SELECT showid
+            FROM ww_shows
+            WHERE bestof = 1
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        show_ids = [v[0] for v in results]
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
+
+        if not info:
+            return []
+
+        shows = []
+        for show in info:
+            if info[show]:
+                info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
+                    info[show]["id"], include_decimal_scores=include_decimal_scores
+                )
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
+                    info[show]["id"]
+                )
+                info[show]["guests"] = self.info.retrieve_guest_info_by_id(
+                    info[show]["id"]
+                )
+                shows.append(info[show])
+
+        return shows
+
+    def retrieve_all_best_of_repeats(self) -> list[dict[str, Any]]:
+        """Retrieves basic show information for all Best Of Repeat shows.
+
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable) and show
+            URL at NPR.org
+        """
+        query = """
+            SELECT showid AS id, showdate AS date,
+            bestof AS best_of, repeatshowid AS repeat_show_id,
+            showurl AS show_url
+            FROM ww_shows
+            WHERE bestof = 1 AND repeatshowid IS NOT NULL
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        shows = []
+        for row in results:
+            show = {
+                "id": row["id"],
+                "date": row["date"].isoformat(),
+                "best_of": bool(row["best_of"]),
+                "repeat_show": bool(row["repeat_show_id"]),
+                "show_url": row["show_url"],
+            }
+
+            if row["repeat_show_id"]:
+                show["original_show_id"] = row["repeat_show_id"]
+                show["original_show_date"] = self.utility.convert_id_to_date(
+                    row["repeat_show_id"]
+                )
+
+            shows.append(show)
+
+        return shows
+
+    def retrieve_all_best_of_repeats_details(
+        self, include_decimal_scores: bool = False
+    ) -> list[dict[str, Any]]:
+        """Retrieves detailed show information for all Best Of Repeat shows.
+
+        :param include_decimal_scores: A boolean to determine if decimal
+            scores should be included
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable), show URL
+            at NPR.org, host, scorekeeper, location, panelists and
+            guests
+        """
+        query = """
+            SELECT showid
+            FROM ww_shows
+            WHERE bestof = 1 AND repeatshowid IS NOT NULL
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        show_ids = [v[0] for v in results]
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
+
+        if not info:
+            return []
+
+        shows = []
+        for show in info:
+            if info[show]:
+                info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
+                    info[show]["id"], include_decimal_scores=include_decimal_scores
+                )
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
+                    info[show]["id"]
+                )
+                info[show]["guests"] = self.info.retrieve_guest_info_by_id(
+                    info[show]["id"]
+                )
+                shows.append(info[show])
+
+        return shows
+
+    def retrieve_all_repeats(self) -> list[dict[str, Any]]:
+        """Retrieves basic show information for all repeat shows.
+
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable) and show
+            URL at NPR.org
+        """
+        query = """
+            SELECT showid AS id, showdate AS date,
+            bestof AS best_of, repeatshowid AS repeat_show_id,
+            showurl AS show_url
+            FROM ww_shows
+            WHERE repeatshowid IS NOT NULL
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        shows = []
+        for row in results:
+            show = {
+                "id": row["id"],
+                "date": row["date"].isoformat(),
+                "best_of": bool(row["best_of"]),
+                "repeat_show": bool(row["repeat_show_id"]),
+                "show_url": row["show_url"],
+            }
+
+            if row["repeat_show_id"]:
+                show["original_show_id"] = row["repeat_show_id"]
+                show["original_show_date"] = self.utility.convert_id_to_date(
+                    row["repeat_show_id"]
+                )
+
+            shows.append(show)
+
+        return shows
+
+    def retrieve_all_repeats_details(
+        self, include_decimal_scores: bool = False
+    ) -> list[dict[str, Any]]:
+        """Retrieves detailed show information for all repeat shows.
+
+        :param include_decimal_scores: A boolean to determine if decimal
+            scores should be included
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable), show URL
+            at NPR.org, host, scorekeeper, location, panelists and
+            guests
+        """
+        query = """
+            SELECT showid
+            FROM ww_shows
+            WHERE repeatshowid IS NOT NULL
+            ORDER BY showdate ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query)
+        results = cursor.fetchall()
+        cursor.close()
+
+        if not results:
+            return []
+
+        show_ids = [v[0] for v in results]
+        info = self.info_multiple.retrieve_core_info_by_ids(show_ids)
+
+        if not info:
+            return []
+
+        shows = []
+        for show in info:
+            if info[show]:
+                info[show]["panelists"] = self.info.retrieve_panelist_info_by_id(
+                    info[show]["id"], include_decimal_scores=include_decimal_scores
+                )
+                info[show]["bluffs"] = self.info.retrieve_bluff_info_by_id(
+                    info[show]["id"]
+                )
+                info[show]["guests"] = self.info.retrieve_guest_info_by_id(
+                    info[show]["id"]
+                )
+                shows.append(info[show])
+
+        return shows
+
     def retrieve_all_details(
         self, include_decimal_scores: bool = False
     ) -> list[dict[str, Any]]:


### PR DESCRIPTION
Application Changes
-------------------

* Add methods to ``show.show`` to retrieve information and details for Best Of, Repeat and Repeat Best Of shows
* Initial Python 3.13 support

Component Changes
-----------------

* Upgrade mysql-connector from 8.4.0 to 9.1.0
* Upgrade numpy from 2.1.0 to 2.1.2

Development Changes
-------------------

* Upgrade black from 24.8.0 to 24.10.0
* Upgrade ruff from 0.6.9 to 0.7.0
* Upgrade build from 1.2.2 to 1.2.2.post1
* Increase minimum pytest version from 8.0 to 8.3 in ``pyproject.toml``
* Add ``py313`` to ``tool.black.target-version``

Documentation Changes
---------------------

* Theme Updates
  * Replace Pallets-Sphinx-Themes/Flask theme with Furo version 2024.8.6
  * Change body text from IBM Plex Serif to IBM Plex Sans
* Sync required package versions with main package requirements
* Upgrade Sphinx from 8.0.2 to 8.1.3
* Upgrade sphinx-autobuild from 2024.9.19 to 2024.10.3
* Upgrade sphinx-autodoc-typehints from 2.4.4 to 2.5.0
* Upgrade sphinx-toolbox from 3.8.0 to 3.8.1
* Adding sphinxext-opengraph version 0.9.1