### PR TITLE
Add retrieve random show date object, update dependencies and documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,9 +16,3 @@ python:
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
-
-search:
-  ranking:
-    '*.html': 2
-    wwdtm/*: 5
-    tests/*: -10

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,3 +16,7 @@ python:
 sphinx:
   configuration: docs/conf.py
   fail_on_warning: false
+
+search:
+  ranking:
+    tests/*: -5

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -19,4 +19,6 @@ sphinx:
 
 search:
   ranking:
-    tests/*: -5
+    '*.html': 2
+    wwdtm/*: 5
+    tests/*: -10

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,33 @@
 Changes
 *******
 
+2.19.0
+======
+
+Application Changes
+-------------------
+
+* Add :py:meth:`wwdtm.show.Show.retrieve_random_date_object` to retrieve a random show date as a :py:class:`datetime.time` object
+* Add :py:meth:`wwdtm.show.Show.retrieve_random_date_object_by_year` to retrieve a random show date as a :py:class:`datetime.time` object for a specific year
+* Add tests for both new methods
+
+Development Changes
+-------------------
+
+* Upgrade ruff from 0.9.3 to 0.11.9
+* Upgrade pytest from 8.3.3 to 8.3.5
+* Upgrade pytest-cov from 5.0.0 to 6.1.1
+* Upgrade wheel from 0.44.0 to 0.45.1
+
+Documentation Changes
+---------------------
+
+* Upgrade pytest from 8.3.3 to 8.3.5
+* Remove black from dependencies
+* Update ``environment.yaml`` file to match library dependencies
+* Replace the word "given" with "specific" in method docstrings
+* Reduce the search ranking for documentation for testing methods
+
 2.18.2
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,7 +27,6 @@ Documentation Changes
 * Remove black from dependencies
 * Update ``environment.yaml`` file to match library dependencies
 * Replace the word "given" with "specific" in method docstrings
-* Reduce the search ranking for documentation for testing methods
 
 2.18.2
 ======

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ current_path = Path.cwd()
 sys.path.insert(0, str(current_path.parent))
 
 project = "wwdtm"
-copyright = "2018-2024 Linh Pham. All Rights Reserved"
+copyright = "2018&ndash;2025 Linh Pham. All Rights Reserved"
 author = "Linh Pham"
 
 extensions = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ current_path = Path.cwd()
 sys.path.insert(0, str(current_path.parent))
 
 project = "wwdtm"
-copyright = "2018&ndash;2025 Linh Pham. All Rights Reserved"
+copyright = "2018–2025 Linh Pham. All Rights Reserved"
 author = "Linh Pham"
 
 extensions = [

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -2,9 +2,10 @@ name: docs
 channels:
   - defaults
 dependencies:
-  - Sphinx==8.0.2
-  - sphinx-autobuild==2024.9.19
-  - sphinx-autodoc-typehints==2.4.4
+  - Sphinx==8.1.3
+  - sphinx-autobuild==2024.10.3
+  - sphinx-autodoc-typehints==2.5.0
   - sphinx-copybutton==0.5.2
-  - sphinx-toolbox==3.8.0
-  - Pallets-Sphinx-Themes==2.1.3
+  - sphinx-toolbox==3.8.1
+  - sphinxext-opengraph==0.9.1
+  - furo==2024.8.6

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,10 +1,9 @@
-pytest==8.3.3
-black==24.10.0
+pytest==8.3.5
 
 mysql-connector-python==9.1.0
 numpy==2.1.2
 python-slugify==8.0.4
-pytz==2024.2
+pytz==2025.2
 
 Sphinx==8.1.3
 sphinx-autobuild==2024.10.3

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
-ruff==0.9.3
-pytest==8.3.3
-pytest-cov==5.0.0
-wheel==0.44.0
+ruff==0.11.9
+pytest==8.3.5
+pytest-cov==6.1.1
+wheel==0.45.1
 build==1.2.2.post1
 
 mysql-connector-python==9.1.0

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing for object :py:class:`wwdtm.show.Show`."""
 
+import datetime
 import json
 from pathlib import Path
 from typing import Any
@@ -816,8 +817,22 @@ def test_show_retrieve_random_date() -> None:
     show = Show(connect_dict=get_connect_dict())
     _date = show.retrieve_random_date()
 
-    assert _date, "Returned random show date string is not valid"
+    assert _date, "No random show date string returned"
     assert isinstance(_date, str), "Returned random show date string is not a string"
+
+
+def test_show_retrieve_random_date_object() -> None:
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_date_object`."""
+    show = Show(connect_dict=get_connect_dict())
+    _date = show.retrieve_random_date_object()
+
+    assert _date, "No random show date returned"
+    assert isinstance(_date, datetime.date), (
+        "Returned random show date is not a valid date object"
+    )
+    assert _date.year, "Random show date year is not valid"
+    assert _date.month, "Random show date month is not valid"
+    assert _date.day, "Random show date day is not valid"
 
 
 @pytest.mark.parametrize("year", [1998, 2020])
@@ -833,6 +848,21 @@ def test_show_retrieve_random_date_by_year(year: int):
     _show = show.retrieve_by_date_string(date_string=_date)
 
     assert _show, f"Returned random show data for {_date} is not valid"
+
+
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_show_retrieve_random_date_object_by_year(year: int):
+    """Testing for :py:meth:`wwdtm.show.Show.retrieve_random_date_object_by_year`."""
+    show = Show(connect_dict=get_connect_dict())
+    _date = show.retrieve_random_date_object_by_year(year=year)
+
+    assert _date, "No random show date returned"
+    assert isinstance(_date, datetime.date), (
+        "Returned random show date is not a valid date object"
+    )
+    assert _date.year, "Random show date year is not valid"
+    assert _date.month, "Random show date month is not valid"
+    assert _date.day, "Random show date day is not valid"
 
 
 def test_show_retrieve_random() -> None:

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.18.2"
+VERSION = "2.19.0"
 
 
 def database_version(

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -392,7 +392,7 @@ class Location:
         self,
         abbreviation: str,
     ) -> dict[str, str]:
-        """Retrieves postal abbreviation information for a given abbreviation.
+        """Retrieves postal abbreviation information for a specific abbreviation.
 
         :param abbreviation: Postal Abbreviation
         :return: A dictionary containing postal abbreviation,

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -1245,7 +1245,7 @@ class Show:
         return result[0]
 
     def retrieve_random_id_by_year(self, year: int) -> int:
-        """Retrieves an ID for a random show for a given year.
+        """Retrieves an ID for a random show for a specific year.
 
         :return: ID for a random show.
         """
@@ -1287,8 +1287,29 @@ class Show:
 
         return result[0].isoformat()
 
+    def retrieve_random_date_object(self) -> datetime.date:
+        """Retrieves a date object for a random show.
+
+        :return: Date object for a random show.
+        """
+        query = """
+            SELECT showdate FROM ww_shows
+            WHERE showdate <= NOW()
+            ORDER BY RAND()
+            LIMIT 1;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query)
+        result = cursor.fetchone()
+        cursor.close()
+
+        if not result:
+            return None
+
+        return result[0]
+
     def retrieve_random_date_by_year(self, year: int) -> str:
-        """Retrieves a date for a random show for a given year.
+        """Retrieves a date for a random show for a specific year.
 
         :return: show date string for a random show, in YYYY-MM-DD format.
         """
@@ -1309,6 +1330,28 @@ class Show:
 
         return result[0].isoformat()
 
+    def retrieve_random_date_object_by_year(self, year: int) -> datetime.date:
+        """Retrieves a date object for a random show for a specific year.
+
+        :return: Date object for a random show.
+        """
+        query = """
+            SELECT showdate FROM ww_shows
+            WHERE showdate <= NOW()
+            AND YEAR(showdate) = %s
+            ORDER BY RAND()
+            LIMIT 1;
+            """
+        cursor = self.database_connection.cursor(dictionary=False)
+        cursor.execute(query, (year,))
+        result = cursor.fetchone()
+        cursor.close()
+
+        if not result:
+            return None
+
+        return result[0]
+
     def retrieve_random(self) -> dict[str, Any]:
         """Retrieves information for a random show.
 
@@ -1324,7 +1367,7 @@ class Show:
         return self.retrieve_by_id(show_id=_id)
 
     def retrieve_random_by_year(self, year: int) -> dict[str, Any]:
-        """Retrieves information for a random show for a given year.
+        """Retrieves information for a random show for a specific year.
 
         :return: A dictionary containing show ID, show date, Best Of
             show flag, repeat show ID (if applicable) and show URL at
@@ -1358,7 +1401,7 @@ class Show:
     def retrieve_random_details_by_year(
         self, year: int, include_decimal_scores: bool = False
     ) -> dict[str, Any]:
-        """Retrieves information and appearances for a random show for a given year.
+        """Retrieves information and appearances for a random show for a specific year.
 
         :return: A dictionary containing show ID, show date, Best Of
             show flag, repeat show ID (if applicable), show URL at


### PR DESCRIPTION
Application Changes
-------------------

* Add :py:meth:`wwdtm.show.Show.retrieve_random_date_object` to retrieve a random show date as a :py:class:`datetime.time` object
* Add :py:meth:`wwdtm.show.Show.retrieve_random_date_object_by_year` to retrieve a random show date as a :py:class:`datetime.time` object for a specific year
* Add tests for both new methods

Development Changes
-------------------

* Upgrade ruff from 0.9.3 to 0.11.9
* Upgrade pytest from 8.3.3 to 8.3.5
* Upgrade pytest-cov from 5.0.0 to 6.1.1
* Upgrade wheel from 0.44.0 to 0.45.1

Documentation Changes
---------------------

* Upgrade pytest from 8.3.3 to 8.3.5
* Remove black from dependencies
* Update ``environment.yaml`` file to match library dependencies
* Replace the word "given" with "specific" in method docstrings