### PR TITLE
Include mention of Universal FOSS Exception for MySQL Connector/Python in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -136,7 +136,7 @@ This library is licensed under the terms of the `Apache License 2.0`_.
 
 Although this library interfaces with `MySQL Connector/Python`_, licensed under version
 2 of the GNU General Public License (GPLv2) and is also subject to the terms included in
-`Universal FOSS Exception, version 1.0`. The exception permits this library to be
+`Universal FOSS Exception, version 1.0`_. The exception permits this library to be
 licensed under an OSI-approved or a license categorized as "free" by the Freedom
 Software Foundation (FSF), such as Apache License 2.0.
 

--- a/README.rst
+++ b/README.rst
@@ -134,5 +134,13 @@ License
 
 This library is licensed under the terms of the `Apache License 2.0`_.
 
+Although this library interfaces with `MySQL Connector/Python`_, licensed under version
+2 of the GNU General Public License (GPLv2) and is also subject to the terms included in
+`Universal FOSS Exception, version 1.0`. The exception permits this library to be
+licensed under an OSI-approved or a license categorized as "free" by the Freedom
+Software Foundation (FSF), such as Apache License 2.0.
+
 .. _Wait Wait Stats Database: https://github.com/questionlp/wwdtm_database
 .. _Apache License 2.0: https://github.com/questionlp/wwdtm/blob/main/LICENSE
+.. _MySQL Connector/Python: https://github.com/mysql/mysql-connector-python
+.. _Universal FOSS Exception, version 1.0: https://oss.oracle.com/licenses/universal-foss-exception/

--- a/README.rst
+++ b/README.rst
@@ -137,8 +137,8 @@ This library is licensed under the terms of the `Apache License 2.0`_.
 Although this library interfaces with `MySQL Connector/Python`_, licensed under version
 2 of the GNU General Public License (GPLv2) and is also subject to the terms included in
 `Universal FOSS Exception, version 1.0`_. The exception permits this library to be
-licensed under an OSI-approved or a license categorized as "free" by the Freedom
-Software Foundation (FSF), such as Apache License 2.0.
+licensed under an OSI-approved or a license categorized as "free" by the Free Software
+Foundation (FSF), such as Apache License 2.0.
 
 .. _Wait Wait Stats Database: https://github.com/questionlp/wwdtm_database
 .. _Apache License 2.0: https://github.com/questionlp/wwdtm/blob/main/LICENSE


### PR DESCRIPTION
Add verbiage to README file for this project to mention the license that [MySQL Connector/Python](https://github.com/mysql/mysql-connector-python) is distributed under along with the [Universal FOSS Exception](https://oss.oracle.com/licenses/universal-foss-exception/) that allows applications that only interface with MySQL Connector/Python are permitted to be distributed under an OSI-approved license or a license categorized by the Free Software Foundation (FSF).