### PR TITLE
Add is_guest, is_host, is_panelist and is_scorekeeper keys/values

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,32 @@
 Changes
 *******
 
+2.20.0
+======
+
+Application Changes
+-------------------
+
+* Added `is_host`, `is_panelist` and `is_scorekeeper` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
+* Added `is_guest`, `is_panelist` and `is_scorekeeper` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
+* Added `is_guest`, `is_host` and `is_scorekeeper` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
+* Added `is_guest`, `is_host` and `is_panelist` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
+* Added tests for one of the three newly added keys for guests, hosts, panelists and scorekeeper
+* Changed incorrect references to ID to slug string in test assertion messages
+
+Component Changes
+-----------------
+
+* Upgrade NumPy from 2.1.2 to 2.2.6
+
+Development Changes
+-------------------
+
+* Upgrade Ruff from 0.11.9 to 0.12.8
+* Upgrade pytest from 8.3.5 to 8.4.1
+* Upgrade pytest-cov from 6.1.1 to 6.2.1
+* Upgrade build from 1.2.2.post1 to 1.3.0
+
 2.19.0
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,10 @@ Changes
 Application Changes
 -------------------
 
-* Added `is_host`, `is_panelist` and `is_scorekeeper` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
-* Added `is_guest`, `is_panelist` and `is_scorekeeper` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
-* Added `is_guest`, `is_host` and `is_scorekeeper` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
-* Added `is_guest`, `is_host` and `is_panelist` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
+* Added ``is_host``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
+* Added ``is_guest``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
+* Added ``is_guest``, ``is_host`` and ``is_scorekeeper`` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
+* Added ``is_guest``, ``is_host`` and ``is_panelist`` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
 * Added tests for one of the three newly added keys for guests, hosts, panelists and scorekeeper
 * Changed incorrect references to ID to slug string in test assertion messages
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 pytest==8.3.5
 
 mysql-connector-python==9.1.0
-numpy==2.1.2
+numpy==2.2.6
 python-slugify==8.0.4
 pytz==2025.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 
 dependencies = [
     "mysql-connector-python==9.1.0",
-    "numpy==2.1.2",
+    "numpy==2.2.6",
     "python-slugify==8.0.4",
     "pytz==2025.2",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-ruff==0.11.9
-pytest==8.3.5
-pytest-cov==6.1.1
+ruff==0.12.8
+pytest==8.4.1
+pytest-cov==6.2.1
 wheel==0.45.1
-build==1.2.2.post1
+build==1.3.0
 
 mysql-connector-python==9.1.0
-numpy==2.1.2
+numpy==2.2.6
 python-slugify==8.0.4
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mysql-connector-python==9.1.0
-numpy==2.1.2
+numpy==2.2.6
 python-slugify==8.0.4
 pytz==2025.2

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -44,6 +44,9 @@ def test_guest_retrieve_all_details():
 
     assert guests, "No guests could be retrieved"
     assert "id" in guests[0], "'id' was not returned for first list item"
+    assert "is_panelist" in guests[0], (
+        "'is_panelist' was not returned for first list item"
+    )
     assert "appearances" in guests[0], (
         "'appearances' was not returned for the first list item"
     )
@@ -103,6 +106,9 @@ def test_guest_retrieve_details_by_id(guest_id: int):
 
     assert info, f"Guest ID {guest_id} not found"
     assert "name" in info, f"'name' attribute was not returned for ID {guest_id}"
+    assert "is_panelist" in info, (
+        f"'is_panelist' attribute was not returned for ID {guest_id}"
+    )
     assert "appearances" in info, f"'appearances' was not returned for ID {guest_id}"
 
 
@@ -117,6 +123,9 @@ def test_guest_guest_retrieve_details_by_slug(guest_slug: str):
 
     assert info, f"Guest slug {guest_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {guest_slug}"
+    assert "is_panelist" in info, (
+        f"'is_panelist' attribute was not returned for slug {guest_slug}"
+    )
     assert "appearances" in info, (
         f"'appearances' was not returned for slug {guest_slug}"
     )

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -50,6 +50,9 @@ def test_host_retrieve_all_details():
     assert "name" in hosts[0], "'name' was not returned for the first list item"
     assert "slug" in hosts[0], "'slug' was not returned for the first list item"
     assert "pronouns" in hosts[0], "'pronouns' was not returned for the first list item"
+    assert "is_panelist" in hosts[0], (
+        "'is_panelist' was not returned for first list item"
+    )
     assert "appearances" in hosts[0], (
         "'appearances' was not returned for thefirst list item"
     )
@@ -86,22 +89,6 @@ def test_host_retrieve_by_id(host_id: int):
     assert "pronouns" in info, f"'pronouns' was not returned for ID {host_id}"
 
 
-@pytest.mark.parametrize("host_id", [2])
-def test_host_retrieve_details_by_id(host_id: int):
-    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`.
-
-    :param host_id: Host ID to test retrieving host details
-    """
-    host = Host(connect_dict=get_connect_dict())
-    info = host.retrieve_details_by_id(host_id)
-
-    assert info, f"Host ID {host_id} not found"
-    assert "name" in info, f"'name' was not returned for ID {host_id}"
-    assert "slug" in info, f"'slug' was not returned for ID {host_id}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {host_id}"
-    assert "appearances" in info, f"'appearances' was not returned for ID {host_id}"
-
-
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_host_retrieve_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_by_slug`.
@@ -118,6 +105,23 @@ def test_host_retrieve_by_slug(host_slug: str):
     assert "pronouns" in info, f"'pronouns' was not returned for ID {host_slug}"
 
 
+@pytest.mark.parametrize("host_id", [2])
+def test_host_retrieve_details_by_id(host_id: int):
+    """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_id`.
+
+    :param host_id: Host ID to test retrieving host details
+    """
+    host = Host(connect_dict=get_connect_dict())
+    info = host.retrieve_details_by_id(host_id)
+
+    assert info, f"Host ID {host_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {host_id}"
+    assert "slug" in info, f"'slug' was not returned for ID {host_id}"
+    assert "pronouns" in info, f"'pronouns' was not returned for ID {host_id}"
+    assert "is_panelist" in info, f"'is_panelist' was not returned for ID {host_id}"
+    assert "appearances" in info, f"'appearances' was not returned for ID {host_id}"
+
+
 @pytest.mark.parametrize("host_slug", ["luke-burbank"])
 def test_host_retrieve_details_by_slug(host_slug: str):
     """Testing for :py:meth:`wwdtm.host.Host.retrieve_details_by_slug`.
@@ -129,8 +133,9 @@ def test_host_retrieve_details_by_slug(host_slug: str):
 
     assert info, f"Host slug {host_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {host_slug}"
-    assert "slug" in info, f"'slug' was not returned for ID {host_slug}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {host_slug}"
+    assert "slug" in info, f"'slug' was not returned for slug {host_slug}"
+    assert "pronouns" in info, f"'pronouns' was not returned for slug {host_slug}"
+    assert "is_panelist" in info, f"'is_panelist' was not returned for slug {host_slug}"
     assert "appearances" in info, f"'appearances' was not returned for slug {host_slug}"
 
 

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -59,6 +59,9 @@ def test_panelist_retrieve_all_details(use_decimal_scores: bool):
     assert "pronouns" in panelists[0], (
         "'pronouns' was not returned for the first list item"
     )
+    assert "is_host" in panelists[0], (
+        "'is_host' was not returned for the first list item"
+    )
     assert "appearances" in panelists[0], (
         "'appearances' was not returned for the first list item"
     )
@@ -96,6 +99,22 @@ def test_panelist_retrieve_by_id(panelist_id: int):
     assert "pronouns" in info, f"'pronouns' was not returned for ID {panelist_id}"
 
 
+@pytest.mark.parametrize("panelist_slug", ["luke-burbank", "drew-carey"])
+def test_panelist_retrieve_by_slug(panelist_slug: str):
+    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`.
+
+    :param panelist_slug: Panelist slug string to test retrieving
+        panelist information
+    """
+    panelist = Panelist(connect_dict=get_connect_dict())
+    info = panelist.retrieve_by_slug(panelist_slug)
+
+    assert info, f"Panelist slug {panelist_slug} not found"
+    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
+    assert "slug" in info, f"'slug' was not returned for slug {panelist_slug}"
+    assert "pronouns" in info, f"'pronouns' was not returned for slug {panelist_slug}"
+
+
 @pytest.mark.parametrize("panelist_id, use_decimal_scores", [(14, True), (14, False)])
 def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: bool):
     """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_details_by_id`.
@@ -113,23 +132,8 @@ def test_panelist_retrieve_details_by_id(panelist_id: int, use_decimal_scores: b
     assert "name" in info, f"'name' was not returned for ID {panelist_id}"
     assert "slug" in info, f"'slug' was not returned for ID {panelist_id}"
     assert "pronouns" in info, f"'pronouns' was not returned for ID {panelist_id}"
+    assert "is_host" in info, f"'is_host' was not returned for ID {panelist_id}"
     assert "appearances" in info, f"'appearances' was not returned for ID {panelist_id}"
-
-
-@pytest.mark.parametrize("panelist_slug", ["luke-burbank", "drew-carey"])
-def test_panelist_retrieve_by_slug(panelist_slug: str):
-    """Testing for :py:meth:`wwdtm.panelist.Panelist.retrieve_by_slug`.
-
-    :param panelist_slug: Panelist slug string to test retrieving
-        panelist information
-    """
-    panelist = Panelist(connect_dict=get_connect_dict())
-    info = panelist.retrieve_by_slug(panelist_slug)
-
-    assert info, f"Panelist slug {panelist_slug} not found"
-    assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
-    assert "slug" in info, f"'slug' was not returned for ID {panelist_slug}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {panelist_slug}"
 
 
 @pytest.mark.parametrize(
@@ -153,8 +157,9 @@ def test_panelist_retrieve_details_by_slug(
 
     assert info, f"Panelist slug {panelist_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {panelist_slug}"
-    assert "slug" in info, f"'slug' was not returned for ID {panelist_slug}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {panelist_slug}"
+    assert "slug" in info, f"'slug' was not returned for slug {panelist_slug}"
+    assert "pronouns" in info, f"'pronouns' was not returned for slug {panelist_slug}"
+    assert "is_host" in info, f"'is_host' was not returned for slug {panelist_slug}"
     assert "appearances" in info, (
         f"'appearances' was not returned for slug {panelist_slug}"
     )

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -54,6 +54,9 @@ def test_scorekeeper_retrieve_all_details():
     assert "pronouns" in scorekeepers[0], (
         "'pronouns' was not returned for the first list item"
     )
+    assert "is_panelist" in scorekeepers[0], (
+        "'is_panelist' was not returned for the first list item"
+    )
     assert "appearances" in scorekeepers[0], (
         "'appearances' was not returned for the first list item"
     )
@@ -91,25 +94,6 @@ def test_scorekeeper_retrieve_by_id(scorekeeper_id: int):
     assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_id}"
 
 
-@pytest.mark.parametrize("scorekeeper_id", [13])
-def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
-    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_id`.
-
-    :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
-        details
-    """
-    scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
-    info = scorekeeper.retrieve_details_by_id(scorekeeper_id)
-
-    assert info, f"Scorekeeper ID {scorekeeper_id} not found"
-    assert "name" in info, f"'name' was not returned for ID {scorekeeper_id}"
-    assert "slug" in info, f"'slug' was not returned for ID {scorekeeper_id}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_id}"
-    assert "appearances" in info, (
-        f"'appearances' was not returned for ID {scorekeeper_id}"
-    )
-
-
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_by_slug`.
@@ -126,6 +110,28 @@ def test_scorekeeper_retrieve_by_slug(scorekeeper_slug: str):
     assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_slug}"
 
 
+@pytest.mark.parametrize("scorekeeper_id", [13])
+def test_scorekeeper_retrieve_details_by_id(scorekeeper_id: int):
+    """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_id`.
+
+    :param scorekeeper_id: Scorekeeper ID to test retrieving scorekeeper
+        details
+    """
+    scorekeeper = Scorekeeper(connect_dict=get_connect_dict())
+    info = scorekeeper.retrieve_details_by_id(scorekeeper_id)
+
+    assert info, f"Scorekeeper ID {scorekeeper_id} not found"
+    assert "name" in info, f"'name' was not returned for ID {scorekeeper_id}"
+    assert "slug" in info, f"'slug' was not returned for ID {scorekeeper_id}"
+    assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_id}"
+    assert "is_panelist" in info, (
+        f"'is_panelist' was not returned for ID {scorekeeper_id}"
+    )
+    assert "appearances" in info, (
+        f"'appearances' was not returned for ID {scorekeeper_id}"
+    )
+
+
 @pytest.mark.parametrize("scorekeeper_slug", ["chioke-i-anson"])
 def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
     """Testing for :py:meth:`wwdtm.scorekeeper.Scorekeeper.retrieve_details_by_slug`.
@@ -138,8 +144,13 @@ def test_scorekeeper_retrieve_details_by_slug(scorekeeper_slug: str):
 
     assert info, f"Scorekeeper slug {scorekeeper_slug} not found"
     assert "name" in info, f"'name' was not returned for slug {scorekeeper_slug}"
-    assert "slug" in info, f"'slug' was not returned for ID {scorekeeper_slug}"
-    assert "pronouns" in info, f"'pronouns' was not returned for ID {scorekeeper_slug}"
+    assert "slug" in info, f"'slug' was not returned for slug {scorekeeper_slug}"
+    assert "pronouns" in info, (
+        f"'pronouns' was not returned for slug {scorekeeper_slug}"
+    )
+    assert "is_panelist" in info, (
+        f"'is_panelist' was not returned for slug {scorekeeper_slug}"
+    )
     assert "appearances" in info, (
         f"'appearances' was not returned for slug {scorekeeper_slug}"
     )

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.19.0"
+VERSION = "2.20.0"
 
 
 def database_version(


### PR DESCRIPTION
Application Changes
-------------------

* Added ``is_host``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
* Added ``is_guest``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
* Added ``is_guest``, ``is_host`` and ``is_scorekeeper`` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
* Added ``is_guest``, ``is_host`` and ``is_panelist`` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
* Added tests for one of the three newly added keys for guests, hosts, panelists and scorekeeper
* Changed incorrect references to ID to slug string in test assertion messages

Component Changes
-----------------

* Upgrade NumPy from 2.1.2 to 2.2.6

Development Changes
-------------------

* Upgrade Ruff from 0.11.9 to 0.12.8
* Upgrade pytest from 8.3.5 to 8.4.1
* Upgrade pytest-cov from 6.1.1 to 6.2.1
* Upgrade build from 1.2.2.post1 to 1.3.0