### PR TITLE
Add methods to get random show data, ID and date for a given year

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Changes
 Application Changes
 -------------------
 
-* Added the following methods to :py:class`wwdtm.show.Show` to extend the random show feature
+* Added the following methods to :py:class:`wwdtm.show.Show` to extend the random show feature
 
   * :py:meth:`wwdtm.show.Show.retrieve_random_id_by_year`
   * :py:meth:`wwdtm.show.Show.retrieve_random_date_by_year`

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@
 Changes
 *******
 
+2.17.0
+======
+
+Application Changes
+-------------------
+
+* Added the following methods to :py:class`wwdtm.show.Show` to extend the random show feature
+
+  * :py:meth:`wwdtm.show.Show.retrieve_random_id_by_year`
+  * :py:meth:`wwdtm.show.Show.retrieve_random_date_by_year`
+  * :py:meth:`wwdtm.show.Show.retrieve_random_by_year`
+  * :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year`
+
 2.16.1
 ======
 

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -514,7 +514,7 @@ def test_show_retrieve_years():
 
 
 def test_show_retrieve_random_id() -> None:
-    """Testing for :py:meth`wwdtm.show.Show.retrieve_random_id`."""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_id`."""
     show = Show(connect_dict=get_connect_dict())
     _id = show.retrieve_random_id()
 
@@ -522,13 +522,43 @@ def test_show_retrieve_random_id() -> None:
     assert isinstance(_id, int), "Returned random show ID is not an integer"
 
 
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_show_retrieve_random_id_by_year(year: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_id_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    _id = show.retrieve_random_id_by_year(year=year)
+
+    assert _id, "Returned random show ID is not valid"
+    assert isinstance(_id, int), "Returned random show ID is not an integer"
+
+    _show = show.retrieve_by_id(show_id=_id)
+
+    assert _show, f"Returned random show data for {_id} is not valid"
+    assert str(year) in _show["date"], f"Show date for {_id} is not from {year}"
+
+
 def test_show_retrieve_random_date() -> None:
-    """Testing for :py:meth`wwdtm.show.Show.retrieve_random_date`."""
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_date`."""
     show = Show(connect_dict=get_connect_dict())
     _date = show.retrieve_random_date()
 
     assert _date, "Returned random show date string is not valid"
     assert isinstance(_date, str), "Returned random show date string is not a string"
+
+
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_show_retrieve_random_date_by_year(year: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_date_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    _date = show.retrieve_random_date_by_year(year=year)
+
+    assert _date, "Returned random show ID is not valid"
+    assert isinstance(_date, str), "Returned random show ID is not an integer"
+    assert str(year) in _date, f"Returned random show date is not from {year}"
+
+    _show = show.retrieve_by_date_string(date_string=_date)
+
+    assert _show, f"Returned random show data for {_date} is not valid"
 
 
 def test_show_retrieve_random() -> None:
@@ -540,6 +570,17 @@ def test_show_retrieve_random() -> None:
     assert "date" in info, "'date' was not returned for a random show"
 
 
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_show_retrieve_random_by_year(year: int) -> None:
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    info = show.retrieve_random_by_year(year=year)
+
+    assert info, "Random show not found"
+    assert "date" in info, "'date' was not returned for a random show"
+    assert str(year) in info["date"], f"Returned random show data is not from {year}"
+
+
 def test_show_retrieve_random_details() -> None:
     """Testing for :py:meth:`wwdtm.panelist.Show.retrieve_random_details`."""
     show = Show(connect_dict=get_connect_dict())
@@ -547,4 +588,16 @@ def test_show_retrieve_random_details() -> None:
 
     assert info, "Random show not found"
     assert "date" in info, "'date' was not returned for a random show"
+    assert "host" in info, "'host' was not returned for a random show"
+
+
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_show_retrieve_random_details_by_year(year: int) -> None:
+    """Testing for :py:meth:`wwdtm.panelist.Show.retrieve_random_details_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    info = show.retrieve_random_details_by_year(year=year)
+
+    assert info, "Random show not found"
+    assert "date" in info, "'date' was not returned for a random show"
+    assert str(year) in info["date"], f"Returned random show data is not from {year}"
     assert "host" in info, "'host' was not returned for a random show"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.16.1"
+VERSION = "2.17.0"
 
 
 def database_version(

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -993,6 +993,28 @@ class Show:
 
         return result[0]
 
+    def retrieve_random_id_by_year(self, year: int) -> int:
+        """Retrieves an ID for a random show for a given year.
+
+        :return: ID for a random show.
+        """
+        query = """
+            SELECT showid FROM ww_shows
+            WHERE showdate <= NOW()
+            AND YEAR(showdate) = %s
+            ORDER BY RAND()
+            LIMIT 1;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query, (year,))
+        result = cursor.fetchone()
+        cursor.close()
+
+        if not result:
+            return None
+
+        return result[0]
+
     def retrieve_random_date(self) -> str:
         """Retrieves a date for a random show.
 
@@ -1006,6 +1028,28 @@ class Show:
             """
         cursor = self.database_connection.cursor(dictionary=False)
         cursor.execute(query)
+        result = cursor.fetchone()
+        cursor.close()
+
+        if not result:
+            return None
+
+        return result[0].isoformat()
+
+    def retrieve_random_date_by_year(self, year: int) -> str:
+        """Retrieves a date for a random show for a given year.
+
+        :return: show date string for a random show, in YYYY-MM-DD format.
+        """
+        query = """
+            SELECT showdate FROM ww_shows
+            WHERE showdate <= NOW()
+            AND YEAR(showdate) = %s
+            ORDER BY RAND()
+            LIMIT 1;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query, (year,))
         result = cursor.fetchone()
         cursor.close()
 
@@ -1028,6 +1072,20 @@ class Show:
 
         return self.retrieve_by_id(show_id=_id)
 
+    def retrieve_random_by_year(self, year: int) -> dict[str, Any]:
+        """Retrieves information for a random show for a given year.
+
+        :return: A dictionary containing show ID, show date, Best Of
+            show flag, repeat show ID (if applicable) and show URL at
+            NPR.org
+        """
+        _id = self.retrieve_random_id_by_year(year=year)
+
+        if not _id:
+            return None
+
+        return self.retrieve_by_id(show_id=_id)
+
     def retrieve_random_details(self) -> dict[str, Any]:
         """Retrieves information and appearances for a random show.
 
@@ -1036,6 +1094,20 @@ class Show:
             NPR.org, host, scorekeeper, location, panelists and guests
         """
         _id = self.retrieve_random_id()
+
+        if not _id:
+            return None
+
+        return self.retrieve_details_by_id(show_id=_id)
+
+    def retrieve_random_details_by_year(self, year: int) -> dict[str, Any]:
+        """Retrieves information and appearances for a random show for a given year.
+
+        :return: A dictionary containing show ID, show date, Best Of
+            show flag, repeat show ID (if applicable), show URL at
+            NPR.org, host, scorekeeper, location, panelists and guests
+        """
+        _id = self.retrieve_random_id_by_year(year=year)
 
         if not _id:
             return None


### PR DESCRIPTION
## Application Changes

* Added the following methods to :py:class:`wwdtm.show.Show` to extend the random show feature
  * :py:meth:`wwdtm.show.Show.retrieve_random_id_by_year`
  * :py:meth:`wwdtm.show.Show.retrieve_random_date_by_year`
  * :py:meth:`wwdtm.show.Show.retrieve_random_by_year`
  * :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year`