### PR TITLE
Minimum Python Version Now >= 3.12, Update Major Dependencies

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,45 @@
 Changes
 *******
 
+2.21.0-alpha.1
+==============
+
+Application Changes
+-------------------
+
+* Raised the minimum supported version of Python from 3.10 to 3.12
+
+  * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
+  * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
+  * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
+
+Component Changes
+-----------------
+
+* Upgraded MySQL Connector/Python from 9.1.0 to 9.4.0
+* Upgraded NumPy from 2.2.6 to 2.3.2
+
+Development Changes
+-------------------
+
+* Added twine version 6.1.0
+* Upgraded Ruff from 0.12.8 to 0.12.10
+
+
+Documentation Changes
+---------------------
+
+* Matched the same upgrades as listed in Component Changes and Development Changes
+* Added Matplotlib version 3.10.5
+* Upgraded furo from 2024.8.6 to 2025.7.19
+* Upgraded pytest from 8.3.6 to 8.4.1
+* Upgraded Sphinx from 8.1.3 to 8.2.3
+* Upgraded sphinx-autodoc-typehint from 2.5.0 to 3.2.0
+* Upgraded sphinx-toolbox from 3.8.1 to 4.0.0
+* Upgraded sphinxext-opengraph from 0.9.1 to 0.12.0
+* Added a "Versioning" section to index page
+
+
 2.20.0
 ======
 

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,12 @@ library is available at `PyPI`_.
 Requirements
 ============
 
-Starting with version 2.5.0, the minimum supported version of Python has been
-changed from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+Starting with version 2.21.0, the minimum supported version of Python has been
+changed from Python 3.10 to 3.12. All versions prior to 3.12 will no longer
 be supported.
 
-Testing for this library has been done using Python 3.10 and 3.12.
+Testing for this library has been done using Python 3.12 and preliminary testing
+has been started for Python 3.13.
 
 In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution
@@ -83,6 +84,15 @@ For documentation on known issues with this project, check out the
 .. _Python Developer's Guide: https://devguide.python.org/documenting/#style-guide
 .. _docs.wwdt.me: https://docs.wwdt.me/
 .. _Known Issues: https://docs.wwdt.me/known_issues.html
+
+Versioning
+==========
+
+This project does its best to follow `Semantic Versioning 2.0.0`_ starting with
+version 2.0 of the library. There have been some semantic versioning errors made
+since the initial release of version 2.0.
+
+.. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
 
 Code of Conduct
 ===============

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,7 +31,17 @@ exclude_patterns = [
     "Thumbs.db",
     ".DS_Store",
     ".git",
+    ".venv",
+    ".venv*",
     "venv",
+    "venv*",
+    "LICENSE",
+    "DESCRIPTION",
+]
+
+source_suffix = [
+    ".rst",
+    ".md",
 ]
 
 html_theme = "furo"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,15 @@ Known Issues
 
 A list of known issues is documented in the ":doc:`/known_issues`" page.
 
+Versioning
+==========
+
+This project does its best to follow `Semantic Versioning 2.0.0`_ starting with
+version 2.0 of the library. There have been some semantic versioning errors made
+since the initial release of version 2.0.
+
+.. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
+
 Table of Contents
 =================
 

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -22,11 +22,11 @@ modules:
 Python Version
 ==============
 
-Starting with version 2.5.0, ``wwdtm`` has deprecated all versions of Python
-prior to 3.10.
+Starting with version 2.21.0, ``wwdtm`` has deprecated all versions of Python
+prior to 3.12.
 
-All development and testing of ``wwdtm`` is done using Python 3.10 and
-3.12.
+All development and testing of ``wwdtm`` is done using Python 3.12, with
+preliminary support for 3.13.
 
 Handling Database Connections
 =============================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,15 @@
-pytest==8.3.5
+pytest==8.4.1
 
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2
 
-Sphinx==8.1.3
+Sphinx==8.2.3
 sphinx-autobuild==2024.10.3
-sphinx-autodoc-typehints==2.5.0
+sphinx-autodoc-typehints==3.2.0
 sphinx-copybutton==0.5.2
-sphinx-toolbox==3.8.1
-sphinxext-opengraph==0.9.1
-furo==2024.8.6
+sphinx-toolbox==4.0.0
+sphinxext-opengraph==0.12.0
+furo==2025.7.19
+matplotlib==3.10.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,21 +7,19 @@ authors = [
 description = "Library used to query data from copy of Wait Wait Stats Database."
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 
 dependencies = [
-    "mysql-connector-python==9.1.0",
-    "numpy==2.2.6",
+    "mysql-connector-python==9.4.0",
+    "numpy==2.3.2",
     "python-slugify==8.0.4",
     "pytz==2025.2",
 ]
@@ -48,14 +46,15 @@ filterwarnings = [
 norecursedirs = [
     ".git",
     "venv",
+    ".venv",
     "dist",
     ".eggs",
     "wwdtm.egg-info",
 ]
 
 [tool.ruff]
-required-version = ">= 0.9.0"
-target-version = "py310"
+required-version = ">= 0.12.0"
+target-version = "py312"
 
 exclude = [
     "migrations",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-ruff==0.12.8
+ruff==0.12.10
 pytest==8.4.1
 pytest-cov==6.2.1
 wheel==0.45.1
 build==1.3.0
 
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.20.0"
+VERSION = "2.21.0-alpha.2"
 
 
 def database_version(


### PR DESCRIPTION
Application Changes
-------------------

* Raised the minimum supported version of Python from 3.10 to 3.12

  * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
  * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
  * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``

Component Changes
-----------------

* Upgraded MySQL Connector/Python from 9.1.0 to 9.4.0
* Upgraded NumPy from 2.2.6 to 2.3.2

Development Changes
-------------------

* Added twine version 6.1.0
* Upgraded Ruff from 0.12.8 to 0.12.10


Documentation Changes
---------------------

* Matched the same upgrades as listed in Component Changes and Development Changes
* Added Matplotlib version 3.10.5
* Upgraded furo from 2024.8.6 to 2025.7.19
* Upgraded pytest from 8.3.6 to 8.4.1
* Upgraded Sphinx from 8.1.3 to 8.2.3
* Upgraded sphinx-autodoc-typehint from 2.5.0 to 3.2.0
* Upgraded sphinx-toolbox from 3.8.1 to 4.0.0
* Upgraded sphinxext-opengraph from 0.9.1 to 0.12.0
* Added a "Versioning" section to index page