### PR TITLE
Add variance to panelist statistics, Update pytest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@
 Changes
 *******
 
+.. ATTENTION::
+    The next major release of the Wait Wait Stats Library will require panelist decimal score columns in the Wait Wait Stats Database. Any ``include_decimal_scores`` or ``use_decimal_scores`` parameters will be removed as decimal scores will always be returned.
+
+2.24.0
+======
+
+Application Changes
+-------------------
+
+* Added ``standard_deviation_nnan`` to panelist statistics that calculates the standard deviation of panelist's complete set of total scores that excludes any ``NaN`` values
+* Added ``variance`` to panelist statistics that calculates the variance of a panelist's complete set of total scores
+* Added ``variance_nnan`` to panelist statistics that calculates the variance of a panelist's complete set of total scores that exclude any ``NaN`` values
+
 2.23.1
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,13 @@ Development Changes
 
 * Upgraded pytest from 9.0.2 to 9.0.3
 
+Documentation Changes
+---------------------
+
+* Upgraded development component changes
+
+  * Upgraded pytest from 8.4.1 to 9.0.2
+
 2.23.1
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,8 +2,8 @@
 Changes
 *******
 
-.. ATTENTION::
-    The next major release of the Wait Wait Stats Library will require panelist decimal score columns in the Wait Wait Stats Database. Any ``include_decimal_scores`` or ``use_decimal_scores`` parameters will be removed as decimal scores will always be returned.
+.. important::
+    The next minor release of the Wait Wait Stats Library will change the default value of the ``include_decimal_scores`` and ``use_decimal_scores`` parameters will switch from ``False`` to ``True``.
 
 2.23.1
 ======

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 .. ATTENTION::
     The next major release of the Wait Wait Stats Library will require panelist decimal score columns in the Wait Wait Stats Database. Any ``include_decimal_scores`` or ``use_decimal_scores`` parameters will be removed as decimal scores will always be returned.
 
-2.24.0
+2.23.1
 ======
 
 Application Changes

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,11 @@ Application Changes
 
 * Added ``variance`` to panelist statistics that calculates the variance of a panelist's complete set of total scores
 
+Development Changes
+-------------------
+
+* Upgraded pytest from 9.0.2 to 9.0.3
+
 2.23.1
 ======
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,9 +11,7 @@ Changes
 Application Changes
 -------------------
 
-* Added ``standard_deviation_nnan`` to panelist statistics that calculates the standard deviation of panelist's complete set of total scores that excludes any ``NaN`` values
 * Added ``variance`` to panelist statistics that calculates the variance of a panelist's complete set of total scores
-* Added ``variance_nnan`` to panelist statistics that calculates the variance of a panelist's complete set of total scores that exclude any ``NaN`` values
 
 2.23.1
 ======

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -43,6 +43,10 @@
         margin-top: 0;
     }
 
+    .admonition, p.admonition-title {
+        font-size: unset !important;
+    }
+
     footer, .page-info .context, .bottom-of-page .left-details, .bottom-of-page .right-details {
         font-size: unset;
     }

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -47,6 +47,10 @@
         font-size: unset !important;
     }
 
+    p.admonition-title {
+        text-transform: uppercase;
+    }
+
     footer, .page-info .context, .bottom-of-page .left-details, .bottom-of-page .right-details {
         font-size: unset;
     }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-pytest==9.0.2
+pytest==9.0.3
 
 mysql-connector-python==9.5.0
 numpy==2.4.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 ruff==0.14.14
-pytest==9.0.2
+pytest==9.0.3
 pytest-cov==7.0.0
 wheel==0.46.3
 build==1.3.0

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.24.0"
+VERSION = "2.23.1"
 
 
 def database_version(

--- a/wwdtm/__init__.py
+++ b/wwdtm/__init__.py
@@ -26,7 +26,7 @@ from wwdtm.panelist import (
 from wwdtm.scorekeeper import Scorekeeper, ScorekeeperAppearances, ScorekeeperUtility
 from wwdtm.show import Show, ShowInfo, ShowInfoMultiple, ShowUtility
 
-VERSION = "2.23.1"
+VERSION = "2.24.0"
 
 
 def database_version(

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -181,9 +181,9 @@ class PanelistStatistics:
     ) -> dict[str, Any]:
         """Retrieves and calculates panelist statistics.
 
-        Note: Population standard deviation calculation is used since
-        it is calculated based on a set of all available total scores
-        for the requested panelist.
+        The returned statistics includes estimated population variance
+        and standard deviation based on the full set of total scores for
+        the requested panelist.
 
         :param panelist_id: Panelist ID
         :param use_decimal_scores: A boolean to determine if decimal
@@ -271,6 +271,10 @@ class PanelistStatistics:
         self, panelist_slug: str, include_decimal_scores: bool = False
     ) -> dict[str, Any]:
         """Retrieves and calculates panelist statistics.
+
+        The returned statistics includes estimated population variance
+        and standard deviation based on the full set of total scores for
+        the requested panelist.
 
         :param panelist_slug: Panelist slug string
         :param use_decimal_scores: A boolean to determine if decimal

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -212,6 +212,9 @@ class PanelistStatistics:
             "mode": score_mode if score_mode is not None else None,
             "mode_multiple": sorted(score_multimode),
             "standard_deviation": round(numpy.std(score_data), 5),
+            "standard_deviation_nnan": round(numpy.nanstd(score_data), 5),
+            "variance": round(numpy.var(score_data), 5),
+            "variance_nnan": round(numpy.nanvar(score_data), 5),
             "total": int(numpy.sum(score_data)),
         }
 
@@ -227,6 +230,11 @@ class PanelistStatistics:
                 "mode": score_mode_decimal if score_mode_decimal is not None else None,
                 "mode_multiple": sorted(score_multimode_decimal),
                 "standard_deviation": round(Decimal(numpy.std(score_data_decimal)), 5),
+                "standard_deviation_nnan": round(
+                    Decimal(numpy.nanstd(score_data_decimal)), 5
+                ),
+                "variance": round(Decimal(numpy.var(score_data_decimal)), 5),
+                "variance_nnan": round(Decimal(numpy.nanvar(score_data_decimal)), 5),
                 "total": Decimal(numpy.sum(score_data_decimal)),
             }
 

--- a/wwdtm/panelist/statistics.py
+++ b/wwdtm/panelist/statistics.py
@@ -181,6 +181,10 @@ class PanelistStatistics:
     ) -> dict[str, Any]:
         """Retrieves and calculates panelist statistics.
 
+        Note: Population standard deviation calculation is used since
+        it is calculated based on a set of all available total scores
+        for the requested panelist.
+
         :param panelist_id: Panelist ID
         :param use_decimal_scores: A boolean to determine if decimal
             scores should be used and returned instead of integer scores
@@ -212,9 +216,7 @@ class PanelistStatistics:
             "mode": score_mode if score_mode is not None else None,
             "mode_multiple": sorted(score_multimode),
             "standard_deviation": round(numpy.std(score_data), 5),
-            "standard_deviation_nnan": round(numpy.nanstd(score_data), 5),
             "variance": round(numpy.var(score_data), 5),
-            "variance_nnan": round(numpy.nanvar(score_data), 5),
             "total": int(numpy.sum(score_data)),
         }
 
@@ -230,11 +232,7 @@ class PanelistStatistics:
                 "mode": score_mode_decimal if score_mode_decimal is not None else None,
                 "mode_multiple": sorted(score_multimode_decimal),
                 "standard_deviation": round(Decimal(numpy.std(score_data_decimal)), 5),
-                "standard_deviation_nnan": round(
-                    Decimal(numpy.nanstd(score_data_decimal)), 5
-                ),
                 "variance": round(Decimal(numpy.var(score_data_decimal)), 5),
-                "variance_nnan": round(Decimal(numpy.nanvar(score_data_decimal)), 5),
                 "total": Decimal(numpy.sum(score_data_decimal)),
             }
 


### PR DESCRIPTION
Application Changes
-------------------

* Added ``variance`` to panelist statistics that calculates the variance of a panelist's complete set of total scores

Development Changes
-------------------

* Upgraded pytest from 9.0.2 to 9.0.3