### PR TITLE
Migrate from black to ruff, fix location join, add postal abbreviations retrieval function, format code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,5 @@
             "source.fixAll": "explicit",
             "source.sortImports": "explicit",
         },
-        "editor.defaultFormatter": "ms-python.black-formatter"
     }
 }

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,22 @@
 Changes
 *******
 
+2.15.0
+======
+
+Application Changes
+-------------------
+
+* Change SQL joins from ``JOIN`` to ``LEFT JOIN`` in :py:class:`wwdtm.location.Location` to properly handle ``NULL`` values in the ``state`` column
+* Add :py:meth:`wwdtm.location.Location.retrieve_postal_abbreviations` that returns postal abbreviations and their corresponding names and countries
+
+Development Changes
+-------------------
+
+* Upgrade ruff from 0.7.0 to 0.9.3
+* Remove black from required development packages as part of migrating entirely to Ruff
+* Ran ```ruff format``` to format Python code files using the Ruff 2025 Style Guide
+
 2.14.0
 ======
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,11 +41,6 @@ version = {attr = "wwdtm.VERSION"}
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.black]
-required-version = "24.10.0"
-target-version = ["py310", "py311", "py312", "py313"]
-line-length = 88
-
 [tool.pytest.ini_options]
 minversion = "8.3"
 filterwarnings = [
@@ -60,6 +55,7 @@ norecursedirs = [
 ]
 
 [tool.ruff]
+required-version = ">= 0.9.0"
 target-version = "py310"
 
 exclude = [
@@ -73,7 +69,7 @@ exclude = [
     ".venv",
 ]
 
-line-length = 88 # Must agree with Black
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [
@@ -93,6 +89,7 @@ ignore = [
     "F401",
     "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
     "S608",
+    "ISC001",
 ]
 
 select = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-ruff==0.7.0
-black==24.10.0
+ruff==0.9.3
 pytest==8.3.3
 pytest-cov==5.0.0
 wheel==0.44.0

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Deprecated: Package setup file."""
+
 from setuptools import setup
 
 setup()

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.guest.GuestAppearances`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.guest.Guest`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -43,9 +44,9 @@ def test_guest_retrieve_all_details():
 
     assert guests, "No guests could be retrieved"
     assert "id" in guests[0], "'id' was not returned for first list item"
-    assert (
-        "appearances" in guests[0]
-    ), "'appearances' was not returned for the first list item"
+    assert "appearances" in guests[0], (
+        "'appearances' was not returned for the first list item"
+    )
 
 
 def test_guest_retrieve_all_ids():
@@ -116,6 +117,6 @@ def test_guest_guest_retrieve_details_by_slug(guest_slug: str):
 
     assert info, f"Guest slug {guest_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {guest_slug}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for slug {guest_slug}"
+    assert "appearances" in info, (
+        f"'appearances' was not returned for slug {guest_slug}"
+    )

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wdtm.guest.GuestUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.host.HostAppearances`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.host.Host`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -49,9 +50,9 @@ def test_host_retrieve_all_details():
     assert "name" in hosts[0], "'name' was not returned for the first list item"
     assert "slug" in hosts[0], "'slug' was not returned for the first list item"
     assert "pronouns" in hosts[0], "'pronouns' was not returned for the first list item"
-    assert (
-        "appearances" in hosts[0]
-    ), "'appearances' was not returned for thefirst list item"
+    assert "appearances" in hosts[0], (
+        "'appearances' was not returned for thefirst list item"
+    )
 
 
 def test_host_retrieve_all_ids():

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.host.HostUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.location.Location`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -86,7 +87,7 @@ def test_location_retrieve_all_slugs():
     assert slugs, "No location slug strings could be retrieved"
 
 
-@pytest.mark.parametrize("location_id", [95])
+@pytest.mark.parametrize("location_id", [95, 148])
 def test_location_retrieve_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.Location.retrieve_by_id`.
 
@@ -108,7 +109,7 @@ def test_location_retrieve_by_id(location_id: int):
         ), f"'longitude' was not returned for ID {location_id}"
 
 
-@pytest.mark.parametrize("location_id", [95])
+@pytest.mark.parametrize("location_id", [95, 148])
 def test_location_retrieve_details_by_id(location_id: int):
     """Testing for :py:meth:`wwdtm.location.location.retrieve_details_by_id`.
 
@@ -179,3 +180,15 @@ def test_location_retrieve_details_by_slug(location_slug: str):
     assert (
         "recordings" in info
     ), f"'recordings' was not returned for slug {location_slug}"
+
+
+def test_location_retrieve_postal_abbreviations():
+    """Testing for :py:meth:`wwdtm.location.Location.retrieve_postal_abbreviations`."""
+    location = Location(connect_dict=get_connect_dict())
+    abbreviations = location.retrieve_postal_abbreviations()
+
+    assert abbreviations, "Postal abbreviations not returned"
+    assert "OR" in abbreviations, "Postal abbreviation 'OR' not found"
+    assert (
+        "name" in abbreviations["OR"]
+    ), "Postal abbreviation 'OR' does not contain a valid name"

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.location.LocationRecordings`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.location.LocationUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.PanelistAppearances`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/panelist/test_panelist_decimal_scores.py
+++ b/tests/panelist/test_panelist_decimal_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.PanelistDecimalScores`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.Panelist`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -36,9 +37,9 @@ def test_panelist_retrieve_all():
     assert "id" in panelists[0], "'id' was not returned for the first list item"
     assert "name" in panelists[0], "'name' was not returned for the first list item"
     assert "slug" in panelists[0], "'slug' was not returned for the first list item"
-    assert (
-        "pronouns" in panelists[0]
-    ), "'pronouns' was not returned for the first list item"
+    assert "pronouns" in panelists[0], (
+        "'pronouns' was not returned for the first list item"
+    )
 
 
 @pytest.mark.parametrize("use_decimal_scores", [True, False])
@@ -55,12 +56,12 @@ def test_panelist_retrieve_all_details(use_decimal_scores: bool):
     assert "id" in panelists[0], "'id' was not returned for first list item"
     assert "name" in panelists[0], "'name' was not returned for the first list item"
     assert "slug" in panelists[0], "'slug' was not returned for the first list item"
-    assert (
-        "pronouns" in panelists[0]
-    ), "'pronouns' was not returned for the first list item"
-    assert (
-        "appearances" in panelists[0]
-    ), "'appearances' was not returned for the first list item"
+    assert "pronouns" in panelists[0], (
+        "'pronouns' was not returned for the first list item"
+    )
+    assert "appearances" in panelists[0], (
+        "'appearances' was not returned for the first list item"
+    )
 
 
 def test_panelist_retrieve_all_ids():
@@ -154,6 +155,6 @@ def test_panelist_retrieve_details_by_slug(
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
     assert "slug" in info, f"'slug' was not returned for ID {panelist_slug}"
     assert "pronouns" in info, f"'pronouns' was not returned for ID {panelist_slug}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for slug {panelist_slug}"
+    assert "appearances" in info, (
+        f"'appearances' was not returned for slug {panelist_slug}"
+    )

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.PanelistScores`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.PanelistStatistics`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -101,9 +102,9 @@ def test_panelist_statistics_retrieve_statistics_by_id(
 
     assert "scoring" in stats, f"'scoring' was not returned for ID {panelist_id}"
     if include_decimal_scores:
-        assert (
-            "scoring_decimal" in stats
-        ), f"'scoring' was not returned for ID {panelist_id}"
+        assert "scoring_decimal" in stats, (
+            f"'scoring' was not returned for ID {panelist_id}"
+        )
     assert "ranking" in stats, f"'ranking' was not returned for ID {panelist_id}"
 
 
@@ -128,7 +129,7 @@ def test_panelist_statistics_retrieve_statistics_by_slug(
 
     assert "scoring" in stats, f"'scoring' was not returned for slug {panelist_slug}"
     if include_decimal_scores:
-        assert (
-            "scoring_decimal" in stats
-        ), f"'scoring' was not returned for ID {panelist_slug}"
+        assert "scoring_decimal" in stats, (
+            f"'scoring' was not returned for ID {panelist_slug}"
+        )
     assert "ranking" in stats, f"'ranking' was not returned for slug {panelist_slug}"

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.panelist.PanelistUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/pronoun/test_pronoun_pronouns.py
+++ b/tests/pronoun/test_pronoun_pronouns.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.pronoun.Pronouns`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -34,9 +35,9 @@ def test_pronouns_retrieve_all():
 
     assert all_pronouns, "No pronouns could be retrieved"
     assert "id" in all_pronouns[0], "'id' was not returned for the first list item"
-    assert (
-        "pronouns" in all_pronouns[0]
-    ), "'pronouns' was not returned for the first list item"
+    assert "pronouns" in all_pronouns[0], (
+        "'pronouns' was not returned for the first list item"
+    )
 
 
 def test_pronouns_retrieve_all_ids():

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperAppearances`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -51,9 +52,9 @@ def test_scorekeeper_appearance_retrieve_appearances_by_slug(scorekeeper_slug: s
     appearances = ScorekeeperAppearances(connect_dict=get_connect_dict())
     appearance = appearances.retrieve_appearances_by_slug(scorekeeper_slug)
 
-    assert (
-        "count" in appearance
-    ), f"'count' was not returned for slug {scorekeeper_slug}"
-    assert (
-        "shows" in appearance
-    ), f"'shows' was not returned for slug {scorekeeper_slug}"
+    assert "count" in appearance, (
+        f"'count' was not returned for slug {scorekeeper_slug}"
+    )
+    assert "shows" in appearance, (
+        f"'shows' was not returned for slug {scorekeeper_slug}"
+    )

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.scorekeeper.Scorekeeper`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -36,9 +37,9 @@ def test_scorekeeper_retrieve_all():
     assert "id" in scorekeepers[0], "'id' was not returned for the first list item"
     assert "name" in scorekeepers[0], "'name' was not returned for the first list item"
     assert "slug" in scorekeepers[0], "'slug' was not returned for the first list item"
-    assert (
-        "pronouns" in scorekeepers[0]
-    ), "'pronouns' was not returned for the first list item"
+    assert "pronouns" in scorekeepers[0], (
+        "'pronouns' was not returned for the first list item"
+    )
 
 
 def test_scorekeeper_retrieve_all_details():
@@ -50,12 +51,12 @@ def test_scorekeeper_retrieve_all_details():
     assert "id" in scorekeepers[0], "'id' was not returned for first list item"
     assert "name" in scorekeepers[0], "'name' was not returned for the first list item"
     assert "slug" in scorekeepers[0], "'slug' was not returned for the first list item"
-    assert (
-        "pronouns" in scorekeepers[0]
-    ), "'pronouns' was not returned for the first list item"
-    assert (
-        "appearances" in scorekeepers[0]
-    ), "'appearances' was not returned for the first list item"
+    assert "pronouns" in scorekeepers[0], (
+        "'pronouns' was not returned for the first list item"
+    )
+    assert "appearances" in scorekeepers[0], (
+        "'appearances' was not returned for the first list item"
+    )
 
 
 def test_scorekeeper_retrieve_all_ids():
@@ -104,9 +105,9 @@ def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
     assert "name" in info, f"'name' was not returned for ID {scorekeeper_id}"
     assert "slug" in info, f"'slug' was not returned for ID {scorekeeper_id}"
     assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_id}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for ID {scorekeeper_id}"
+    assert "appearances" in info, (
+        f"'appearances' was not returned for ID {scorekeeper_id}"
+    )
 
 
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
@@ -139,6 +140,6 @@ def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
     assert "name" in info, f"'name' was not returned for slug {scorekeeper_slug}"
     assert "slug" in info, f"'slug' was not returned for ID {scorekeeper_slug}"
     assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_slug}"
-    assert (
-        "appearances" in info
-    ), f"'appearances' was not returned for slug {scorekeeper_slug}"
+    assert "appearances" in info, (
+        f"'appearances' was not returned for slug {scorekeeper_slug}"
+    )

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:class:`wwdtm.scorekeeper.ScorekeeperUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object :py:class:`wwdtm.show.ShowInfo`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -37,9 +38,9 @@ def test_show_info_retrieve_bluff_info_by_id(show_id: int):
     info = ShowInfo(connect_dict=get_connect_dict())
     bluff = info.retrieve_bluff_info_by_id(show_id)
 
-    assert (
-        isinstance(bluff, list) and bluff
-    ), f"Bluff the Listener information for the show ID {show_id} could not be retrieved"
+    assert isinstance(bluff, list) and bluff, (
+        f"Bluff the Listener information for the show ID {show_id} could not be retrieved"
+    )
 
     assert "chosen_panelist" in bluff[0], (
         "'chosen_panelist' was not returned with panelist information for show ID "
@@ -62,12 +63,12 @@ def test_show_info_retrieve_core_info_by_id(show_id: int):
 
     assert show, f"Core information for show ID {show_id} could not be retrieved"
 
-    assert (
-        "id" in show
-    ), f"'id' was not returned with core information for show ID {show_id}"
-    assert (
-        "description" in show
-    ), f"'description' was not returned with show information for show ID {show_id}"
+    assert "id" in show, (
+        f"'id' was not returned with core information for show ID {show_id}"
+    )
+    assert "description" in show, (
+        f"'description' was not returned with show information for show ID {show_id}"
+    )
 
 
 @pytest.mark.parametrize("show_id", [1162])
@@ -80,12 +81,12 @@ def test_show_info_retrieve_guest_info_by_id(show_id: int):
     guests = info.retrieve_guest_info_by_id(show_id)
 
     assert guests, f"Guest information for show ID {show_id} could not be retrieved"
-    assert (
-        "id" in guests[0]
-    ), f"'id' was not returned for the first guest for show ID {show_id}"
-    assert (
-        "score" in guests[0]
-    ), f"'score' was not returned for the first guest for show ID {show_id}"
+    assert "id" in guests[0], (
+        f"'id' was not returned for the first guest for show ID {show_id}"
+    )
+    assert "score" in guests[0], (
+        f"'score' was not returned for the first guest for show ID {show_id}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -105,16 +106,16 @@ def test_show_info_retrieve_panelist_info_by_id(
         show_id, include_decimal_scores=include_decimal_scores
     )
 
-    assert (
-        panelists
-    ), f"Panelist information for show ID {show_id} could not be retrieved"
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
+    assert panelists, (
+        f"Panelist information for show ID {show_id} could not be retrieved"
+    )
+    assert "id" in panelists[0], (
+        f"'id' was not returned for the first panelist for show ID {show_id}"
+    )
+    assert "score" in panelists[0], (
+        f"'score' was not returned for the first panelist for show ID {show_id}"
+    )
     if include_decimal_scores:
-        assert (
-            "score_decimal" in panelists[0]
-        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+        assert "score_decimal" in panelists[0], (
+            f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+        )

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object :py:class:`wwdtm.show.ShowInfo`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -33,21 +34,21 @@ def test_show_info_retrieve_bluff_info_all(show_id: int):
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     bluffs = info.retrieve_bluff_info_all()
 
-    assert isinstance(
-        bluffs, dict
-    ), "Bluff the Listener information for all shows could not be retrieved"
+    assert isinstance(bluffs, dict), (
+        "Bluff the Listener information for all shows could not be retrieved"
+    )
 
-    assert show_id in bluffs and isinstance(
-        bluffs[show_id], list
-    ), f"Bluff the Listener information was not returned for show ID {show_id}"
+    assert show_id in bluffs and isinstance(bluffs[show_id], list), (
+        f"Bluff the Listener information was not returned for show ID {show_id}"
+    )
 
-    assert (
-        "chosen_panelist" in bluffs[show_id][0]
-    ), f"'chosen_panelist' was not returned with panelist information for show ID {show_id}"
+    assert "chosen_panelist" in bluffs[show_id][0], (
+        f"'chosen_panelist' was not returned with panelist information for show ID {show_id}"
+    )
 
-    assert (
-        "correct_panelist" in bluffs[show_id][0]
-    ), f"'correct_panelist' was not returned with panelist information for show ID {show_id}"
+    assert "correct_panelist" in bluffs[show_id][0], (
+        f"'correct_panelist' was not returned with panelist information for show ID {show_id}"
+    )
 
 
 @pytest.mark.parametrize("show_ids", [[319, 1083, 1162]])
@@ -66,9 +67,9 @@ def test_show_info_retrieve_bluff_info_by_ids(show_ids: list[int]):
     )
 
     for show_id in show_ids:
-        assert show_id in bluffs and isinstance(
-            bluffs[show_id], list
-        ), f"Bluff the Listener information was not returned for show ID {show_id}"
+        assert show_id in bluffs and isinstance(bluffs[show_id], list), (
+            f"Bluff the Listener information was not returned for show ID {show_id}"
+        )
 
         assert "chosen_panelist" in bluffs[show_id][0], (
             "'chosen_panelist' was not returned with panelist information for show ID "
@@ -92,17 +93,17 @@ def test_show_info_retrieve_core_info_all(show_id: int):
     shows = info.retrieve_core_info_all()
 
     assert shows, "Core information for all shows could not be retrieved"
-    assert (
-        show_id in shows
-    ), f"Core information for show ID {show_id} could not be retrieved"
+    assert show_id in shows, (
+        f"Core information for show ID {show_id} could not be retrieved"
+    )
 
     show = shows[show_id]
-    assert (
-        "id" in show
-    ), f"'id' was not returned with core information for show ID {show_id}"
-    assert (
-        "description" in show
-    ), f"'description' was not returned with show information for show ID {show_id}"
+    assert "id" in show, (
+        f"'id' was not returned with core information for show ID {show_id}"
+    )
+    assert "description" in show, (
+        f"'description' was not returned with show information for show ID {show_id}"
+    )
 
 
 @pytest.mark.parametrize("show_ids", [[1082, 1162]])
@@ -117,12 +118,12 @@ def test_show_info_retrieve_core_info_by_ids(show_ids: list[int]):
     assert shows, "Core information all shows could not be retrieved"
 
     for show_id in show_ids:
-        assert (
-            show_id in shows
-        ), f"Core information could not be retrieved for show ID {show_id}"
-        assert (
-            "id" in shows[show_id]
-        ), f"'id' was not returned with core information for show ID {show_id}"
+        assert show_id in shows, (
+            f"Core information could not be retrieved for show ID {show_id}"
+        )
+        assert "id" in shows[show_id], (
+            f"'id' was not returned with core information for show ID {show_id}"
+        )
         assert "description" in shows[show_id], (
             "'description' was not returned with show information for show ID "
             f"{show_id}"
@@ -140,18 +141,18 @@ def test_show_info_retrieve_guest_info_all(show_id: int):
     shows_guests = info.retrieve_guest_info_all()
 
     assert shows_guests, "Guest information all shows could not be retrieved"
-    assert (
-        show_id in shows_guests
-    ), f"Guest information could not be retrieved for show ID {show_id}"
+    assert show_id in shows_guests, (
+        f"Guest information could not be retrieved for show ID {show_id}"
+    )
 
     guests = shows_guests[show_id]
     if guests:
-        assert (
-            "id" in guests[0]
-        ), f"'id' was not returned for the first guest for show ID {show_id}"
-        assert (
-            "score" in guests[0]
-        ), f"'score' was not returned for the first guest for show ID {show_id}"
+        assert "id" in guests[0], (
+            f"'id' was not returned for the first guest for show ID {show_id}"
+        )
+        assert "score" in guests[0], (
+            f"'score' was not returned for the first guest for show ID {show_id}"
+        )
 
 
 @pytest.mark.parametrize("show_ids", [[1082, 1162]])
@@ -164,23 +165,23 @@ def test_show_info_retrieve_guest_info_by_ids(show_ids: list[int]):
     info = ShowInfoMultiple(connect_dict=get_connect_dict())
     shows_guests = info.retrieve_guest_info_by_ids(show_ids)
 
-    assert (
-        shows_guests
-    ), f"Guest information for show IDs {show_ids} could not be retrieved"
+    assert shows_guests, (
+        f"Guest information for show IDs {show_ids} could not be retrieved"
+    )
 
     for show_id in show_ids:
-        assert (
-            show_id in shows_guests
-        ), f"Guest information for show ID {show_id} could not be retrieved"
+        assert show_id in shows_guests, (
+            f"Guest information for show ID {show_id} could not be retrieved"
+        )
 
         guests = shows_guests[show_id]
         if guests:
-            assert (
-                "id" in guests[0]
-            ), f"'id' was not returned for the first guest for show ID {show_id}"
-            assert (
-                "score" in guests[0]
-            ), f"'score' was not returned for the first guest for show ID {show_id}"
+            assert "id" in guests[0], (
+                f"'id' was not returned for the first guest for show ID {show_id}"
+            )
+            assert "score" in guests[0], (
+                f"'score' was not returned for the first guest for show ID {show_id}"
+            )
 
 
 @pytest.mark.parametrize(
@@ -202,21 +203,21 @@ def test_show_info_retrieve_panelist_info_all(
     )
 
     assert shows_panelists, "Panelist information for all shows could not be retrieved"
-    assert (
-        show_id in shows_panelists
-    ), f"Panelist information could not be retrieved for show ID {show_id}"
+    assert show_id in shows_panelists, (
+        f"Panelist information could not be retrieved for show ID {show_id}"
+    )
 
     panelists = shows_panelists[show_id]
-    assert (
-        "id" in panelists[0]
-    ), f"'id' was not returned for the first panelist for show ID {show_id}"
-    assert (
-        "score" in panelists[0]
-    ), f"'score' was not returned for the first panelist for show ID {show_id}"
+    assert "id" in panelists[0], (
+        f"'id' was not returned for the first panelist for show ID {show_id}"
+    )
+    assert "score" in panelists[0], (
+        f"'score' was not returned for the first panelist for show ID {show_id}"
+    )
     if include_decimal_scores:
-        assert (
-            "score_decimal" in panelists[0]
-        ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+        assert "score_decimal" in panelists[0], (
+            f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -237,24 +238,23 @@ def test_show_info_retrieve_panelist_info_by_ids(
         show_ids, include_decimal_scores=include_decimal_scores
     )
 
-    assert (
-        shows_panelists
-    ), f"Panelist information for show IDs {show_ids} could not be retrieved"
+    assert shows_panelists, (
+        f"Panelist information for show IDs {show_ids} could not be retrieved"
+    )
 
     for show_id in shows_panelists:
-        assert (
-            show_id in shows_panelists
-        ), f"Panelist information could not be retrieved for show ID {show_id}"
+        assert show_id in shows_panelists, (
+            f"Panelist information could not be retrieved for show ID {show_id}"
+        )
         panelists = shows_panelists[show_id]
         if panelists:
-            assert (
-                "id" in panelists[0]
-            ), f"'id' was not returned for the first panelist for show ID {show_id}"
+            assert "id" in panelists[0], (
+                f"'id' was not returned for the first panelist for show ID {show_id}"
+            )
             assert "score" in panelists[0], (
-                f"'score' was not returned for the first panelist for show ID "
-                f"{show_id}"
+                f"'score' was not returned for the first panelist for show ID {show_id}"
             )
             if include_decimal_scores:
-                assert (
-                    "score_decimal" in panelists[0]
-                ), f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+                assert "score_decimal" in panelists[0], (
+                    f"'score_decimal' was not returned for the first panelist for show ID {show_id}"
+                )

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object :py:class:`wwdtm.show.Show`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -212,9 +213,9 @@ def test_show_retrieve_by_date(year: int, month: int, day: int):
     info = show.retrieve_by_date(year, month, day)
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert (
-        "date" in info
-    ), f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    assert "date" in info, (
+        f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    )
 
 
 @pytest.mark.parametrize("date", ["2018-10-27"])
@@ -271,9 +272,9 @@ def test_show_retrieve_by_year(year: int):
     shows = show.retrieve_by_year(year)
 
     assert shows, f"No shows could be retrieved for year {year:04d}"
-    assert (
-        "id" in shows[0]
-    ), f"'id' was not returned for the first list item for year {year:04d}"
+    assert "id" in shows[0], (
+        f"'id' was not returned for the first list item for year {year:04d}"
+    )
 
 
 @pytest.mark.parametrize("year, month", [(1998, 1), (2018, 10)])
@@ -315,12 +316,12 @@ def test_show_retrieve_details_by_date(
     )
 
     assert info, f"Show for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert (
-        "date" in info
-    ), f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
-    assert (
-        "host" in info
-    ), f"'host' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    assert "date" in info, (
+        f"'date' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    )
+    assert "host" in info, (
+        f"'host' was not returned for show {year:04d}-{month:02d}-{day:02d}"
+    )
 
 
 @pytest.mark.parametrize(
@@ -420,12 +421,12 @@ def test_show_retrieve_details_by_year(year: int, include_decimal_scores: bool):
     )
 
     assert info, f"No shows could be retrieved for year {year:04d}"
-    assert (
-        "date" in info[0]
-    ), f"'date' was not returned for first list item for year {year:04d}"
-    assert (
-        "host" in info[0]
-    ), f"'host' was not returned for first list item for year {year:04d}"
+    assert "date" in info[0], (
+        f"'date' was not returned for first list item for year {year:04d}"
+    )
+    assert "host" in info[0], (
+        f"'host' was not returned for first list item for year {year:04d}"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object :py:class:`wwdtm.show.ShowUtility`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -39,9 +40,9 @@ def test_show_utility_convert_date_to_id(year: int, month: int, day: int):
     id_ = utility.convert_date_to_id(year, month, day)
 
     assert id_, f"Show ID for date {year:04d}-{month:02d}-{day:02d} not found"
-    assert isinstance(
-        id_, int
-    ), f"Invalid value returned for date {year:04d}-{month:02d}-{day:02d}"
+    assert isinstance(id_, int), (
+        f"Invalid value returned for date {year:04d}-{month:02d}-{day:02d}"
+    )
 
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 26)])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object: :py:module:`wwdtm`."""
+
 import json
 from pathlib import Path
 from typing import Any
@@ -33,11 +34,11 @@ def test_database_version():
     """Testing for :py:func:`wwdtm.database_version`."""
     _database_version = database_version(connect_dict=get_connect_dict())
 
-    assert isinstance(
-        _database_version, tuple
-    ), "Invalid database version value type returned"
+    assert isinstance(_database_version, tuple), (
+        "Invalid database version value type returned"
+    )
 
     if isinstance(_database_version, tuple):
-        assert (
-            len(_database_version) == 2 or len(_database_version) == 3
-        ), "Invalid database version value returned"
+        assert len(_database_version) == 2 or len(_database_version) == 3, (
+            "Invalid database version value returned"
+        )

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2018-2024 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.validation`."""
+
 import pytest
 
 from wwdtm.validation import valid_int_id

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Explicitly listing all modules in this package."""
+
 from typing import Any
 
 from mysql.connector import connect
@@ -25,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.14.0"
+VERSION = "2.15.0"
 
 
 def database_version(

--- a/wwdtm/guest/__init__.py
+++ b/wwdtm/guest/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Guest module."""
+
 from wwdtm.guest.appearances import GuestAppearances
 from wwdtm.guest.guest import Guest
 from wwdtm.guest.utility import GuestUtility

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Guest Appearance Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Guest Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Guest Data Utility Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/host/__init__.py
+++ b/wwdtm/host/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Host module."""
+
 from wwdtm.host.appearances import HostAppearances
 from wwdtm.host.host import Host
 from wwdtm.host.utility import HostUtility

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Host Appearance Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Host Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Host Data Utility Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/location/__init__.py
+++ b/wwdtm/location/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Location module."""
+
 from wwdtm.location.location import Location
 from wwdtm.location.recordings import LocationRecordings
 from wwdtm.location.utility import LocationUtility

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Location Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect
@@ -59,7 +60,7 @@ class Location:
             pa.name AS state_name, l.venue, l.latitude, l.longitude,
             l.locationslug AS slug
             FROM ww_locations l
-            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             """
 
         if sort_by_venue:
@@ -121,7 +122,7 @@ class Location:
             pa.name AS state_name, l.venue, l.latitude, l.longitude,
             l.locationslug AS slug
             FROM ww_locations l
-            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             """
         if sort_by_venue:
             query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
@@ -180,7 +181,7 @@ class Location:
         query = """
             SELECT l.locationid
             FROM ww_locations l
-            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             """
         if sort_by_venue:
             query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
@@ -207,7 +208,7 @@ class Location:
         query = """
             SELECT l.locationslug
             FROM ww_locations l
-            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             """
         if sort_by_venue:
             query = query + " ORDER BY l.venue ASC, l.city ASC, pa.name ASC;"
@@ -239,7 +240,7 @@ class Location:
             pa.name AS state_name, l.venue, l.latitude, l.longitude,
             l.locationslug AS slug
             FROM ww_locations l
-            JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
+            LEFT JOIN ww_postal_abbreviations pa ON pa.postal_abbreviation = l.state
             WHERE l.locationid = %s
             LIMIT 1;
             """
@@ -335,3 +336,30 @@ class Location:
             return {}
 
         return self.retrieve_details_by_id(id_)
+
+    def retrieve_postal_abbreviations(self) -> dict[str, dict[str, str]]:
+        """Retrieves postal abbreviations and corresponding values.
+
+        :return: A dictionary containing postal abbreviation as keys
+            and corresponding name and country as values.
+        """
+        query = """
+            SELECT postal_abbreviation, name, country
+            FROM ww_postal_abbreviations
+            ORDER BY postal_abbreviation ASC;
+            """
+        cursor = self.database_connection.cursor(dictionary=True)
+        cursor.execute(query)
+        results = cursor.fetchall()
+
+        if not results:
+            return None
+
+        abbreviations = {}
+        for row in results:
+            abbreviations[row["postal_abbreviation"]] = {
+                "name": row["name"],
+                "country": row["country"],
+            }
+
+        return abbreviations

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Location Recordings Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Location Data Utility Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/panelist/__init__.py
+++ b/wwdtm/panelist/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Panelist module."""
+
 from wwdtm.panelist.appearances import PanelistAppearances
 from wwdtm.panelist.decimal_scores import PanelistDecimalScores
 from wwdtm.panelist.panelist import Panelist

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Appearance Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Decimal Scores Retrieval Functions."""
+
 from decimal import Decimal
 from math import floor
 from typing import Any

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Scores Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Statistics Retrieval Functions."""
+
 from decimal import Decimal
 from typing import Any
 

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Panelist Data Utility Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/pronoun/__init__.py
+++ b/wwdtm/pronoun/__init__.py
@@ -4,4 +4,5 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Pronouns module."""
+
 from wwdtm.pronoun.pronouns import Pronouns

--- a/wwdtm/pronoun/pronouns.py
+++ b/wwdtm/pronoun/pronouns.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Pronouns Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/scorekeeper/__init__.py
+++ b/wwdtm/scorekeeper/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Scorekeeper module."""
+
 from wwdtm.scorekeeper.appearances import ScorekeeperAppearances
 from wwdtm.scorekeeper.scorekeeper import Scorekeeper
 from wwdtm.scorekeeper.utility import ScorekeeperUtility

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Scorekeeper Appearance Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Scorekeeper Data Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Scorekeeper Data Utility Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats: Show module."""
+
 from wwdtm.show.info import ShowInfo
 from wwdtm.show.info_multiple import ShowInfoMultiple
 from wwdtm.show.show import Show

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Show Detailed Information Retrieval Functions."""
+
 from typing import Any
 
 from mysql.connector import connect

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=C0209
 """Wait Wait Stats Show Detailed Information Retrieval Functions for Multiple Shows."""
+
 from typing import Any
 
 from mysql.connector import connect
@@ -439,9 +440,7 @@ class ShowInfoMultiple:
             JOIN ww_showdescriptions sd ON sd.showid = s.showid
             JOIN ww_shownotes sn ON sn.showid = s.showid
             WHERE s.showid IN ({ids})
-            ORDER BY s.showdate ASC;""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
+            ORDER BY s.showdate ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -600,9 +599,7 @@ class ShowInfoMultiple:
             JOIN ww_shows s ON s.showid = gm.showid
             WHERE gm.showid IN ({ids})
             ORDER BY s.showdate ASC,
-            gm.showguestmapid ASC;""".format(
-            ids=", ".join(str(v) for v in show_ids)
-        )
+            gm.showguestmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)
         results = cursor.fetchall()
@@ -738,9 +735,7 @@ class ShowInfoMultiple:
                 JOIN ww_shows s ON s.showid = pm.showid
                 WHERE pm.showid IN ({ids})
                 ORDER by s.showdate ASC, pm.panelistscore_decimal DESC,
-                pm.showpnlmapid ASC;""".format(
-                ids=", ".join(str(v) for v in show_ids)
-            )
+                pm.showpnlmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
         else:
             query = """
                 SELECT s.showid AS show_id, pm.panelistid AS panelist_id,
@@ -753,9 +748,7 @@ class ShowInfoMultiple:
                 JOIN ww_shows s ON s.showid = pm.showid
                 WHERE pm.showid IN ({ids})
                 ORDER by s.showdate ASC, pm.panelistscore DESC,
-                pm.showpnlmapid ASC;""".format(
-                ids=", ".join(str(v) for v in show_ids)
-            )
+                pm.showpnlmapid ASC;""".format(ids=", ".join(str(v) for v in show_ids))
 
         cursor = self.database_connection.cursor(dictionary=True)
         cursor.execute(query)

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 # pylint: disable=C0206
 """Wait Wait Stats Show Information Retrieval Functions."""
+
 import datetime
 from decimal import Decimal
 from typing import Any

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Wait Wait Stats Show Data Utility Functions."""
+
 import datetime
 from typing import Any
 


### PR DESCRIPTION
Application Changes
-------------------

* Change SQL joins from ``JOIN`` to ``LEFT JOIN`` in :py:class:`wwdtm.location.Location` to properly handle ``NULL`` values in the ``state`` column
* Add :py:meth:`wwdtm.location.Location.retrieve_postal_abbreviations` that returns postal abbreviations and their corresponding names and countries

Development Changes
-------------------

* Upgrade ruff from 0.7.0 to 0.9.3
* Remove black from required development packages as part of migrating entirely to Ruff
* Ran ```ruff format``` to format Python code files using the Ruff 2025 Style Guide