### PR TITLE
Add missing include_decimal_scores parameters and passthrough for random details methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@
 Changes
 *******
 
+2.17.1
+======
+
+Application Changes
+-------------------
+
+* Added missing ``include_decimal_scores`` method parameter to :py:meth:`wwdtm.show.Show.retrieve_random_details` and :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year` and passthrough to :py:meth:`wwdtm.show.Show.retrieve_details_by_id`
+
+Development Changes
+-------------------
+
+* Updated tests for :py:meth:`wwdtm.show.Show.retrieve_random_details` and :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year` to including passing in values for the corresponding ``include_decimal_scores`` parameters
+
 2.17.0
 ======
 

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -581,21 +581,29 @@ def test_show_retrieve_random_by_year(year: int) -> None:
     assert str(year) in info["date"], f"Returned random show data is not from {year}"
 
 
-def test_show_retrieve_random_details() -> None:
+@pytest.mark.parametrize("include_decimal_scores", [True, False])
+def test_show_retrieve_random_details(include_decimal_scores: bool) -> None:
     """Testing for :py:meth:`wwdtm.panelist.Show.retrieve_random_details`."""
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_random_details()
+    info = show.retrieve_random_details(include_decimal_scores=include_decimal_scores)
 
     assert info, "Random show not found"
     assert "date" in info, "'date' was not returned for a random show"
     assert "host" in info, "'host' was not returned for a random show"
 
 
-@pytest.mark.parametrize("year", [1998, 2020])
-def test_show_retrieve_random_details_by_year(year: int) -> None:
+@pytest.mark.parametrize(
+    "year, include_decimal_scores",
+    ([1998, True], [1998, False], [2020, True], [2020, False]),
+)
+def test_show_retrieve_random_details_by_year(
+    year: int, include_decimal_scores: bool
+) -> None:
     """Testing for :py:meth:`wwdtm.panelist.Show.retrieve_random_details_by_year`."""
     show = Show(connect_dict=get_connect_dict())
-    info = show.retrieve_random_details_by_year(year=year)
+    info = show.retrieve_random_details_by_year(
+        year=year, include_decimal_scores=include_decimal_scores
+    )
 
     assert info, "Random show not found"
     assert "date" in info, "'date' was not returned for a random show"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.17.0"
+VERSION = "2.17.1"
 
 
 def database_version(

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -1086,7 +1086,9 @@ class Show:
 
         return self.retrieve_by_id(show_id=_id)
 
-    def retrieve_random_details(self) -> dict[str, Any]:
+    def retrieve_random_details(
+        self, include_decimal_scores: bool = False
+    ) -> dict[str, Any]:
         """Retrieves information and appearances for a random show.
 
         :return: A dictionary containing show ID, show date, Best Of
@@ -1098,9 +1100,13 @@ class Show:
         if not _id:
             return None
 
-        return self.retrieve_details_by_id(show_id=_id)
+        return self.retrieve_details_by_id(
+            show_id=_id, include_decimal_scores=include_decimal_scores
+        )
 
-    def retrieve_random_details_by_year(self, year: int) -> dict[str, Any]:
+    def retrieve_random_details_by_year(
+        self, year: int, include_decimal_scores: bool = False
+    ) -> dict[str, Any]:
         """Retrieves information and appearances for a random show for a given year.
 
         :return: A dictionary containing show ID, show date, Best Of
@@ -1112,7 +1118,9 @@ class Show:
         if not _id:
             return None
 
-        return self.retrieve_details_by_id(show_id=_id)
+        return self.retrieve_details_by_id(
+            show_id=_id, include_decimal_scores=include_decimal_scores
+        )
 
     def retrieve_recent(
         self,


### PR DESCRIPTION
Application Changes
-------------------

* Added missing ``include_decimal_scores`` method parameter to :py:meth:`wwdtm.show.Show.retrieve_random_details` and :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year` and passthrough to :py:meth:`wwdtm.show.Show.retrieve_details_by_id`

Development Changes
-------------------

* Updated tests for :py:meth:`wwdtm.show.Show.retrieve_random_details` and :py:meth:`wwdtm.show.Show.retrieve_random_details_by_year` to including passing in values for the corresponding ``include_decimal_scores`` parameters
