### PR TITLE
Require Python 3.12+, Add provisional support for MariaDB 11.8/12, Update Doc Dependencies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig File
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.{json,md,py,rst}]
+charset = utf-8
+
+[*.{css,html,json,py,rst,tmpl,md}]
+indent_size = 4
+indent_style = space

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Ignore venv directory
 venv/
+venv*/
 docs/venv/
 
 # Ignore the default configuration file

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,7 +3,7 @@ version: 2
 build:
   os: "ubuntu-24.04"
   tools:
-    python: "3.12"
+    python: "3.13"
 
 formats:
   - pdf

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -37,7 +37,7 @@ Documentation Changes
 
 * Matched the same upgrades as listed in Component Changes and Development Changes
 * Added Matplotlib version 3.10.5
-* Upgraded furo from 2024.8.6 to 2025.7.19
+* Upgraded furo from 2024.8.6 to 2025.9.25
 * Upgraded pytest from 8.3.6 to 8.4.1
 * Upgraded Sphinx from 8.1.3 to 8.2.3
 * Upgraded sphinx-autodoc-typehint from 2.5.0 to 3.2.0

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,7 +2,7 @@
 Changes
 *******
 
-2.21.0-alpha.1
+2.21.0-beta
 ==============
 
 Application Changes
@@ -13,6 +13,8 @@ Application Changes
   * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
   * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
   * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
+
+* Add experimental support for MariaDB Server 11.8
 
 Component Changes
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Changes
 *******
 
-2.21.0-beta
-==============
+2.21.0-rc
+=========
 
 Application Changes
 -------------------
@@ -14,7 +14,10 @@ Application Changes
   * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
   * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
 
-* Add experimental support for MariaDB Server 11.8
+* Added experimental support for MariaDB Server 11.8 and 12.0
+
+  * Support for MariaDB Server 12 is more experimental due to version 12 being on a rolling release train
+  * Any version prior to 11.8 has not been tested and issues related to those versions will not be accepted or resolved
 
 Component Changes
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,10 +8,10 @@ Changes
 Application Changes
 -------------------
 
-* Added `is_host`, `is_panelist` and `is_scorekeeper` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
-* Added `is_guest`, `is_panelist` and `is_scorekeeper` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
-* Added `is_guest`, `is_host` and `is_scorekeeper` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
-* Added `is_guest`, `is_host` and `is_panelist` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
+* Added ``is_host``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned guest details with boolean values whether a Not My Job guest has also been a host, panelist or scorekeeper
+* Added ``is_guest``, ``is_panelist`` and ``is_scorekeeper`` keys for all returned host details with boolean values whether a host has also been a Not My Job guest, panelist or scorekeeper
+* Added ``is_guest``, ``is_host`` and ``is_scorekeeper`` keys for all returned panelist details with boolean values whether a panelist has also been a guest, host or scorekeeper
+* Added ``is_guest``, ``is_host`` and ``is_panelist`` keys for all returned scorekeeper details with boolean values whether a scorekeeper has also been a guest, host or panelist
 * Added tests for one of the three newly added keys for guests, hosts, panelists and scorekeeper
 * Changed incorrect references to ID to slug string in test assertion messages
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,45 @@
 Changes
 *******
 
+2.21.0-alpha.1
+==============
+
+Application Changes
+-------------------
+
+* Raised the minimum supported version of Python from 3.10 to 3.12
+
+  * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
+  * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
+  * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
+
+Component Changes
+-----------------
+
+* Upgraded MySQL Connector/Python from 9.1.0 to 9.4.0
+* Upgraded NumPy from 2.2.6 to 2.3.2
+
+Development Changes
+-------------------
+
+* Added twine version 6.1.0
+* Upgraded Ruff from 0.12.8 to 0.12.10
+
+
+Documentation Changes
+---------------------
+
+* Matched the same upgrades as listed in Component Changes and Development Changes
+* Added Matplotlib version 3.10.5
+* Upgraded furo from 2024.8.6 to 2025.7.19
+* Upgraded pytest from 8.3.6 to 8.4.1
+* Upgraded Sphinx from 8.1.3 to 8.2.3
+* Upgraded sphinx-autodoc-typehint from 2.5.0 to 3.2.0
+* Upgraded sphinx-toolbox from 3.8.1 to 4.0.0
+* Upgraded sphinxext-opengraph from 0.9.1 to 0.12.0
+* Added a "Versioning" section to index page
+
+
 2.20.0
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,13 +23,13 @@ Component Changes
 -----------------
 
 * Upgraded MySQL Connector/Python from 9.1.0 to 9.4.0
-* Upgraded NumPy from 2.2.6 to 2.3.2
+* Upgraded NumPy from 2.2.6 to 2.3.3
 
 Development Changes
 -------------------
 
-* Added twine version 6.1.0
-* Upgraded Ruff from 0.12.8 to 0.12.10
+* Added twine version 6.2.0
+* Upgraded Ruff from 0.12.8 to 0.13.3
 
 
 Documentation Changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Changes
 *******
 
-2.21.0-rc
-=========
+2.21.0
+======
 
 Application Changes
 -------------------
@@ -14,10 +14,10 @@ Application Changes
   * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
   * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
 
-* Added experimental support for MariaDB Server 11.8 and 12.0
+* Added provisional support for MariaDB Server 11.8 (LTS) and 12 (rolling release)
 
-  * Support for MariaDB Server 12 is more experimental due to version 12 being on a rolling release train
-  * Any version prior to 11.8 has not been tested and issues related to those versions will not be accepted or resolved
+  * Compatibility and support for MariaDB Server 12 is slightly experimental due to MariaDB Server 12 being a rolling release
+  * Compatibility and support for MariaDB Server prior to version 11.8 is not provided or guaranteed
 
 Component Changes
 -----------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,7 @@ Application Changes
 
   * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
   * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
-  * Removed Python 3.10 and 3.11 and added Python 3.13 from ``project.classifiers``
+  * Replaced Python 3.10 and 3.11 with Python 3.13 and 3.14 in ``project.classifiers``
 
 * Added provisional support for MariaDB Server 11.8 (LTS) and 12 (rolling release)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,11 @@
 If you would like to contribute to this projects, there are a few guidelines
 that you'll want to review below.
 
+## AI Generated Code
+
+This project does not accept pull requests or bugfixes that include code that
+has been partially or wholly generated using AI.
+
 ## Code of Conduct
 
 The Code of Conduct for this project is adapted from the Contributor Covenant,

--- a/README.rst
+++ b/README.rst
@@ -14,11 +14,12 @@ library is available at `PyPI`_.
 Requirements
 ============
 
-Starting with version 2.5.0, the minimum supported version of Python has been
-changed from Python 3.8 to 3.10. All versions prior to 3.10 will no longer
+Starting with version 2.21.0, the minimum supported version of Python has been
+changed from Python 3.10 to 3.12. All versions prior to 3.12 will no longer
 be supported.
 
-Testing for this library has been done using Python 3.10 and 3.12.
+Testing for this library has been done using Python 3.12 and preliminary testing
+has been started for Python 3.13.
 
 In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution
@@ -83,6 +84,15 @@ For documentation on known issues with this project, check out the
 .. _Python Developer's Guide: https://devguide.python.org/documenting/#style-guide
 .. _docs.wwdt.me: https://docs.wwdt.me/
 .. _Known Issues: https://docs.wwdt.me/known_issues.html
+
+Versioning
+==========
+
+This project does its best to follow `Semantic Versioning 2.0.0`_ starting with
+version 2.0 of the library. There have been some semantic versioning errors made
+since the initial release of version 2.0.
+
+.. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
 
 Code of Conduct
 ===============

--- a/README.rst
+++ b/README.rst
@@ -25,10 +25,15 @@ In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution
 of MySQL Server like Percona) running version 8.0 or higher.
 
-Support for MariaDB is highly experimental and not a guarantee. Initial tests
-have successfully been run a Debian 13 server with MariaDB 11.8 installed. Other
-versions have not been tested and data validation of the results have also not
-been completed at this time.
+Starting with version 2.21.0, experimental support has been added for MariaDB
+versions 11.8 and 12.0. Test runs have been run successfully against a MariaDB
+Server 11.8 and 12.0 running on Debian 13. Versions prior to 11.8 have not and
+will not be tested.
+
+If you are planning to use MariaDB instead of MySQL, it is recommended that
+version 11.8 is used over 12 due to the former being on a stable release train
+while the latter is on a rolling release train. Rolling releases can introduce
+regressions or breaking changes that are generally avoided with stable releases.
 
 Running Tests
 =============
@@ -99,12 +104,28 @@ since the initial release of version 2.0.
 
 .. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
 
+Contributing
+============
+
+If you would like to contribute to this project, please refer to the
+`Contributing Guidelines`_ file in this repository.
+
+AI Generated Code
+-----------------
+
+Please note that this project does not accept pull requests or bugfixes that
+include code that has been partially or wholly generated using AI.
+
+.. _Contributing Guidelines: https://github.com/questionlp/wwdtm/blob/main/CONTRIBUTING.md
+
 Code of Conduct
 ===============
 
-The Code of Conduct for this project is adapted from the Contributor Covenant, version 3.0, permanently available at: https://www.contributor-covenant.org/version/3/0/.
+The Code of Conduct for this project is adapted from the Contributor Covenant,
+version 3.0, permanently available at: https://www.contributor-covenant.org/version/3/0/.
 
-The adapted version with instructions on how to report possible violations are available in the `Code of Conduct`_ file in this repository.
+The adapted version with instructions on how to report possible violations are
+available in the `Code of Conduct`_ file in this repository.
 
 .. _Code of Conduct: https://github.com/questionlp/wwdtm/blob/main/CODE_OF_CONDUCT.md
 

--- a/README.rst
+++ b/README.rst
@@ -25,6 +25,11 @@ In addition to the Python version requirement, the library depends on a copy
 of the `Wait Wait Stats Database`_ running on a MySQL Server (or a distribution
 of MySQL Server like Percona) running version 8.0 or higher.
 
+Support for MariaDB is highly experimental and not a guarantee. Initial tests
+have successfully been run a Debian 13 server with MariaDB 11.8 installed. Other
+versions have not been tested and data validation of the results have also not
+been completed at this time.
+
 Running Tests
 =============
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -31,7 +31,17 @@ exclude_patterns = [
     "Thumbs.db",
     ".DS_Store",
     ".git",
+    ".venv",
+    ".venv*",
     "venv",
+    "venv*",
+    "LICENSE",
+    "DESCRIPTION",
+]
+
+source_suffix = [
+    ".rst",
+    ".md",
 ]
 
 html_theme = "furo"

--- a/docs/environment.yaml
+++ b/docs/environment.yaml
@@ -8,4 +8,4 @@ dependencies:
   - sphinx-copybutton==0.5.2
   - sphinx-toolbox==3.8.1
   - sphinxext-opengraph==0.9.1
-  - furo==2024.8.6
+  - furo==2024.9.25

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,15 @@ Known Issues
 
 A list of known issues is documented in the ":doc:`/known_issues`" page.
 
+Versioning
+==========
+
+This project does its best to follow `Semantic Versioning 2.0.0`_ starting with
+version 2.0 of the library. There have been some semantic versioning errors made
+since the initial release of version 2.0.
+
+.. _Semantic Versioning 2.0.0: https://semver.org/spec/v2.0.0.html
+
 Table of Contents
 =================
 

--- a/docs/migrating/index.rst
+++ b/docs/migrating/index.rst
@@ -22,11 +22,11 @@ modules:
 Python Version
 ==============
 
-Starting with version 2.5.0, ``wwdtm`` has deprecated all versions of Python
-prior to 3.10.
+Starting with version 2.21.0, ``wwdtm`` has deprecated all versions of Python
+prior to 3.12.
 
-All development and testing of ``wwdtm`` is done using Python 3.10 and
-3.12.
+All development and testing of ``wwdtm`` is done using Python 3.12, with
+preliminary support for 3.13.
 
 Handling Database Connections
 =============================

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,15 @@
-pytest==8.3.5
+pytest==8.4.1
 
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2
 
-Sphinx==8.1.3
+Sphinx==8.2.3
 sphinx-autobuild==2024.10.3
-sphinx-autodoc-typehints==2.5.0
+sphinx-autodoc-typehints==3.2.0
 sphinx-copybutton==0.5.2
-sphinx-toolbox==3.8.1
-sphinxext-opengraph==0.9.1
-furo==2024.8.6
+sphinx-toolbox==4.0.0
+sphinxext-opengraph==0.12.0
+furo==2025.7.19
+matplotlib==3.10.5

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 pytest==8.4.1
 
 mysql-connector-python==9.4.0
-numpy==2.3.2
+numpy==2.3.3
 python-slugify==8.0.4
 pytz==2025.2
 
@@ -11,5 +11,5 @@ sphinx-autodoc-typehints==3.2.0
 sphinx-copybutton==0.5.2
 sphinx-toolbox==4.0.0
 sphinxext-opengraph==0.12.0
-furo==2025.7.19
+furo==2025.9.25
 matplotlib==3.10.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development :: Libraries",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,21 +7,19 @@ authors = [
 description = "Library used to query data from copy of Wait Wait Stats Database."
 readme = {file = "README.rst", content-type = "text/x-rst"}
 license = "Apache-2.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Software Development :: Libraries",
 ]
 
 dependencies = [
-    "mysql-connector-python==9.1.0",
-    "numpy==2.2.6",
+    "mysql-connector-python==9.4.0",
+    "numpy==2.3.2",
     "python-slugify==8.0.4",
     "pytz==2025.2",
 ]
@@ -48,14 +46,15 @@ filterwarnings = [
 norecursedirs = [
     ".git",
     "venv",
+    ".venv",
     "dist",
     ".eggs",
     "wwdtm.egg-info",
 ]
 
 [tool.ruff]
-required-version = ">= 0.9.0"
-target-version = "py310"
+required-version = ">= 0.12.0"
+target-version = "py312"
 
 exclude = [
     "migrations",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 
 dependencies = [
     "mysql-connector-python==9.4.0",
-    "numpy==2.3.2",
+    "numpy==2.3.3",
     "python-slugify==8.0.4",
     "pytz==2025.2",
 ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,11 @@
-ruff==0.12.10
+ruff==0.13.3
 pytest==8.4.1
 pytest-cov==6.2.1
 wheel==0.45.1
 build==1.3.0
+twine==6.2.0
 
 mysql-connector-python==9.4.0
-numpy==2.3.2
+numpy==2.3.3
 python-slugify==8.0.4
 pytz==2025.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
-ruff==0.12.8
+ruff==0.12.10
 pytest==8.4.1
 pytest-cov==6.2.1
 wheel==0.45.1
 build==1.3.0
 
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mysql-connector-python==9.4.0
-numpy==2.3.2
+numpy==2.3.3
 python-slugify==8.0.4
 pytz==2025.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-mysql-connector-python==9.1.0
-numpy==2.2.6
+mysql-connector-python==9.4.0
+numpy==2.3.2
 python-slugify==8.0.4
 pytz==2025.2

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/guest/test_guest_appearances.py
+++ b/tests/guest/test_guest_appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/guest/test_guest_guest.py
+++ b/tests/guest/test_guest_guest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/guest/test_guest_utility.py
+++ b/tests/guest/test_guest_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/host/test_host_appearances.py
+++ b/tests/host/test_host_appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/host/test_host_host.py
+++ b/tests/host/test_host_host.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/host/test_host_utility.py
+++ b/tests/host/test_host_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/location/test_location_location.py
+++ b/tests/location/test_location_location.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/location/test_location_recordings.py
+++ b/tests/location/test_location_recordings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/location/test_location_utility.py
+++ b/tests/location/test_location_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_appearances.py
+++ b/tests/panelist/test_panelist_appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_decimal_scores.py
+++ b/tests/panelist/test_panelist_decimal_scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_panelist.py
+++ b/tests/panelist/test_panelist_panelist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_scores.py
+++ b/tests/panelist/test_panelist_scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_statistics.py
+++ b/tests/panelist/test_panelist_statistics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/panelist/test_panelist_utility.py
+++ b/tests/panelist/test_panelist_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/pronoun/test_pronoun_pronouns.py
+++ b/tests/pronoun/test_pronoun_pronouns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/scorekeeper/test_scorekeeper_appearances.py
+++ b/tests/scorekeeper/test_scorekeeper_appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/scorekeeper/test_scorekeeper_scorekeeper.py
+++ b/tests/scorekeeper/test_scorekeeper_scorekeeper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/scorekeeper/test_scorekeeper_utility.py
+++ b/tests/scorekeeper/test_scorekeeper_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/show/test_show_info.py
+++ b/tests/show/test_show_info.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/show/test_show_info_multiple.py
+++ b/tests/show/test_show_info_multiple.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/show/test_show_show.py
+++ b/tests/show/test_show_show.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/show/test_show_utility.py
+++ b/tests/show/test_show_utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,6 @@
 # vim: set noai syntax=python ts=4 sw=4:
 #
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 """Testing for object: :py:class:`wwdtm.validation`."""
 

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.21.0-alpha.2"
+VERSION = "2.21.0-beta"
 
 
 def database_version(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.21.0-beta"
+VERSION = "2.21.0-rc"
 
 
 def database_version(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.20.0"
+VERSION = "2.21.0-alpha.2"
 
 
 def database_version(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.21.0-rc"
+VERSION = "2.21.0"
 
 
 def database_version(

--- a/wwdtm/guest/__init__.py
+++ b/wwdtm/guest/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/guest/appearances.py
+++ b/wwdtm/guest/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/guest/guest.py
+++ b/wwdtm/guest/guest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/guest/utility.py
+++ b/wwdtm/guest/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/host/__init__.py
+++ b/wwdtm/host/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/host/appearances.py
+++ b/wwdtm/host/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/host/host.py
+++ b/wwdtm/host/host.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/host/utility.py
+++ b/wwdtm/host/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/location/__init__.py
+++ b/wwdtm/location/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/location/location.py
+++ b/wwdtm/location/location.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/location/recordings.py
+++ b/wwdtm/location/recordings.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/location/utility.py
+++ b/wwdtm/location/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/__init__.py
+++ b/wwdtm/panelist/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/appearances.py
+++ b/wwdtm/panelist/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/decimal_scores.py
+++ b/wwdtm/panelist/decimal_scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/panelist.py
+++ b/wwdtm/panelist/panelist.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/scores.py
+++ b/wwdtm/panelist/scores.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/panelist/utility.py
+++ b/wwdtm/panelist/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/pronoun/__init__.py
+++ b/wwdtm/pronoun/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/pronoun/pronouns.py
+++ b/wwdtm/pronoun/pronouns.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/scorekeeper/__init__.py
+++ b/wwdtm/scorekeeper/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/scorekeeper/appearances.py
+++ b/wwdtm/scorekeeper/appearances.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/scorekeeper/scorekeeper.py
+++ b/wwdtm/scorekeeper/scorekeeper.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/scorekeeper/utility.py
+++ b/wwdtm/scorekeeper/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/show/__init__.py
+++ b/wwdtm/show/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/show/info.py
+++ b/wwdtm/show/info.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/show/info_multiple.py
+++ b/wwdtm/show/info_multiple.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/show/show.py
+++ b/wwdtm/show/show.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/show/utility.py
+++ b/wwdtm/show/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/wwdtm/validation.py
+++ b/wwdtm/validation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # wwdtm is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
Application Changes
-------------------

* Raised the minimum supported version of Python from 3.10 to 3.12
  * Updated ``project.requires-python`` from ``>=3.10`` to ``>=3.12``
  * Updated ``tools.ruff.target-version`` from ``py310`` to ``py312`` in ``pyproject.toml``
  * Replaced Python 3.10 and 3.11 with Python 3.13 and 3.14 in ``project.classifiers``
* Added provisional support for MariaDB Server 11.8 (LTS) and 12 (rolling release)
  * Compatibility and support for MariaDB Server 12 is slightly experimental due to MariaDB Server 12 being a rolling release
  * Compatibility and support for MariaDB Server prior to version 11.8 is not provided or guaranteed

Component Changes
-----------------

* Upgraded MySQL Connector/Python from 9.1.0 to 9.4.0
* Upgraded NumPy from 2.2.6 to 2.3.3

Development Changes
-------------------

* Added twine version 6.2.0
* Upgraded Ruff from 0.12.8 to 0.13.3


Documentation Changes
---------------------

* Matched the same upgrades as listed in Component Changes and Development Changes
* Added Matplotlib version 3.10.5
* Upgraded furo from 2024.8.6 to 2025.9.25
* Upgraded pytest from 8.3.6 to 8.4.1
* Upgraded Sphinx from 8.1.3 to 8.2.3
* Upgraded sphinx-autodoc-typehint from 2.5.0 to 3.2.0
* Upgraded sphinx-toolbox from 3.8.1 to 4.0.0
* Upgraded sphinxext-opengraph from 0.9.1 to 0.12.0
* Added a "Versioning" section to index page