### PR TITLE
Add Show methods to retrieve show counts by year or for all years, grouped by year

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
-ignore = E203, E501, F401
+ignore = E203, E501, F401, W503
 max-line-length = 88

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Application Changes
 -------------------
 
 * Adding :py:meth:`wwdtm.show.Show.retrieve_counts_by_year` to retrieve a count of regular, Best Of, repeat, repeat Best Of and a total count of shows
+* Adding :py:meth:`wwdtm.show.Show.retrieve_all_counts_by_year` to retrieve a count of regular, Best Of, repeat, repeat Best Of and a total count of shows for all years, grouped by year
 
 Component Changes
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,21 @@
 Changes
 *******
 
+2.18.0
+======
+
+Application Changes
+-------------------
+
+* Adding :py:meth:`wwdtm.show.Show.retrieve_counts_by_year` to retrieve a count of regular, Best Of, repeat, repeat Best Of and a total count of shows
+
+Component Changes
+-----------------
+
+* Upgrade pytz from 2024.2 to 2025.2
+
 2.17.2
+======
 
 Application Changes
 -------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "mysql-connector-python==9.1.0",
     "numpy==2.1.2",
     "python-slugify==8.0.4",
-    "pytz==2024.2",
+    "pytz==2025.2",
 ]
 
 [project.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ build==1.2.2.post1
 mysql-connector-python==9.1.0
 numpy==2.1.2
 python-slugify==8.0.4
-pytz==2024.2
+pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mysql-connector-python==9.1.0
 numpy==2.1.2
 python-slugify==8.0.4
-pytz==2024.2
+pytz==2025.2

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -295,6 +295,46 @@ def test_show_retrieve_by_year_month(year: int, month: int):
     )
 
 
+@pytest.mark.parametrize("year", [1998, 2010])
+def test_show_retrieve_counts_by_year(year: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_counts_by_year`.
+
+    :param year: Four digit year to test retrieving show counts
+    """
+    show = Show(connect_dict=get_connect_dict())
+    counts = show.retrieve_counts_by_year(year)
+
+    assert "regular" in counts, f"No regular show count retrieved for year {year:04d}"
+    assert counts["regular"] is not None, (
+        f"Invalid regular show count for year {year:04d}"
+    )
+    assert "best_of" in counts, f"No Best Of show count retrieved for year {year:04d}"
+    assert counts["best_of"] is not None, (
+        f"Invalid Best Of show count for year {year:04d}"
+    )
+    assert "repeat" in counts, f"No repeat show count retrieved for year {year:04d}"
+    assert counts["repeat"] is not None, (
+        f"Invalid repeat show count for year {year:04d}"
+    )
+    assert "repeat_best_of" in counts, (
+        f"No repeat Best Of show count retrieved for year {year:04d}"
+    )
+    assert counts["repeat_best_of"] is not None, (
+        f"Invalid repeat Best Of show count for year {year:04d}"
+    )
+    assert "total" in counts, f"No total show count retrieved for year {year:04d}"
+    assert counts["total"] is not None, (
+        f"Incorrect total show count for year {year:04d}"
+    )
+    assert (
+        counts["total"]
+        == counts["regular"]
+        + counts["best_of"]
+        + counts["repeat"]
+        + counts["repeat_best_of"]
+    ), f"Total show count does not match actual total show count for year {year:04d}"
+
+
 @pytest.mark.parametrize(
     "year, month, day, include_decimal_scores",
     [(2020, 4, 25, True), (2020, 4, 25, False)],

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -304,25 +304,26 @@ def test_show_retrieve_counts_by_year(year: int):
     show = Show(connect_dict=get_connect_dict())
     counts = show.retrieve_counts_by_year(year)
 
-    assert "regular" in counts, f"No regular show count retrieved for year {year:04d}"
+    assert counts, f"No show counts were returned for year {year:04d}"
+    assert "regular" in counts, f"No regular show count returned for year {year:04d}"
     assert counts["regular"] is not None, (
         f"Invalid regular show count for year {year:04d}"
     )
-    assert "best_of" in counts, f"No Best Of show count retrieved for year {year:04d}"
+    assert "best_of" in counts, f"No Best Of show count returned for year {year:04d}"
     assert counts["best_of"] is not None, (
         f"Invalid Best Of show count for year {year:04d}"
     )
-    assert "repeat" in counts, f"No repeat show count retrieved for year {year:04d}"
+    assert "repeat" in counts, f"No repeat show count returned for year {year:04d}"
     assert counts["repeat"] is not None, (
         f"Invalid repeat show count for year {year:04d}"
     )
     assert "repeat_best_of" in counts, (
-        f"No repeat Best Of show count retrieved for year {year:04d}"
+        f"No repeat Best Of show count returned for year {year:04d}"
     )
     assert counts["repeat_best_of"] is not None, (
         f"Invalid repeat Best Of show count for year {year:04d}"
     )
-    assert "total" in counts, f"No total show count retrieved for year {year:04d}"
+    assert "total" in counts, f"No total show count returned for year {year:04d}"
     assert counts["total"] is not None, (
         f"Incorrect total show count for year {year:04d}"
     )
@@ -333,6 +334,33 @@ def test_show_retrieve_counts_by_year(year: int):
         + counts["repeat"]
         + counts["repeat_best_of"]
     ), f"Total show count does not match actual total show count for year {year:04d}"
+
+
+def test_show_retrieve_all_counts_by_year():
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_all_counts_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    counts = show.retrieve_all_counts_by_year()
+
+    assert counts, "No show counts were returned"
+    assert 1998 in counts, "No show count information returned for year 1998"
+    assert "regular" in counts[1998], "No regular show count returned for year 1998"
+    assert counts[1998]["regular"] is not None, (
+        "Invalid regular show count returned for 1998"
+    )
+    assert "best_of" in counts[1998], "No Best Of show count returned for year 1998"
+    assert counts[1998]["best_of"] is not None, (
+        "Invalid Best Of show count returned for 1998"
+    )
+    assert "repeat" in counts[1998], "No repeat show count returned for year 1998"
+    assert counts[1998]["repeat"] is not None, (
+        "Invalid repeat show count returned for 1998"
+    )
+    assert "repeat_best_of" in counts[1998], (
+        "No repeat Best Of show count returned for year 1998"
+    )
+    assert counts[1998]["repeat_best_of"] is not None, (
+        "Invalid repeat Best Of show count returned for 1998"
+    )
 
 
 @pytest.mark.parametrize(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.17.2"
+VERSION = "2.18.0"
 
 
 def database_version(

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -698,6 +698,62 @@ class Show:
 
         return [self.retrieve_by_id(v[0]) for v in results]
 
+    def retrieve_counts_by_year(self, year: int) -> dict[str, int]:
+        """Retrieves show counts by year.
+
+        :param year: Four-digit year
+        :return: A dictionary containing counts for all shows, Best Of
+            shows, repeat shows, and repeat Best Of shows
+        """
+        try:
+            parsed_year = datetime.datetime.strptime(f"{year:04d}", "%Y")
+        except ValueError:
+            return {}
+
+        query = """
+            SELECT
+            (SELECT COUNT(showid) FROM ww_shows
+                WHERE YEAR(showdate) = %s AND showdate <= NOW()
+                AND bestof = 0 AND repeatshowid IS NULL) AS 'regular',
+            (SELECT COUNT(showid) FROM ww_shows
+                WHERE YEAR(showdate) = %s AND showdate <= NOW()
+                AND bestof = 1 AND repeatshowid IS NULL) AS 'bestof',
+            (SELECT COUNT(showid) FROM ww_shows
+                WHERE YEAR(showdate) = %s AND showdate <= NOW()
+                AND bestof = 0 AND repeatshowid IS NOT NULL) AS 'repeat',
+            (SELECT COUNT(showid) FROM ww_shows
+                WHERE YEAR(showdate) = %s AND showdate <= NOW()
+                AND bestof = 1 AND repeatshowid IS NOT NULL) AS 'repeat_bestof';
+        """
+        cursor = self.database_connection.cursor(dictionary=True)
+        cursor.execute(
+            query,
+            (
+                parsed_year,
+                parsed_year,
+                parsed_year,
+                parsed_year,
+            ),
+        )
+        result = cursor.fetchone()
+        cursor.close()
+
+        if not result:
+            return {}
+
+        return {
+            "regular": result["regular"],
+            "best_of": result["bestof"],
+            "repeat": result["repeat"],
+            "repeat_best_of": result["repeat_bestof"],
+            "total": (
+                result["regular"]
+                + result["bestof"]
+                + result["repeat"]
+                + result["repeat_bestof"]
+            ),
+        }
+
     def retrieve_details_by_date(
         self, year: int, month: int, day: int, include_decimal_scores: bool = False
     ) -> dict[str, Any]:

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -754,6 +754,28 @@ class Show:
             ),
         }
 
+    def retrieve_all_counts_by_year(self) -> dict[int, dict[str, int]]:
+        """Retrieves show counts for all years, grouped by year.
+
+        :return: A dictionary with year as keys with corresponding
+            counts for all shows, Best Of shows, repeat shows, and
+            repeat Best Of shows as values
+        """
+        years = self.retrieve_years()
+        if not years:
+            return {}
+
+        all_counts = {}
+        for year in years:
+            year_counts = self.retrieve_counts_by_year(year=year)
+
+            if year_counts:
+                all_counts[year] = year_counts
+            else:
+                all_counts[year] = {}
+
+        return all_counts
+
     def retrieve_details_by_date(
         self, year: int, month: int, day: int, include_decimal_scores: bool = False
     ) -> dict[str, Any]:


### PR DESCRIPTION
## Application Changes

* Adding :py:meth:`wwdtm.show.Show.retrieve_counts_by_year` to retrieve a count of regular, Best Of, repeat, repeat Best Of and a total count of shows
* Adding :py:meth:`wwdtm.show.Show.retrieve_all_counts_by_year` to retrieve a count of regular, Best Of, repeat, repeat Best Of and a total count of shows for all years, grouped by year

## Component Changes

* Upgrade pytz from 2024.2 to 2025.2