### PR TITLE
Rename and alias Best Of Repeats methods to Repeat Best Ofs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changes
 *******
 
+2.14.0
+======
+
+Application Changes
+-------------------
+
+* Rename two show class methods to reflect more accurate phrasing:
+
+  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`
+  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats_details` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`
+
+* Create an aliases for the renamed class methods:
+
+  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`
+  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats_details` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`
+
 2.13.0
 ======
 

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -88,6 +88,32 @@ def test_show_retrieve_all_repeat_details(include_decimal_scores: bool):
     assert "host" in shows[0], "'host' was not returned for first list item"
 
 
+def test_show_retrieve_all_repeat_best_ofs():
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`."""
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_repeat_best_ofs()
+
+    assert shows, "No shows could be retrieved"
+    assert "id" in shows[0], "No Show ID returned for the first list item"
+
+
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_all_repeat_best_ofs_details(include_decimal_scores: bool):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`.
+
+    :param include_decimal_scores: Flag set to include decimal score columns
+        and values
+    """
+    show = Show(connect_dict=get_connect_dict())
+    shows = show.retrieve_all_repeat_best_ofs_details(
+        include_decimal_scores=include_decimal_scores
+    )
+
+    assert shows, "No shows could be retrieved"
+    assert "date" in shows[0], "'date' was not returned for the first list item"
+    assert "host" in shows[0], "'host' was not returned for first list item"
+
+
 def test_show_retrieve_all_best_of_repeats():
     """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats`."""
     show = Show(connect_dict=get_connect_dict())

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -25,7 +25,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.13.0"
+VERSION = "2.14.0"
 
 
 def database_version(

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -185,8 +185,8 @@ class Show:
 
         return shows
 
-    def retrieve_all_best_of_repeats(self) -> list[dict[str, Any]]:
-        """Retrieves basic show information for all Best Of Repeat shows.
+    def retrieve_all_repeat_best_ofs(self) -> list[dict[str, Any]]:
+        """Retrieves basic show information for all Repeat Best Of shows.
 
         :return: A list of dictionaries containing show ID, show date,
             Best Of show flag, repeat show ID (if applicable) and show
@@ -228,10 +228,19 @@ class Show:
 
         return shows
 
-    def retrieve_all_best_of_repeats_details(
+    def retrieve_all_best_of_repeats(self) -> list[dict[str, Any]]:
+        """Alias for :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`.
+
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable) and show
+            URL at NPR.org
+        """
+        return self.retrieve_all_repeat_best_ofs()
+
+    def retrieve_all_repeat_best_ofs_details(
         self, include_decimal_scores: bool = False
     ) -> list[dict[str, Any]]:
-        """Retrieves detailed show information for all Best Of Repeat shows.
+        """Retrieves detailed show information for all Repeat Best Of shows.
 
         :param include_decimal_scores: A boolean to determine if decimal
             scores should be included
@@ -275,6 +284,22 @@ class Show:
                 shows.append(info[show])
 
         return shows
+
+    def retrieve_all_best_of_repeats_details(
+        self, include_decimal_scores: bool = False
+    ) -> list[dict[str, Any]]:
+        """Alias for :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`.
+
+        :param include_decimal_scores: A boolean to determine if decimal
+            scores should be included
+        :return: A list of dictionaries containing show ID, show date,
+            Best Of show flag, repeat show ID (if applicable), show URL
+            at NPR.org, host, scorekeeper, location, panelists and
+            guests
+        """
+        return self.retrieve_all_repeat_best_ofs_details(
+            include_decimal_scores=include_decimal_scores
+        )
 
     def retrieve_all_repeats(self) -> list[dict[str, Any]]:
         """Retrieves basic show information for all repeat shows.


### PR DESCRIPTION
## Application Changes

* Rename two show class methods to reflect more accurate phrasing:
  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`
  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats_details` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`
* Create an aliases for the renamed class methods:
  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs`
  * :py:meth:`wwdtm.show.Show.retrieve_all_best_of_repeats_details` → :py:meth:`wwdtm.show.Show.retrieve_all_repeat_best_ofs_details`