### PR TITLE
Add missing use_decimal_scores parameters and passthrough for random details methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,18 @@
 Changes
 *******
 
+2.17.2
+
+Application Changes
+-------------------
+
+* Added missing ``use_decimal_scores`` method parameter to :py:meth:`wwdtm.panelist.Panelist.retrieve_random_details`
+
+Development Changes
+-------------------
+
+* Updated test for :py:meth:`wwdtm.panelist.Panelist.retrieve_random_details` to including passing in values for ``use_decimal_scores``
+
 2.17.1
 ======
 

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -191,10 +191,11 @@ def test_panelist_retrieve_random() -> None:
     assert "pronouns" in info, "'pronouns' was not returned for a random panelist"
 
 
-def test_panelist_retrieve_random_details() -> None:
+@pytest.mark.parametrize("use_decimal_scores", [True, False])
+def test_panelist_retrieve_random_details(use_decimal_scores: bool) -> None:
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_random_details`."""
     panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_random_details()
+    info = panelist.retrieve_random_details(use_decimal_scores=use_decimal_scores)
 
     assert info, "Random panelist not found"
     assert "name" in info, "'name' attribute was not returned for a random panelist"

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.17.1"
+VERSION = "2.17.2"
 
 
 def database_version(

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -377,7 +377,9 @@ class Panelist:
 
         return self.retrieve_by_id(panelist_id=_id)
 
-    def retrieve_random_details(self) -> dict[str, Any]:
+    def retrieve_random_details(
+        self, use_decimal_scores: bool = False
+    ) -> dict[str, Any]:
         """Retrieves information and appearances for a random panelist.
 
         :return: A dictionary containing panelist ID, name, slug string,
@@ -388,4 +390,6 @@ class Panelist:
         if not _id:
             return None
 
-        return self.retrieve_details_by_id(panelist_id=_id)
+        return self.retrieve_details_by_id(
+            panelist_id=_id, use_decimal_scores=use_decimal_scores
+        )


### PR DESCRIPTION
Application Changes
-------------------

* Added missing ``use_decimal_scores`` method parameter to :py:meth:`wwdtm.panelist.Panelist.retrieve_random_details`

Development Changes
-------------------

* Updated test for :py:meth:`wwdtm.panelist.Panelist.retrieve_random_details` to including passing in values for ``use_decimal_scores``